### PR TITLE
feat(px): add core task system procedures

### DIFF
--- a/praxis/procedures/session-continuity.px
+++ b/praxis/procedures/session-continuity.px
@@ -64,7 +64,7 @@ procedure get_active_commitments:
 }
 
 procedure inject_commitment_context:
-  trigger: on_event("model_request")
+  trigger: model_request
   given: "Before model calls, inject active commitments as system context"
 {
     let active = get_active_commitments({});

--- a/praxis/procedures/session-continuity.px
+++ b/praxis/procedures/session-continuity.px
@@ -1,0 +1,79 @@
+# session-continuity.px — Track commitments radix makes and inject as context
+# Ensures "I'll do X" results in X actually happening
+
+procedure track_commitment:
+  trigger: manual
+  given: "Record a commitment made by radix during conversation"
+{
+    let id = generate_id({ prefix: "commit" });
+    let now = timestamp_now({});
+    let commitment = {
+        text: $args.text,
+        chat_id: $args.chat_id,
+        created_at: now,
+        status: "active",
+        deadline: $args.deadline,
+        context: $args.context
+    };
+    db_put({ key: id, value: commitment });
+    emit("commitment.created", { id: id, text: $args.text });
+    return id;
+}
+
+procedure check_commitments:
+  trigger: timer
+  given: "Check all active commitments and flag overdue ones"
+{
+    let now = timestamp_now({});
+    let commitments = db_get_prefix({ prefix: "commit:" });
+    
+    for $c in commitments.items:
+        if $c.value.status == "active":
+            if $c.value.deadline > 0:
+                if now > $c.value.deadline:
+                    db_put({ key: $c.key, value: { status: "overdue", original: $c.value, overdue_at: now } });
+                    emit("commitment.overdue", { id: $c.key, text: $c.value.text, chat_id: $c.value.chat_id });
+                end
+            end
+        end
+    end
+}
+
+procedure fulfill_commitment:
+  trigger: manual
+  given: "Mark a commitment as fulfilled"
+{
+    let now = timestamp_now({});
+    let existing = db_get({ key: $args.commitment_id });
+    db_put({ key: $args.commitment_id, value: { status: "fulfilled", fulfilled_at: now, original: existing } });
+    emit("commitment.fulfilled", { id: $args.commitment_id });
+}
+
+procedure get_active_commitments:
+  trigger: manual
+  given: "Get all active commitments for context injection"
+{
+    let commitments = db_get_prefix({ prefix: "commit:" });
+    let active = [];
+    for $c in commitments.items:
+        if $c.value.status == "active" || $c.value.status == "overdue":
+            active = active + [$c];
+        end
+    end
+    return active;
+}
+
+procedure inject_commitment_context:
+  trigger: on_event("model_request")
+  given: "Before model calls, inject active commitments as system context"
+{
+    let active = get_active_commitments({});
+    if active.length > 0:
+        let context_lines = "Active commitments you made:\n";
+        for $c in active:
+            let status_tag = $c.value.status;
+            context_lines = context_lines + "- [" + status_tag + "] " + $c.value.text + "\n";
+        end
+        emit("context.inject", { role: "system", content: context_lines });
+    end
+}

--- a/praxis/procedures/spine-actions.px
+++ b/praxis/procedures/spine-actions.px
@@ -1,0 +1,69 @@
+# spine-actions.px — Action contracts for the Rust IO boundary
+# These are behavioral contracts, not executable procedures.
+# They document what RadixToolHandler MUST implement for .px procedures to work.
+
+contract timestamp_now:
+  given: "Returns current Unix epoch seconds"
+  when: "Any procedure needs current time"
+  then: "Returns integer seconds since epoch"
+  examples:
+    - input: {}
+      expect: "integer > 1700000000"
+
+contract generate_id:
+  given: "Generates a unique ID with optional prefix"
+  when: "Any procedure needs a unique identifier"
+  then: "Returns string in format prefix_uuid or bare uuid"
+  examples:
+    - input: { prefix: "task" }
+      expect: "task_<uuid>"
+    - input: {}
+      expect: "<uuid>"
+
+contract db_get_prefix:
+  given: "Prefix scan of PluresDB state store"
+  when: "A procedure needs to enumerate keys by prefix"
+  then: "Returns {items: [{key, value}...], count: N}"
+  examples:
+    - input: { prefix: "task:" }
+      expect: "{items: [...], count: N}"
+
+contract send_message:
+  given: "Send a message to a chat channel via spine delivery"
+  when: "A procedure needs to proactively message a user"
+  then: "Emits SpineEvent::DeliveryRequest, returns confirmation"
+  examples:
+    - input: { chat_id: "12345", text: "Task complete" }
+      expect: "delivery_request_emitted"
+
+contract db_get:
+  given: "Get a single key from PluresDB state store"
+  when: "A procedure needs to read state"
+  then: "Returns the stored value or null"
+  examples:
+    - input: { key: "task:abc123" }
+      expect: "stored value or null"
+
+contract db_put:
+  given: "Write a key-value pair to PluresDB state store"
+  when: "A procedure needs to persist state"
+  then: "Writes value, returns confirmation"
+  examples:
+    - input: { key: "task:abc123", value: { status: "done" } }
+      expect: "ok"
+
+contract exec:
+  given: "Execute a shell command"
+  when: "A procedure needs to run a system command"
+  then: "Returns {stdout, stderr, exit_code}"
+  examples:
+    - input: { command: "echo hello" }
+      expect: "{stdout: 'hello\\n', stderr: '', exit_code: 0}"
+
+contract model_call:
+  given: "Invoke the LLM for reasoning or generation"
+  when: "A procedure needs AI-generated content or decisions"
+  then: "Returns model response text"
+  examples:
+    - input: { prompt: "Summarize this", context: "..." }
+      expect: "model-generated text"

--- a/praxis/procedures/task-evaluation.px
+++ b/praxis/procedures/task-evaluation.px
@@ -38,10 +38,10 @@ procedure execute_procedure_task:
   trigger: manual
   given: "Execute a procedure-type task by running another .px procedure"
 {
-    let result = praxis_run({ procedure: $args.task.value.procedure, args: $args.task.value.args });
+    let result = praxis_run({ procedure: input.task.value.procedure, vars: input.task.value.args });
     let now = timestamp_now({});
-    db_put({ key: $args.task.key, value: { status: "completed", completed_at: now, result: result } });
-    emit("task.completed", { task_id: $args.task.key, type: "procedure" });
+    db_put({ key: input.task.key, value: { status: "completed", completed_at: now, result: result } });
+    emit("task.completed", { task_id: input.task.key, type: "procedure" });
 }
 
 procedure execute_message_task:

--- a/praxis/procedures/task-evaluation.px
+++ b/praxis/procedures/task-evaluation.px
@@ -8,24 +8,21 @@ procedure evaluate_tasks:
 {
     let now = timestamp_now({});
     let tasks = db_get_prefix({ prefix: "task:" });
-    
-    for $task in tasks.items:
-        if $task.value.status == "pending":
-            let age_seconds = now - $task.value.created_at;
-            if age_seconds > $task.value.delay_seconds:
+
+    for task in tasks.items {
+        if task.value.status == "pending" {
+            let age_seconds = now - task.value.created_at;
+            if age_seconds >= task.value.delay_seconds {
                 # Mark as running
-                db_put({ key: $task.key, value: { status: "running", started_at: now, original: $task.value } });
-                
+                db_put({ key: task.key, value: { status: "running", started_at: now, original: task.value } });
+
                 # Execute based on task type
-                match:
-                    $task.value.type == "shell" -> execute_shell_task({ task: $task })
-                    $task.value.type == "procedure" -> execute_procedure_task({ task: $task })
-                    $task.value.type == "message" -> execute_message_task({ task: $task })
-                end
-            end
-        end
-    end
-}
+                if task.value.type == "shell" { execute_shell_task({ task: task }); }
+                if task.value.type == "procedure" { execute_procedure_task({ task: task }); }
+                if task.value.type == "message" { execute_message_task({ task: task }); }
+            }
+        }
+    }
 
 procedure execute_shell_task:
   trigger: manual

--- a/praxis/procedures/task-evaluation.px
+++ b/praxis/procedures/task-evaluation.px
@@ -28,10 +28,10 @@ procedure execute_shell_task:
   trigger: manual
   given: "Execute a shell-type task"
 {
-    let result = exec({ command: $args.task.value.command });
+    let result = exec({ command: input.task.value.command });
     let now = timestamp_now({});
-    db_put({ key: $args.task.key, value: { status: "completed", completed_at: now, result: result.stdout, exit_code: result.exit_code } });
-    emit("task.completed", { task_id: $args.task.key, type: "shell" });
+    db_put({ key: input.task.key, value: { status: "completed", completed_at: now, result: result.stdout, exit_code: result.exit_code } });
+    emit("task.completed", { task_id: input.task.key, type: "shell" });
 }
 
 procedure execute_procedure_task:

--- a/praxis/procedures/task-evaluation.px
+++ b/praxis/procedures/task-evaluation.px
@@ -1,0 +1,90 @@
+# task-evaluation.px — Periodic task evaluation and execution
+# Triggered by SpineEvent::Timer every 60s
+# Evaluates pending tasks, executes ready ones, reports results
+
+procedure evaluate_tasks:
+  trigger: timer
+  given: "Evaluate all pending tasks and execute those that are ready"
+{
+    let now = timestamp_now({});
+    let tasks = db_get_prefix({ prefix: "task:" });
+    
+    for $task in tasks.items:
+        if $task.value.status == "pending":
+            let age_seconds = now - $task.value.created_at;
+            if age_seconds > $task.value.delay_seconds:
+                # Mark as running
+                db_put({ key: $task.key, value: { status: "running", started_at: now, original: $task.value } });
+                
+                # Execute based on task type
+                match:
+                    $task.value.type == "shell" -> execute_shell_task({ task: $task })
+                    $task.value.type == "procedure" -> execute_procedure_task({ task: $task })
+                    $task.value.type == "message" -> execute_message_task({ task: $task })
+                end
+            end
+        end
+    end
+}
+
+procedure execute_shell_task:
+  trigger: manual
+  given: "Execute a shell-type task"
+{
+    let result = exec({ command: $args.task.value.command });
+    let now = timestamp_now({});
+    db_put({ key: $args.task.key, value: { status: "completed", completed_at: now, result: result.stdout, exit_code: result.exit_code } });
+    emit("task.completed", { task_id: $args.task.key, type: "shell" });
+}
+
+procedure execute_procedure_task:
+  trigger: manual
+  given: "Execute a procedure-type task by running another .px procedure"
+{
+    let result = praxis_run({ procedure: $args.task.value.procedure, args: $args.task.value.args });
+    let now = timestamp_now({});
+    db_put({ key: $args.task.key, value: { status: "completed", completed_at: now, result: result } });
+    emit("task.completed", { task_id: $args.task.key, type: "procedure" });
+}
+
+procedure execute_message_task:
+  trigger: manual
+  given: "Execute a message-type task by sending a message"
+{
+    send_message({ chat_id: $args.task.value.chat_id, text: $args.task.value.text });
+    let now = timestamp_now({});
+    db_put({ key: $args.task.key, value: { status: "completed", completed_at: now } });
+    emit("task.completed", { task_id: $args.task.key, type: "message" });
+}
+
+procedure create_task:
+  trigger: manual
+  given: "Create a new task for deferred execution"
+{
+    let id = generate_id({ prefix: "task" });
+    let now = timestamp_now({});
+    let task = {
+        status: "pending",
+        type: $args.type,
+        created_at: now,
+        delay_seconds: $args.delay_seconds,
+        command: $args.command,
+        procedure: $args.procedure,
+        chat_id: $args.chat_id,
+        text: $args.text,
+        args: $args.args,
+        priority: $args.priority
+    };
+    db_put({ key: id, value: task });
+    emit("task.created", { task_id: id, type: $args.type });
+    return id;
+}
+
+procedure park_task:
+  trigger: manual
+  given: "Park a task that is blocked on external input"
+{
+    let now = timestamp_now({});
+    db_put({ key: $args.task_id, value: { status: "parked", parked_at: now, reason: $args.reason, resume_on: $args.resume_on } });
+    emit("task.parked", { task_id: $args.task_id, reason: $args.reason });
+}

--- a/praxis/procedures/task-evaluation.px
+++ b/praxis/procedures/task-evaluation.px
@@ -58,22 +58,22 @@ procedure create_task:
   trigger: manual
   given: "Create a new task for deferred execution"
 {
-    let id = generate_id({ prefix: "task" });
+    let id = "task:" + generate_id({});
     let now = timestamp_now({});
     let task = {
         status: "pending",
-        type: $args.type,
+        type: input.type,
         created_at: now,
-        delay_seconds: $args.delay_seconds,
-        command: $args.command,
-        procedure: $args.procedure,
-        chat_id: $args.chat_id,
-        text: $args.text,
-        args: $args.args,
-        priority: $args.priority
+        delay_seconds: input.delay_seconds,
+        command: input.command,
+        procedure: input.procedure,
+        chat_id: input.chat_id,
+        text: input.text,
+        args: input.args,
+        priority: input.priority
     };
     db_put({ key: id, value: task });
-    emit("task.created", { task_id: id, type: $args.type });
+    emit("task.created", { task_id: id, type: input.type });
     return id;
 }
 

--- a/praxis/procedures/task-evaluation.px
+++ b/praxis/procedures/task-evaluation.px
@@ -48,10 +48,10 @@ procedure execute_message_task:
   trigger: manual
   given: "Execute a message-type task by sending a message"
 {
-    send_message({ chat_id: $args.task.value.chat_id, text: $args.task.value.text });
+    send_message({ chat_id: input.task.value.chat_id, text: input.task.value.text });
     let now = timestamp_now({});
-    db_put({ key: $args.task.key, value: { status: "completed", completed_at: now } });
-    emit("task.completed", { task_id: $args.task.key, type: "message" });
+    db_put({ key: input.task.key, value: { status: "completed", completed_at: now } });
+    emit("task.completed", { task_id: input.task.key, type: "message" });
 }
 
 procedure create_task:

--- a/praxis/procedures/task-system.px
+++ b/praxis/procedures/task-system.px
@@ -1,0 +1,31 @@
+# task-system.px — Architectural constraints for the task system
+# Enforces C-DEV-001: logic in .px, Rust only for IO boundaries
+
+constraint task_logic_in_px:
+  when: change.modifies("crates/") && change.adds_business_logic
+  require: change.has_corresponding_px_procedure
+  severity: error
+  message: "Task logic must be expressed as .px procedures (C-DEV-001). Rust handles only IO boundaries."
+
+constraint no_standalone_task_state:
+  when: change.adds("HashMap") && change.in_path("task")
+  require: change.uses_state_store
+  severity: error
+  message: "Task state must go through PluresDB StateStore, not standalone HashMaps (C-PLURES-003)."
+
+constraint timer_triggers_px:
+  when: event.type == "timer" && event.name == "task_eval"
+  require: procedure.evaluate_tasks.is_registered
+  severity: error
+  message: "Timer events must trigger .px procedures, not inline Rust logic."
+
+constraint commitment_tracking_required:
+  when: model_response.contains_future_tense_promise
+  require: commitment.is_tracked
+  severity: warning
+  message: "Model promises ('I will...', 'I'll...') should be tracked as commitments."
+
+# Policy documentation header:
+# These constraints use freeform domain expressions that guide AI agent behavior.
+# They are not compiled by the Condition evaluator at runtime — they serve as
+# architectural guardrails readable by both humans and AI agents reviewing changes.


### PR DESCRIPTION
## Summary

Adds 4 .px procedure files implementing the proactive task system:

### Files

| File | Purpose |
|------|---------|
| \	ask-evaluation.px\ | Periodic eval loop triggered by SpineEvent::Timer every 60s. Evaluates pending tasks, executes ready ones (shell/procedure/message), reports results. |
| \session-continuity.px\ | Commitment tracking + context injection. Ensures 'I will do X' actually results in X happening. |
| \spine-actions.px\ | Behavioral contracts documenting what RadixToolHandler MUST implement for .px procedures to work (timestamp_now, generate_id, db_get/put/prefix, send_message, exec, model_call). |
| \	ask-system.px\ | Architectural constraints enforcing .px-first development (C-DEV-001). |

### Dependencies

- #440 (task-action MCP tools in radix_handler)
- #441 (SpineEvent::Timer + procedure loader in CLI)

### Design

Follows the .px-first principle: all task logic lives in declarative procedures. Rust provides only the IO boundary (tool handler actions). The timer event fires every 60s, triggering \valuate_tasks\ which scans PluresDB for pending tasks past their delay threshold.

Commitment tracking hooks into \model_request\ events to inject active commitments as system context before each LLM call — ensuring radix remembers what it promised.