### PR TITLE
fix: empty-string comparison in condition evaluator

### DIFF
--- a/crates/praxis/src/px/executor.rs
+++ b/crates/praxis/src/px/executor.rs
@@ -2427,8 +2427,11 @@ fn split_comparison<'a>(expr: &'a str, op: &str) -> Option<(&'a str, &'a str)> {
                     continue;
                 }
                 let lhs = expr[..i].trim();
-                let rhs = expr[i + op_len..].trim().trim_matches('"');
-                if !lhs.is_empty() && !rhs.is_empty() {
+                let rhs_raw = expr[i + op_len..].trim();
+                let rhs = rhs_raw.trim_matches('"');
+                // Allow empty rhs when it came from a quoted empty string ""
+                let rhs_valid = !rhs.is_empty() || (rhs_raw.starts_with('"') && rhs_raw.ends_with('"'));
+                if !lhs.is_empty() && rhs_valid {
                     return Some((lhs, rhs));
                 }
             }
@@ -3701,6 +3704,31 @@ mod tests {
         assert!(default_evaluate_condition("count == 5", &vars));
         assert!(default_evaluate_condition("flag", &vars));
         assert!(!default_evaluate_condition("nonexistent", &vars));
+    }
+
+    #[test]
+    fn empty_string_comparison() {
+        let vars = HashMap::from([
+            ("empty".to_string(), json!("")),
+            ("nonempty".to_string(), json!("hello")),
+            ("null_val".to_string(), Value::Null),
+        ]);
+
+        // Empty string equals ""
+        assert!(default_evaluate_condition(r#"empty == """#, &vars));
+        // Non-empty string does not equal ""
+        assert!(!default_evaluate_condition(r#"nonempty == """#, &vars));
+        // Empty string != "" is false
+        assert!(!default_evaluate_condition(r#"empty != """#, &vars));
+        // Non-empty string != "" is true
+        assert!(default_evaluate_condition(r#"nonempty != """#, &vars));
+        // With $ prefix notation
+        assert!(default_evaluate_condition(r#"$empty == """#, &vars));
+        assert!(!default_evaluate_condition(r#"$nonempty == """#, &vars));
+        // Null is not equal to empty string
+        assert!(!default_evaluate_condition(r#"null_val == """#, &vars));
+        // Unresolved variable is not equal to empty string
+        assert!(!default_evaluate_condition(r#"nonexistent == """#, &vars));
     }
 
     #[test]

--- a/testing/tests/test_match_return_abort.py
+++ b/testing/tests/test_match_return_abort.py
@@ -647,3 +647,96 @@ class TestCombinedControlFlow:
         assert steps[0]["kind"] == "call"
         assert steps[1]["kind"] == "return"
         assert steps[1]["output"] == "got_output"
+
+
+class TestEmptyStringComparison:
+    """Tests for empty-string comparison in conditions (bug fix).
+
+    Previously, `$x == ""` would fail to evaluate because the condition
+    parser rejected empty RHS values after stripping quotes.
+    """
+
+    def test_empty_var_equals_empty_string(self, mcp):
+        """Variable holding empty string equals ""."""
+        name = unique_name("empty_eq")
+        source = (
+            f'procedure {name}:\n'
+            f'  trigger: manual\n'
+            f'  when $val == "":\n'
+            f'    return "was_empty"\n'
+            f'  end\n'
+            f'  return "was_not_empty"\n'
+        )
+        result = run_inline(mcp, source, vars={"val": ""})
+        assert_success(result)
+        steps = get_steps(result)
+        last_return = [s for s in steps if s["kind"] == "return"]
+        assert last_return[-1]["output"] == "was_empty"
+
+    def test_nonempty_var_not_equals_empty_string(self, mcp):
+        """Variable with content does not equal ""."""
+        name = unique_name("nonempty_eq")
+        source = (
+            f'procedure {name}:\n'
+            f'  trigger: manual\n'
+            f'  when $val == "":\n'
+            f'    return "was_empty"\n'
+            f'  end\n'
+            f'  return "was_not_empty"\n'
+        )
+        result = run_inline(mcp, source, vars={"val": "hello"})
+        assert_success(result)
+        steps = get_steps(result)
+        last_return = [s for s in steps if s["kind"] == "return"]
+        assert last_return[-1]["output"] == "was_not_empty"
+
+    def test_empty_var_not_equals_empty_string(self, mcp):
+        """Empty var != "" should be false (skip when block)."""
+        name = unique_name("empty_neq")
+        source = (
+            f'procedure {name}:\n'
+            f'  trigger: manual\n'
+            f'  when $val != "":\n'
+            f'    return "has_value"\n'
+            f'  end\n'
+            f'  return "empty"\n'
+        )
+        result = run_inline(mcp, source, vars={"val": ""})
+        assert_success(result)
+        steps = get_steps(result)
+        last_return = [s for s in steps if s["kind"] == "return"]
+        assert last_return[-1]["output"] == "empty"
+
+    def test_nonempty_var_ne_returns_has_value(self, mcp):
+        """Non-empty var != "" should be true."""
+        name = unique_name("nonempty_neq")
+        source = (
+            f'procedure {name}:\n'
+            f'  trigger: manual\n'
+            f'  when $val != "":\n'
+            f'    return "has_value"\n'
+            f'  end\n'
+            f'  return "empty"\n'
+        )
+        result = run_inline(mcp, source, vars={"val": "world"})
+        assert_success(result)
+        steps = get_steps(result)
+        last_return = [s for s in steps if s["kind"] == "return"]
+        assert last_return[-1]["output"] == "has_value"
+
+    def test_empty_string_guard_with_dollar_prefix(self, mcp):
+        """$ prefix variables work with empty string comparison."""
+        name = unique_name("dollar_empty")
+        source = (
+            f'procedure {name}:\n'
+            f'  trigger: manual\n'
+            f'  when $input == "":\n'
+            f'    return "no_input"\n'
+            f'  end\n'
+            f'  return $input\n'
+        )
+        result = run_inline(mcp, source, vars={"input": ""})
+        assert_success(result)
+        steps = get_steps(result)
+        last_return = [s for s in steps if s["kind"] == "return"]
+        assert last_return[-1]["output"] == "no_input"


### PR DESCRIPTION
## Summary

Fixes a bug where conditions like `$x == ""` would silently fail to evaluate.

## Root Cause

In `split_comparison()`, after finding the `==` operator, the RHS was processed with:
```rust
let rhs = expr[i + op_len..].trim().trim_matches('"');
if !lhs.is_empty() && !rhs.is_empty() {
    return Some((lhs, rhs));
}
```

When comparing against `""`, `trim_matches('"')` strips both quotes leaving an empty string, and the `!rhs.is_empty()` guard rejects it. The comparison was never evaluated — it silently returned `false`.

## Fix

Detect when the raw RHS was a quoted empty string (`""`) and allow it through the guard:
```rust
let rhs_raw = expr[i + op_len..].trim();
let rhs = rhs_raw.trim_matches('"');
let rhs_valid = !rhs.is_empty() || (rhs_raw.starts_with('"') && rhs_raw.ends_with('"'));
```

## Tests

- **Unit test**: `empty_string_comparison` — 8 assertions covering `==`, `!=`, `$` prefix, null, and unresolved variables
- **Integration tests**: `TestEmptyStringComparison` — 5 MCP end-to-end tests exercising `when $val == ""` in real procedure execution

All tests verified locally:
- `cargo test -p pares-radix-praxis`: all pass
- `pytest TestEmptyStringComparison`: 5/5 pass (0.45s)