### PR TITLE
fix: flaky write_to_stdin test — retry poll instead of fixed sleep

### DIFF
--- a/crates/core/src/shell_executor.rs
+++ b/crates/core/src/shell_executor.rs
@@ -892,11 +892,17 @@ mod tests {
             .await
             .unwrap();
 
-        // Give it a moment to process
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        let poll = executor.poll(&session_id, Some(500)).await.unwrap();
-        assert!(poll.new_output.contains("hello from stdin"));
+        // Poll with retries — cat may take time to echo back
+        let mut found = false;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let poll = executor.poll(&session_id, Some(500)).await.unwrap();
+            if poll.new_output.contains("hello from stdin") {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "Expected 'hello from stdin' in poll output");
 
         executor.kill(&session_id).await.unwrap();
     }


### PR DESCRIPTION
## Problem

`shell_executor::tests::write_to_stdin` relied on a fixed 200ms sleep before asserting `cat` had echoed back input. Under load, this race condition causes intermittent failures — blocking mutation testing baseline runs.

## Fix

Replace the fixed sleep + single assertion with a retry loop (10 attempts × 100ms) that polls until the expected output appears. Verified stable over 5 consecutive runs.

## Evidence

- **Before**: Fails ~10% of the time under heavy CPU (mutation testing builds)
- **After**: 5/5 passes under identical load
- **Full suite**: 648 tests pass

## Related

Discovered while running mutation testing on chronos.rs (see PR #365). This was blocking the baseline clean-check.