### PR TITLE
ci: add auto-version-bump workflow on merge to main

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,37 @@
+name: Auto Version Bump
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['**.md', 'docs/**', '.github/**']
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump patch version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+          sed -i "s/^version = \"$VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml
+          git commit -m "chore: bump version to v$NEW_VERSION [skip ci]"
+          git tag "v$NEW_VERSION"
+          git push --follow-tags


### PR DESCRIPTION
## Summary

Adds .github/workflows/auto-version.yml that automatically bumps the patch version in Cargo.toml on every merge to main (excluding doc-only changes).

### How it works
1. On push to main (ignoring **.md, docs/**, .github/**)
2. Reads current version from Cargo.toml
3. Increments patch number (e.g. 1.44.3 → 1.44.4)
4. Commits the version bump with [skip ci] to avoid infinite loops
5. Creates a * tag and pushes with --follow-tags

### Cascade into release
The existing elease.yml triggers on 	ags: ['v*'], so this auto-bump will automatically trigger a full release build.

### Safeguards
- [skip ci] in commit message prevents infinite workflow loops
- paths-ignore avoids unnecessary bumps for doc-only changes
- Uses GITHUB_TOKEN (no PAT needed)