### PR TITLE
feat: wire periodic timer + .px procedure loader in main.rs

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3866,12 +3866,55 @@ async fn main() {
             pipeline.register(Arc::new(ResponseRouter)).await;
             info!("Pipeline procedures registered: inbound_router, history_recorder, model_invoker, tool_executor, response_router");
 
+            // 4.5. Load .px procedures from praxis/procedures/
+            {
+                use pares_agens_core::px_adapter::{load_px_directory, ToolDispatchActionHandler, AsyncActionHandler};
+
+                let px_action_handler = Arc::new(ToolDispatchActionHandler::new_lazy());
+                let praxis_dir = PathBuf::from(&home).join(".pares-radix/praxis/procedures");
+                if praxis_dir.is_dir() {
+                    let adapters = load_px_directory(
+                        &praxis_dir,
+                        px_action_handler.clone() as Arc<dyn AsyncActionHandler>,
+                    );
+                    if !adapters.is_empty() {
+                        info!(
+                            count = adapters.len(),
+                            dir = %praxis_dir.display(),
+                            "Loaded .px procedures for spine pipeline"
+                        );
+                        for adapter in adapters {
+                            pipeline.register(Arc::new(adapter)).await;
+                        }
+                    }
+                } else {
+                    debug!(dir = %praxis_dir.display(), ".px procedures directory not found, skipping");
+                }
+            }
+
             // 5. Start the pipeline event loop
             let pipeline_for_loop = Arc::clone(&pipeline);
             tokio::spawn(async move {
                 pipeline_for_loop.run(rx).await;
             });
             info!("Pipeline event loop started");
+
+            // 5.5. Periodic task evaluation timer (60s)
+            {
+                use pares_agens_core::spine::event::SpineEvent;
+                let timer_emitter = pipeline.emitter();
+                tokio::spawn(async move {
+                    let mut interval = tokio::time::interval(Duration::from_secs(60));
+                    loop {
+                        interval.tick().await;
+                        timer_emitter.emit(SpineEvent::Timer {
+                            id: SpineEvent::new_id(),
+                            name: "task_eval".into(),
+                        }).await;
+                    }
+                });
+                info!("Task evaluation timer started (60s interval)");
+            }
 
             // 6. Start channel (delivery loop + receiver)
             let delivery_rx = pipeline.subscribe_deliveries();

--- a/crates/core/src/spine/event.rs
+++ b/crates/core/src/spine/event.rs
@@ -91,6 +91,13 @@ pub enum SpineEvent {
         chat_id: String,
         error: String,
     },
+
+    /// A periodic timer tick (used to trigger task evaluation).
+    Timer {
+        id: String,
+        /// The timer's logical name (e.g. "task_eval").
+        name: String,
+    },
 }
 
 impl SpineEvent {
@@ -109,7 +116,8 @@ impl SpineEvent {
             | Self::DeliverySuccess { id, .. }
             | Self::DeliveryFailure { id, .. }
             | Self::ToolRequest { id, .. }
-            | Self::ToolResult { id, .. } => id,
+            | Self::ToolResult { id, .. }
+            | Self::Timer { id, .. } => id,
         }
     }
 
@@ -124,6 +132,7 @@ impl SpineEvent {
             Self::DeliveryFailure { .. } => "delivery_failure",
             Self::ToolRequest { .. } => "tool_request",
             Self::ToolResult { .. } => "tool_result",
+            Self::Timer { .. } => "timer",
         }
     }
 }


### PR DESCRIPTION
Enables runtime execution of .px procedures by wiring:

1. **Periodic timer** — 60s tokio interval emitting SpineEvent::Timer for task evaluation
2. **.px procedure loader** — compiles praxis/procedures/*.px at startup, registers as spine procedures

## Changes
- **crates/core/src/spine/event.rs** — new \SpineEvent::Timer { id, name }\ variant
- **crates/cli/src/main.rs** — procedure loader + timer spawn in ServeSpine command

## Architecture
\\\
Timer (60s) → SpineEvent::Timer → pipeline → task-evaluation.px procedure → side-effect actions
\\\

This makes the .px task system from task-evaluation.px executable at runtime.
Depends on: #440 (task-action tools)