### PR TITLE
feat: sync plures-dev-guide.px + refactor .px procedures (cross-platform)

### DIFF
--- a/praxis/directives.px
+++ b/praxis/directives.px
@@ -1,12 +1,51 @@
+# directives.px — Core plures org development directives
+#
+# These procedures implement the key decision-making logic for working
+# within the plures org. They are callable by agents and enforce the
+# development guide's rules procedurally.
+
 procedure route_code:
   trigger: manual
   given: "Determine which repository owns a piece of code based on its description"
 {
     let registry = db_get({ key: "plures:repos:registry" });
     let routing = db_get({ key: "plures:routing:rules" });
+
+    # Build a decision context from the registry and routing rules
     let target = "UNKNOWN";
     let reason = "No routing rule matched";
-    emit("routing.query", { registry: registry, routing: routing });
+    let confidence = "low";
+
+    # Check explicit routing rules first (highest priority)
+    for $rule in routing.rules:
+        if $rule.matches_description == true:
+            let target = $rule.target_repo;
+            let reason = $rule.rationale;
+            let confidence = "high";
+        end
+    end
+
+    # If no explicit rule, check repo ownership domains
+    if target == "UNKNOWN":
+        for $repo in registry.repos:
+            if $repo.domain_match == true:
+                let target = $repo.name;
+                let reason = "Domain ownership: " + $repo.domain;
+                let confidence = "medium";
+            end
+        end
+    end
+
+    # Emit result with actionable guidance
+    if target == "UNKNOWN":
+        emit("routing.unresolved", {
+            suggestion: "Check development-guide/design/PLURES-FOUNDATION.md for repo responsibilities",
+            action: "Create an issue in development-guide proposing a routing rule"
+        });
+    end
+
+    emit("routing.resolved", { target: target, reason: reason, confidence: confidence });
+    return { repo: target, reason: reason, confidence: confidence };
 }
 
 procedure prioritize_work:
@@ -14,8 +53,54 @@ procedure prioritize_work:
   given: "Determine what to work on next based on current state"
 {
     let framework = db_get({ key: "plures:prioritization:framework" });
-    let levels = framework;
-    emit("prioritization.query", { framework: framework });
+    let active_issues = db_get({ key: "plures:issues:assigned" });
+    let blocked_items = db_get({ key: "plures:issues:blocked" });
+
+    # Priority levels (from WORK-PRIORITIZATION.md):
+    # P0: Broken production / security incident
+    # P1: Blocking other work / CI red
+    # P2: Committed sprint work
+    # P3: Backlog improvements
+    # P4: Nice-to-haves / exploration
+
+    let recommendations = [];
+
+    # Check P0 first — anything broken?
+    for $item in active_issues:
+        if $item.priority == 0 and $item.status != "resolved":
+            let recommendations = append(recommendations, {
+                item: $item,
+                reason: "P0: Production/security issue — fix immediately"
+            });
+        end
+    end
+
+    # If no P0, check P1
+    if length(recommendations) == 0:
+        for $item in active_issues:
+            if $item.priority == 1 and $item.status != "resolved":
+                let recommendations = append(recommendations, {
+                    item: $item,
+                    reason: "P1: Blocking work — unblock before continuing"
+                });
+            end
+        end
+    end
+
+    # If no P0/P1, work committed sprint items (P2)
+    if length(recommendations) == 0:
+        for $item in active_issues:
+            if $item.priority == 2 and $item.status == "in_progress":
+                let recommendations = append(recommendations, {
+                    item: $item,
+                    reason: "P2: Active sprint work — continue"
+                });
+            end
+        end
+    end
+
+    emit("prioritization.resolved", { recommendations: recommendations, framework: framework });
+    return { next_items: recommendations };
 }
 
 procedure validate_architecture:
@@ -25,7 +110,42 @@ procedure validate_architecture:
     let registry = db_get({ key: "plures:repos:registry" });
     let routing = db_get({ key: "plures:routing:rules" });
     let pillars = db_get({ key: "plures:lifecycle:seven-pillars" });
-    emit("architecture.query", { registry: registry, routing: routing, pillars: pillars });
+    let violations = [];
+
+    # Check 1: Is this code going in the right repo?
+    let route_result = route_code({});
+    if route_result.confidence == "low":
+        let violations = append(violations, {
+            check: "repo_routing",
+            severity: "warning",
+            message: "Could not confidently determine correct repo. Verify with development-guide."
+        });
+    end
+
+    # Check 2: Does this violate single-source-of-truth?
+    let existing_impls = db_get({ key: "plures:functions:" + change.function_name });
+    if existing_impls != null and length(existing_impls) > 0:
+        let violations = append(violations, {
+            check: "single_source_of_truth",
+            severity: "error",
+            message: "Function already exists in: " + existing_impls[0].repo + ". Delegate, don't duplicate (ADR-0010)."
+        });
+    end
+
+    # Check 3: Does this follow the 7 pillars lifecycle?
+    for $pillar in pillars:
+        if $pillar.required == true and change[$pillar.check_field] == false:
+            let violations = append(violations, {
+                check: "lifecycle_pillar_" + $pillar.name,
+                severity: "error",
+                message: "Missing pillar: " + $pillar.name + " — " + $pillar.guidance
+            });
+        end
+    end
+
+    let passed = length(violations) == 0;
+    emit("architecture.validated", { passed: passed, violations: violations });
+    return { valid: passed, violations: violations };
 }
 
 procedure guide_lifecycle:
@@ -34,16 +154,66 @@ procedure guide_lifecycle:
 {
     let pillars = db_get({ key: "plures:lifecycle:seven-pillars" });
     let registry = db_get({ key: "plures:repos:registry" });
-    emit("lifecycle.query", { pillars: pillars, registry: registry });
+
+    # The 7 pillars define the build lifecycle:
+    # 1. Design (ADR + .px constraints)
+    # 2. Prototype (TS spike)
+    # 3. Core (Rust implementation)
+    # 4. Bridge (NAPI bindings)
+    # 5. Integration (wire into system)
+    # 6. Test (automated verification)
+    # 7. Ship (CI/CD + release)
+
+    let current_stage = detect_current_stage({});
+    let guidance = [];
+
+    for $pillar in pillars:
+        if $pillar.order >= current_stage:
+            let guidance = append(guidance, {
+                step: $pillar.order,
+                name: $pillar.name,
+                description: $pillar.description,
+                checklist: $pillar.checklist,
+                repo: $pillar.primary_repo
+            });
+        end
+    end
+
+    emit("lifecycle.guidance", { current_stage: current_stage, remaining_steps: guidance });
+    return { stage: current_stage, steps: guidance };
 }
 
 procedure detect_anti_patterns:
   trigger: manual
   given: "Check an action for known anti-patterns from incident history"
 {
-    let lesson_pluresdb = db_get({ key: "praxis:learned:2026-05-23:pluresdb-is-foundation" });
-    let lesson_compiler = db_get({ key: "praxis:learned:px-compiler-location" });
-    let lesson_general = db_get({ key: "praxis:learned:2026-05-18" });
+    let lessons = db_get({ key: "praxis:lessons:all" });
     let routing = db_get({ key: "plures:routing:rules" });
-    emit("anti_pattern.query", { lessons: lesson_pluresdb, compiler: lesson_compiler, general: lesson_general });
+    let warnings = [];
+
+    # Check against known lessons learned
+    for $lesson in lessons:
+        if $lesson.pattern_matches == true:
+            let warnings = append(warnings, {
+                lesson: $lesson.id,
+                date: $lesson.date,
+                pattern: $lesson.anti_pattern,
+                correction: $lesson.correct_approach,
+                severity: $lesson.severity
+            });
+        end
+    end
+
+    # Specific known anti-patterns:
+    # - Building in wrong repo (2026-05-23: pluresdb-is-foundation)
+    # - Duplicating logic across crates (ADR-0010)
+    # - Hardcoding repo lists instead of dynamic discovery
+    # - Testing only happy paths
+    # - Embedding volatile logic in binaries
+
+    if length(warnings) > 0:
+        emit("anti_pattern.detected", { count: length(warnings), warnings: warnings });
+    end
+
+    return { detected: length(warnings) > 0, warnings: warnings };
 }

--- a/praxis/procedures/health_check.px
+++ b/praxis/procedures/health_check.px
@@ -1,14 +1,45 @@
-# health_check.px — System health check procedure
+# health_check.px — System health check procedure (cross-platform)
 #
 # Callable as the "health_check" tool by the model.
 # Runs a series of diagnostic checks and returns aggregated status.
+# Works on Windows, Linux, and macOS.
 
 procedure system_health:
   trigger: manual
   given: "Run system health diagnostics and return aggregated status"
 {
-    let load = read_file({ path: "/proc/loadavg" });
-    let disk = exec({ command: "df -h / | tail -1" });
-    let memory = exec({ command: "free -m | grep Mem" });
-    emit("health.check.complete", { load: load, disk: disk, memory: memory });
+    let os_type = detect_os({});
+
+    if os_type == "windows":
+        let cpu = exec({ command: "powershell -NoProfile -Command \"(Get-CimInstance Win32_Processor).LoadPercentage\"" });
+        let disk = exec({ command: "powershell -NoProfile -Command \"Get-PSDrive C | Select-Object Used,Free | ConvertTo-Json\"" });
+        let memory = exec({ command: "powershell -NoProfile -Command \"Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize,FreePhysicalMemory | ConvertTo-Json\"" });
+    end
+
+    if os_type == "linux":
+        let cpu = read_file({ path: "/proc/loadavg" });
+        let disk = exec({ command: "df -h / | tail -1" });
+        let memory = exec({ command: "free -m | grep Mem" });
+    end
+
+    if os_type == "darwin":
+        let cpu = exec({ command: "sysctl -n vm.loadavg" });
+        let disk = exec({ command: "df -h / | tail -1" });
+        let memory = exec({ command: "vm_stat | head -5" });
+    end
+
+    let status = "ok";
+    emit("health.check.complete", { os: os_type, cpu: cpu, disk: disk, memory: memory, status: status });
+}
+
+procedure detect_os:
+  trigger: manual
+  given: "Detect the current operating system"
+{
+    let result = exec({ command: "uname -s 2>/dev/null || echo Windows" });
+    match result.stdout:
+        "Linux" => return "linux";
+        "Darwin" => return "darwin";
+        _ => return "windows";
+    end
 }

--- a/praxis/procedures/self-test.px
+++ b/praxis/procedures/self-test.px
@@ -1,4 +1,4 @@
-# self-test.px — pares-radix tests itself
+# self-test.px — pares-radix tests itself (cross-platform)
 #
 # These procedures exercise the pares-radix MCP server and .px runtime
 # using the built-in test actions. Run via:
@@ -9,27 +9,42 @@
 # Test 3: File I/O (write, read, cleanup)
 # Test 4: JSON parsing (structured data)
 # Test 5: Sleep (timing action)
+# Test 6: Process lifecycle (HTTP server)
+#
+# All tests use cross-platform paths and commands.
 
 procedure self_test:
   trigger: manual
   given: "Full self-test of pares-radix .px runtime and built-in actions"
 {
     emit("test.suite.start", { suite: "self_test" });
+
+    # Test 1: Assertions
     assert_eq({ actual: 1, expected: 1, message: "basic integer equality" });
     assert_eq({ actual: "hello", expected: "hello", message: "string equality" });
     assert_contains({ value: "hello world", contains: "world", message: "substring check" });
     assert_ok({ value: true, message: "truthy assertion" });
     emit("test.pass", { name: "assertions" });
+
+    # Test 2: Shell exec (cross-platform echo)
+    let os_type = detect_os({});
     let echo_result = exec({ command: "echo radix-self-test" });
     assert_contains({ value: echo_result.stdout, contains: "radix-self-test", message: "shell exec echo" });
     emit("test.pass", { name: "shell_exec" });
-    write_file({ path: "/tmp/radix-self-test.txt", content: "test-data-42" });
-    let file_content = read_file({ path: "/tmp/radix-self-test.txt" });
+
+    # Test 3: File I/O (use temp dir appropriate to platform)
+    let temp_dir = get_temp_dir({});
+    let test_file = join_path({ base: temp_dir, name: "radix-self-test.txt" });
+    write_file({ path: test_file, content: "test-data-42" });
+    let file_content = read_file({ path: test_file });
     assert_contains({ value: file_content, contains: "test-data-42", message: "file roundtrip" });
-    exec({ command: "rm /tmp/radix-self-test.txt" });
+    delete_file({ path: test_file });
     emit("test.pass", { name: "file_io" });
+
+    # Test 4: Sleep
     sleep({ ms: 50 });
     emit("test.pass", { name: "sleep" });
+
     emit("test.suite.complete", { suite: "self_test", passed: 4 });
 }
 
@@ -46,7 +61,16 @@ procedure test_process_lifecycle:
   trigger: manual
   given: "Verify start_process and stop_process work correctly"
 {
-    let server = start_process({ command: "python3 -m http.server 19876" });
+    let os_type = detect_os({});
+    let port = 19876;
+
+    if os_type == "windows":
+        let server = start_process({ command: "powershell -NoProfile -Command \"$l=[System.Net.HttpListener]::new();$l.Prefixes.Add('http://+:19876/');$l.Start();while($l.IsListening){$c=$l.GetContext();$r=$c.Response;$b=[Text.Encoding]::UTF8.GetBytes('OK');$r.OutputStream.Write($b,0,$b.Length);$r.Close()}\"" });
+    end
+    if os_type != "windows":
+        let server = start_process({ command: "python3 -m http.server 19876" });
+    end
+
     assert_ok({ value: server, message: "server started" });
     wait_for_ready({ url: "http://localhost:19876", timeout_secs: 5 });
     let response = http_get({ url: "http://localhost:19876" });
@@ -54,4 +78,16 @@ procedure test_process_lifecycle:
     stop_process({ pid: server });
     sleep({ ms: 500 });
     emit("test.pass", { name: "process_lifecycle" });
+}
+
+procedure get_temp_dir:
+  trigger: manual
+  given: "Return platform-appropriate temp directory"
+{
+    let os_type = detect_os({});
+    if os_type == "windows":
+        let result = exec({ command: "echo %TEMP%" });
+        return result.stdout;
+    end
+    return "/tmp";
 }

--- a/praxis/skills/plures-dev-guide.px
+++ b/praxis/skills/plures-dev-guide.px
@@ -1,10 +1,5 @@
 # plures-dev-guide.px — Auto-generated from plures/development-guide
 #
-# NOTE: These constraints are POLICY DOCUMENTATION, not compiled enforcement.
-# They guide AI agents reading this repo. The Condition evaluator cannot parse
-# freeform domain expressions. Enforcement happens through the agent's system
-# prompt and .px procedure guards, not through runtime constraint evaluation.
-#
 # This file is produced by scripts/generate-px-constraints.mjs
 # Do not edit manually — edit the source .md files and re-run the generator.
 #
@@ -17,522 +12,742 @@
 # PRACTICES (from practices/)
 # ══════════════════════════════════════════════════════════════════════
 
-constraint practice__hyperswarm_patterns:
+constraint practice.hyperswarm-patterns:
   severity: warning
+  source: "practices/HYPERSWARM-PATTERNS.md"
   message: "Follow guidance from: Hyperswarm Integration Patterns"
 
-constraint practice__merge_conflict_prevention:
+constraint practice.merge-conflict-prevention:
   severity: warning
+  source: "practices/MERGE-CONFLICT-PREVENTION.md"
   message: "Follow guidance from: Merge Conflict Prevention & Resolution Guide"
 
-constraint practice__automation_first_1:
+constraint practice.work-prioritization:
   severity: warning
-  message: "Fresh environment → one command → success. No manual steps, no 'now open this file and change line 42.'"
+  source: "practices/WORK-PRIORITIZATION.md"
+  message: "Follow guidance from: Work Prioritization Framework"
 
-constraint practice__automation_first_2:
+constraint practice.automation-first-1:
+  severity: warning
+  source: "practices/automation-first.md"
+  message: "Fresh environment → one command → success. No manual steps, no \"now open this file and change line 42.\""
+
+constraint practice.automation-first-2:
   severity: error
+  source: "practices/automation-first.md"
   message: "Automation must not amplify problems. A workflow that creates issues faster than humans can triage them is harmful. Build cascade detection and escalation thresholds into every loop. See [lessons learned: praxis-business cascade](../lessons-learned/2026-03-praxis-business-cascade.md)."
 
-constraint practice__automation_first_3:
+constraint practice.automation-first-3:
   severity: warning
+  source: "practices/automation-first.md"
   message: "Idempotent by default. Every automation is safe to run twice. Check state before acting."
 
-constraint practice__automation_first_4:
+constraint practice.automation-first-4:
   severity: warning
+  source: "practices/automation-first.md"
   message: "Fail loudly with actionable messages. Silent failures are worse than crashes."
 
-constraint practice__automation_first_5:
+constraint practice.automation-first-5:
   severity: warning
+  source: "practices/automation-first.md"
   message: "Edge cases are expected cases. Network timeouts, rate limits, missing permissions — handle them explicitly."
 
-constraint practice__automation_first_6:
+constraint practice.automation-first-6:
   severity: warning
+  source: "practices/automation-first.md"
   message: "Event-driven beats polling beats cron (in that order). Cron is a last resort, not a default."
 
-constraint practice__copilot_delegation_1:
+constraint practice.copilot-delegation-1:
   severity: warning
+  source: "practices/copilot-delegation.md"
   message: "Issues are goals, not tickets. One issue may decompose into multiple work units (PRs, config changes, procedure updates). There is no required 1:1 issue-to-PR mapping."
 
-constraint practice__copilot_delegation_2:
+constraint practice.copilot-delegation-2:
   severity: warning
+  source: "practices/copilot-delegation.md"
   message: "Pipeline state lives in PluresDB. Every transition is recorded in `work_units`, `goals`, and `activity_log` — not in ad-hoc comments or spreadsheets."
 
-constraint practice__copilot_delegation_3:
+constraint practice.copilot-delegation-3:
   severity: warning
+  source: "practices/copilot-delegation.md"
   message: "The coordinator communicates via structured PR comments. Copilot receives fix requests and revision requests through the PR comment thread, with relevant PluresLM context prepended."
 
-constraint practice__copilot_delegation_4:
+constraint practice.copilot-delegation-4:
   severity: warning
+  source: "practices/copilot-delegation.md"
   message: "Retry thresholds gate escalation. CI fix attempts ≤ 3, review revision attempts ≤ 2. Exceeding these surfaces a human escalation — the coordinator does not loop indefinitely."
 
-constraint practice__copilot_delegation_5:
+constraint practice.copilot-delegation-5:
   severity: warning
+  source: "practices/copilot-delegation.md"
   message: "Queue priority is explicit. Goals are prioritized by integer `priority` field (1 = highest). Strategy changes re-score the entire queue."
 
-constraint practice__dogfooding:
+constraint practice.dogfooding:
   severity: warning
+  source: "practices/dogfooding.md"
   message: "Follow guidance from: Dogfooding"
 
-constraint practice__ledger_driven_ops:
+constraint practice.ledger-driven-ops:
   severity: warning
+  source: "practices/ledger-driven-ops.md"
   message: "Follow guidance from: Ledger-Driven Ops"
 
-constraint practice__local_first_development:
+constraint practice.local-first-development:
   severity: warning
+  source: "practices/local-first-development.md"
   message: "Follow guidance from: Local-First Development"
 
-constraint practice__merge_sweeps:
+constraint practice.merge-sweeps:
   severity: warning
+  source: "practices/merge-sweeps.md"
   message: "Follow guidance from: Merge Sweeps"
 
-constraint practice__org_anomaly_detection_1:
+constraint practice.org-anomaly-detection-1:
   severity: warning
+  source: "practices/org-anomaly-detection.md"
   message: "Rate of change beats absolute thresholds. A sudden spike from 0.02 to 0.18 CI failure rate is more significant than a stable 0.20. Detect velocity changes, not just threshold crossings."
 
-constraint practice__org_anomaly_detection_2:
+constraint practice.org-anomaly-detection-2:
   severity: warning
+  source: "practices/org-anomaly-detection.md"
   message: "Correlate before alerting. A single anomaly may be noise. The same metric degrading across three or more repositories in 30 minutes is an org-wide signal."
 
-constraint practice__org_anomaly_detection_3:
+constraint practice.org-anomaly-detection-3:
   severity: warning
+  source: "practices/org-anomaly-detection.md"
   message: "Causal hypotheses, not just alerts. Every anomaly notification includes the most probable cause (shared dependency change, recent PR merge, known failure pattern) — not just the metric value."
 
-constraint practice__org_anomaly_detection_4:
+constraint practice.org-anomaly-detection-4:
   severity: warning
+  source: "practices/org-anomaly-detection.md"
   message: "Auto-remediate only low-risk actions. The monitor can open coordinator tasks and trigger known-safe fixes. High-impact actions always require human approval via Praxis gate."
 
-constraint practice__org_anomaly_detection_5:
+constraint practice.org-anomaly-detection-5:
   severity: warning
+  source: "practices/org-anomaly-detection.md"
   message: "False positives are learning data. When a human marks a detection as a false positive, the pattern library updates its sensitivity for that signature."
 
-constraint practice__org_anomaly_detection_6:
+constraint practice.org-anomaly-detection-6:
   severity: warning
+  source: "practices/org-anomaly-detection.md"
   message: "All detections are logged. Nothing happens silently. Every anomaly is written to `health_anomalies` with status, causal hypothesis, and resolution."
 
-constraint practice__praxis_logic_1:
+constraint practice.praxis-logic-1:
   severity: warning
-  message: "Facts, events, and rules over finite state machines. FSMs become unwieldy when state transitions depend on multiple conditions, business rules change independently of state flow, or you need to explain 'why did this happen?'"
+  source: "practices/praxis-logic.md"
+  message: "Facts, events, and rules over finite state machines. FSMs become unwieldy when state transitions depend on multiple conditions, business rules change independently of state flow, or you need to explain \"why did this happen?\""
 
-constraint practice__praxis_logic_2:
+constraint practice.praxis-logic-2:
   severity: error
+  source: "practices/praxis-logic.md"
   message: "Every conclusion must be traceable. No rule fires in isolation. Each decision links back to the facts and events that triggered it."
 
-constraint practice__praxis_logic_3:
+constraint practice.praxis-logic-3:
   severity: warning
+  source: "practices/praxis-logic.md"
   message: "Rules are pure. A rule's `impl` receives state and events and returns a result. No I/O, no side effects, no mutations."
 
-constraint practice__praxis_logic_4:
+constraint practice.praxis-logic-4:
   severity: warning
-  message: "Hypotheses are first-class. When evidence is incomplete, the system proposes hypotheses (`praxis_kind: 'hypothesis'`) and records confidence. Hypotheses decay if not confirmed."
+  source: "practices/praxis-logic.md"
+  message: "Hypotheses are first-class. When evidence is incomplete, the system proposes hypotheses (`praxis_kind: \"hypothesis\"`) and records confidence. Hypotheses decay if not confirmed."
 
-constraint practice__praxis_logic_5:
+constraint practice.praxis-logic-5:
   severity: warning
+  source: "practices/praxis-logic.md"
   message: "The loop improves with use. Each accepted or rejected guidance becomes a feedback signal. Over time, conflict rates fall and objective alignment scores rise."
 
-constraint practice__reactive_architecture_1:
+constraint practice.reactive-architecture-1:
   severity: warning
+  source: "practices/reactive-architecture.md"
   message: "Procedures over code. Agent behavior is defined as PluresDB procedures, not imperative TypeScript or Rust functions. You extend behavior by adding or updating a procedure — not by forking a repo."
 
-constraint practice__reactive_architecture_2:
+constraint practice.reactive-architecture-2:
   severity: warning
-  message: "Events over state polling. React to events when they happen. Do not check 'what is the current state?' on a schedule."
+  source: "practices/reactive-architecture.md"
+  message: "Events over state polling. React to events when they happen. Do not check \"what is the current state?\" on a schedule."
 
-constraint practice__reactive_architecture_3:
+constraint practice.reactive-architecture-3:
   severity: warning
+  source: "practices/reactive-architecture.md"
   message: "State is always consistent. Because procedures are triggered by the very event that changes state, there is no window where state is stale."
 
-constraint practice__reactive_architecture_4:
+constraint practice.reactive-architecture-4:
   severity: warning
+  source: "practices/reactive-architecture.md"
   message: "Cron for sweeps only. Cron (timer-based execution) is acceptable for periodic health checks and aggregation sweeps. It is not acceptable as the primary trigger for lifecycle transitions."
 
-constraint practice__reactive_architecture_5:
+constraint practice.reactive-architecture-5:
   severity: warning
+  source: "practices/reactive-architecture.md"
   message: "Everything is auditable. Every event that triggers a procedure is recorded. Every procedure output is recorded in `activity_log` and `pipeline_events`. Nothing happens silently."
 
-constraint practice__reactive_architecture_6:
+constraint practice.reactive-architecture-6:
   severity: warning
+  source: "practices/reactive-architecture.md"
   message: "Pipelines are graphs, not linear YAML. Flows trigger on conditions over state and events, including joins. A pipeline step can wait for multiple upstream conditions simultaneously."
 
-constraint practice__repo_routing_validation:
+constraint practice.repo-routing-validation:
   severity: warning
+  source: "practices/repo-routing-validation.md"
   message: "Follow guidance from: Repository Routing Validation"
 
-constraint practice__stale_pr_process:
+constraint practice.stale-pr-process:
   severity: warning
+  source: "practices/stale-pr-process.md"
   message: "Follow guidance from: Stale PR Process"
 
-constraint practice__systemic_triage_protocol:
+constraint practice.systemic-triage-protocol:
   severity: warning
+  source: "practices/systemic-triage-protocol.md"
   message: "Follow guidance from: Systemic Triage Protocol"
 
 # ══════════════════════════════════════════════════════════════════════
 # LESSONS (from lessons-learned/)
 # ══════════════════════════════════════════════════════════════════════
 
-constraint lesson__2026_02_copilot_sub_prs:
+constraint lesson.2026-02-copilot-sub-prs:
   severity: error
+  source: "lessons-learned/2026-02-copilot-sub-prs.md"
   message: "Follow guidance from: Copilot Creating Chains of Failing Sub-PRs"
 
-constraint lesson__2026_02_gun_removal:
+constraint lesson.2026-02-gun-removal:
   severity: error
+  source: "lessons-learned/2026-02-gun-removal.md"
   message: "Follow guidance from: Removing GUN in Favor of PluresDB"
 
-constraint lesson__2026_02_plugin_slot_conflict:
+constraint lesson.2026-02-plugin-slot-conflict:
   severity: error
-  message: "Follow guidance from: OpenClaw Plugin kind=memory Conflicts with Built-in Slot"
+  source: "lessons-learned/2026-02-plugin-slot-conflict.md"
+  message: "Follow guidance from: OpenClaw Plugin kind="memory" Conflicts with Built-in Slot"
 
-constraint lesson__2026_02_pluresdb_embedded:
+constraint lesson.2026-02-pluresdb-embedded:
   severity: error
+  source: "lessons-learned/2026-02-pluresdb-embedded.md"
   message: "Follow guidance from: PluresDB npm Package Requires Server for Embedded Use"
 
-constraint lesson__2026_03_copilot_tainted_issues_1:
+constraint lesson.2026-03-copilot-tainted-issues-1:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Check the issue for any Copilot error comments (environment/firewall errors appear as callout blocks in the issue body or as comments from the Copilot bot)."
 
-constraint lesson__2026_03_copilot_tainted_issues_2:
+constraint lesson.2026-03-copilot-tainted-issues-2:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Resolve the underlying environment issue (e.g., add the blocked URL to the Copilot agent allowlist in repo Copilot coding agent settings)."
 
-constraint lesson__2026_03_copilot_tainted_issues_3:
+constraint lesson.2026-03-copilot-tainted-issues-3:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Close the tainted issue and open a new one with identical content."
 
-constraint lesson__2026_03_copilot_tainted_issues_4:
+constraint lesson.2026-03-copilot-tainted-issues-4:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "A silent Copilot is not an idle Copilot. If the queue-advance workflow assigns an issue and no PR appears after 30+ minutes, the issue may be tainted — not just delayed."
 
-constraint lesson__2026_03_copilot_tainted_issues_5:
+constraint lesson.2026-03-copilot-tainted-issues-5:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Check for error callouts before re-pinging. Copilot embeds firewall/environment error details as warning callouts in the issue body. Read them before troubleshooting the queue logic."
 
-constraint lesson__2026_03_copilot_tainted_issues_6:
+constraint lesson.2026-03-copilot-tainted-issues-6:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Close and recreate, don't re-open or re-assign. Re-assigning a tainted issue to Copilot will not trigger a new attempt. The issue must be closed and a new issue created."
 
-constraint lesson__2026_03_copilot_tainted_issues_7:
+constraint lesson.2026-03-copilot-tainted-issues-7:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "External URL access must be configured before deployment. Any issue that requires `npm install`, package downloads, or external API access needs those URLs in the Copilot agent allowlist (configured in repo Settings → Copilot → Coding agent → Allowed URLs)."
 
-constraint lesson__2026_03_copilot_tainted_issues_8:
+constraint lesson.2026-03-copilot-tainted-issues-8:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "The 30-minute stall detection in `copilot-pr-lifecycle.yml` will re-ping tainted issues indefinitely. Add a max-ping counter or close-and-recreate step to the stall handler."
 
-constraint lesson__2026_03_copilot_tainted_issues_9:
+constraint lesson.2026-03-copilot-tainted-issues-9:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Added tainted-issue detection note to `practices/copilot-delegation.md`"
 
-constraint lesson__2026_03_copilot_tainted_issues_10:
+constraint lesson.2026-03-copilot-tainted-issues-10:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Added close-and-recreate procedure to issue management runbook"
 
-constraint lesson__2026_03_copilot_tainted_issues_11:
+constraint lesson.2026-03-copilot-tainted-issues-11:
   severity: error
+  source: "lessons-learned/2026-03-copilot-tainted-issues.md"
   message: "Updated stall detection in `copilot-pr-lifecycle.yml` to cap re-pings at 4 before alerting for human review (`queue-check:N` label)"
 
-constraint lesson__2026_03_double_vlan_tagging_1:
+constraint lesson.2026-03-double-vlan-tagging-1:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Identified the NIC-level VLAN configuration on the Hyper-V host's physical NIC (visible in NIC adapter advanced properties and NIC teaming configuration)."
 
-constraint lesson__2026_03_double_vlan_tagging_2:
+constraint lesson.2026-03-double-vlan-tagging-2:
   severity: error
-  message: "Removed the VLAN ID from the physical NIC / NIC team. The vSwitch external port was set to 'no VLAN' (untagged / access mode at the host NIC level)."
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
+  message: "Removed the VLAN ID from the physical NIC / NIC team. The vSwitch external port was set to \"no VLAN\" (untagged / access mode at the host NIC level)."
 
-constraint lesson__2026_03_double_vlan_tagging_3:
+constraint lesson.2026-03-double-vlan-tagging-3:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "VLAN tagging is now exclusively managed by the Azure Local logical network configuration — a single layer of tagging applied by the SDN stack."
 
-constraint lesson__2026_03_double_vlan_tagging_4:
+constraint lesson.2026-03-double-vlan-tagging-4:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Connectivity restored immediately after the NIC VLAN setting was cleared."
 
-constraint lesson__2026_03_double_vlan_tagging_5:
+constraint lesson.2026-03-double-vlan-tagging-5:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Only one layer owns VLAN tagging. When using SDN logical networks (Azure Local, Hyper-V SDN, NSX-T, etc.), disable VLAN configuration at the physical NIC and vSwitch port level. Let the SDN layer be the sole source of VLAN tags."
 
-constraint lesson__2026_03_double_vlan_tagging_6:
+constraint lesson.2026-03-double-vlan-tagging-6:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Double-tagging is silent. Frames leave the host looking healthy; the problem only manifests at the physical switch where double-tagged frames are dropped without error. Packet captures on the host show correctly tagged frames — captures on the physical switch are necessary to diagnose the issue."
 
-constraint lesson__2026_03_double_vlan_tagging_7:
+constraint lesson.2026-03-double-vlan-tagging-7:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Check NIC advanced properties, not just vSwitch settings. NIC driver-level VLAN settings (visible in Device Manager → NIC → Advanced properties) are independent of Hyper-V vSwitch configuration and easy to overlook."
 
-constraint lesson__2026_03_double_vlan_tagging_8:
+constraint lesson.2026-03-double-vlan-tagging-8:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Document the VLAN ownership model before deployment. Before deploying Azure Local, explicitly document: which layer applies VLAN tags (physical NIC, vSwitch, or SDN logical network), and verify that only one layer has a non-zero VLAN ID configured."
 
-constraint lesson__2026_03_double_vlan_tagging_9:
+constraint lesson.2026-03-double-vlan-tagging-9:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "ARP visible but no reply is a hallmark of double-tagging. If you can see outbound ARP frames from a VM on the physical switch but receive no reply, double-tagging or VLAN mismatch is the first thing to check — not firewall rules or routing."
 
-constraint lesson__2026_03_double_vlan_tagging_10:
+constraint lesson.2026-03-double-vlan-tagging-10:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Updated Azure Local deployment runbook with VLAN ownership checklist"
 
-constraint lesson__2026_03_double_vlan_tagging_11:
+constraint lesson.2026-03-double-vlan-tagging-11:
   severity: error
-  message: "Added 'NIC VLAN = 0 (untagged)' as a required pre-deployment verification step for Hyper-V hosts joining an Azure Local cluster"
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
+  message: "Added \"NIC VLAN = 0 (untagged)\" as a required pre-deployment verification step for Hyper-V hosts joining an Azure Local cluster"
 
-constraint lesson__2026_03_double_vlan_tagging_12:
+constraint lesson.2026-03-double-vlan-tagging-12:
   severity: error
+  source: "lessons-learned/2026-03-double-vlan-tagging.md"
   message: "Added to infrastructure troubleshooting guide: double-tagging symptom pattern and diagnosis steps"
 
-constraint lesson__2026_03_praxis_business_cascade_1:
+constraint lesson.2026-03-praxis-business-cascade-1:
   severity: error
+  source: "lessons-learned/2026-03-praxis-business-cascade.md"
   message: "Automation must not create systemic failure issues without identifying the upstream cause. A symptom tracker that creates issues faster than humans can triage them is harmful."
 
-constraint lesson__2026_03_praxis_business_cascade_2:
+constraint lesson.2026-03-praxis-business-cascade-2:
   severity: error
+  source: "lessons-learned/2026-03-praxis-business-cascade.md"
   message: "Three or more related blocked issues is a cascade, not a backlog. The correct response is a single meta-issue for coordination, not more individual issues."
 
-constraint lesson__2026_03_praxis_business_cascade_3:
+constraint lesson.2026-03-praxis-business-cascade-3:
   severity: error
+  source: "lessons-learned/2026-03-praxis-business-cascade.md"
   message: "Large cascades (> 5 issues) require human eyes. Automation should gate itself and wait for human triage rather than continuing to add to the pile."
 
-constraint lesson__2026_03_praxis_business_cascade_4:
+constraint lesson.2026-03-praxis-business-cascade-4:
   severity: error
+  source: "lessons-learned/2026-03-praxis-business-cascade.md"
   message: "Search before creating. Any workflow that creates issues must first search for existing issues with the same fingerprint or cause."
 
-constraint lesson__2026_03_reactive_over_cron_1:
+constraint lesson.2026-03-reactive-over-cron-1:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Removed 21 cron-based workflow schedules, replacing them with event-driven triggers (`pull_request`, `check_suite`, `issues`, `repository_dispatch`)."
 
-constraint lesson__2026_03_reactive_over_cron_2:
+constraint lesson.2026-03-reactive-over-cron-2:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Retained one cron sweep in `copilot-pr-lifecycle.yml` as an explicit stall-detection safety net, documented as intentional."
 
-constraint lesson__2026_03_reactive_over_cron_3:
+constraint lesson.2026-03-reactive-over-cron-3:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Added workflow trigger inventory to the org anomaly detection sweep (`practices/org-anomaly-detection.md`)."
 
-constraint lesson__2026_03_reactive_over_cron_4:
+constraint lesson.2026-03-reactive-over-cron-4:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Added workflow failure alerting: failed cron runs now create a GitHub issue with the `automation-failure` label."
 
-constraint lesson__2026_03_reactive_over_cron_5:
+constraint lesson.2026-03-reactive-over-cron-5:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Cron fails silently. A failed cron workflow does not retry, does not alert by default, and leaves no trace in the normal developer workflow. Use it only when you can tolerate missed runs."
 
-constraint lesson__2026_03_reactive_over_cron_6:
+constraint lesson.2026-03-reactive-over-cron-6:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Cron creates stale state. Any cron-driven action operates on state that may have changed since the last run. Event-driven actions operate on state at the moment the event occurs. Prefer event-driven for all lifecycle transitions."
 
-constraint lesson__2026_03_reactive_over_cron_7:
+constraint lesson.2026-03-reactive-over-cron-7:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Cron schedules accumulate. Without an audit process, every new automation adds a schedule and old ones are never removed. Maintain a workflow inventory and review cron usage quarterly."
 
-constraint lesson__2026_03_reactive_over_cron_8:
+constraint lesson.2026-03-reactive-over-cron-8:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "One sweep cron is acceptable; many are a smell. If a repo has more than one cron-triggered workflow, it almost certainly has redundant automation. Consolidate to a single sweep with explicit documented purpose."
 
-constraint lesson__2026_03_reactive_over_cron_9:
+constraint lesson.2026-03-reactive-over-cron-9:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Org-wide trigger audits are necessary. Each repo's workflow triggers are invisible to other repos. Regular org-wide audits are the only way to catch trigger proliferation before it becomes a volume or correctness problem."
 
-constraint lesson__2026_03_reactive_over_cron_10:
+constraint lesson.2026-03-reactive-over-cron-10:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Removed 21 cron schedules org-wide; documented surviving sweep in `copilot-pr-lifecycle.yml`"
 
-constraint lesson__2026_03_reactive_over_cron_11:
+constraint lesson.2026-03-reactive-over-cron-11:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Added cron audit step to quarterly org health review"
 
-constraint lesson__2026_03_reactive_over_cron_12:
+constraint lesson.2026-03-reactive-over-cron-12:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Added `cron: acceptable` / `cron: legacy` annotation convention for surviving schedules"
 
-constraint lesson__2026_03_reactive_over_cron_13:
+constraint lesson.2026-03-reactive-over-cron-13:
   severity: error
+  source: "lessons-learned/2026-03-reactive-over-cron.md"
   message: "Updated [Reactive Architecture](../practices/reactive-architecture.md) with explicit guidance on when cron is acceptable"
 
-constraint lesson__2026_03_rogue_automation_actor_1:
+constraint lesson.2026-03-rogue-automation-actor-1:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Disabled `check_suite` as a relay trigger; only user-initiated `pull_request` and `pull_request_review` events are forwarded."
 
-constraint lesson__2026_03_rogue_automation_actor_2:
+constraint lesson.2026-03-rogue-automation-actor-2:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Added `PLURES_PROJECTS` secret preflight check so the relay silently no-ops in repos where the secret is absent."
 
-constraint lesson__2026_03_rogue_automation_actor_3:
+constraint lesson.2026-03-rogue-automation-actor-3:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Documented the relay rollout process: pilot on one repo, observe volume for 48 hours, then expand."
 
-constraint lesson__2026_03_rogue_automation_actor_4:
+constraint lesson.2026-03-rogue-automation-actor-4:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Added Actions usage alerting to catch abnormal workflow run volume before it reaches critical levels."
 
-constraint lesson__2026_03_rogue_automation_actor_5:
+constraint lesson.2026-03-rogue-automation-actor-5:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Pilot before org-wide rollout. Any workflow that touches all repos must be tested on a single non-critical repo and monitored for 48 hours before expanding."
 
-constraint lesson__2026_03_rogue_automation_actor_6:
+constraint lesson.2026-03-rogue-automation-actor-6:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "`check_suite` is not a free trigger. It fires on every CI job in every repo. Use it only when the downstream action is idempotent and lightweight, and never as a fan-out relay trigger."
 
-constraint lesson__2026_03_rogue_automation_actor_7:
+constraint lesson.2026-03-rogue-automation-actor-7:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Automation that generates automation must have a volume ceiling. Any workflow that dispatches downstream events needs a rate limit or circuit breaker. If you can't bound the maximum event rate analytically, add one empirically."
 
-constraint lesson__2026_03_rogue_automation_actor_8:
+constraint lesson.2026-03-rogue-automation-actor-8:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Monitor Actions minute consumption as an early warning signal. Unexpected spikes in workflow runs are the canary for runaway automation."
 
-constraint lesson__2026_03_rogue_automation_actor_9:
+constraint lesson.2026-03-rogue-automation-actor-9:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Updated `pr-lane-event-relay.yml` to remove `check_suite` trigger and add secret preflight guard"
 
-constraint lesson__2026_03_rogue_automation_actor_10:
+constraint lesson.2026-03-rogue-automation-actor-10:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Added org-wide Actions usage alert to anomaly detection sweep"
 
-constraint lesson__2026_03_rogue_automation_actor_11:
+constraint lesson.2026-03-rogue-automation-actor-11:
   severity: error
+  source: "lessons-learned/2026-03-rogue-automation-actor.md"
   message: "Documented relay rollout checklist in `practices/automation-first.md`"
 
-constraint lesson__2026_03_single_assignment_authority_1:
+constraint lesson.2026-03-single-assignment-authority-1:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "`tech-doc-writer.yml` no longer assigns Copilot directly. It creates the documentation issue unassigned and adds the `documentation` label. The `queue-advance` job in `copilot-pr-lifecycle.yml` is the sole path by which Copilot is assigned (Priority 1: doc debt)."
 
-constraint lesson__2026_03_single_assignment_authority_2:
+constraint lesson.2026-03-single-assignment-authority-2:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Single assignment authority principle: only one workflow — `copilot-pr-lifecycle.yml` — may assign the Copilot SWE agent. All other workflows create issues (unassigned) and rely on queue-advance for assignment."
 
-constraint lesson__2026_03_single_assignment_authority_3:
+constraint lesson.2026-03-single-assignment-authority-3:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Added the `copilotBusy` guard to check both issue assignees *and* open PR authors before assigning."
 
-constraint lesson__2026_03_single_assignment_authority_4:
+constraint lesson.2026-03-single-assignment-authority-4:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "One workflow owns assignment. Copilot SWE agent assignment must flow through a single queue manager. Any workflow that creates issues must leave them unassigned and let the queue manager handle assignment."
 
-constraint lesson__2026_03_single_assignment_authority_5:
+constraint lesson.2026-03-single-assignment-authority-5:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Read-check-write is never atomic. Any queue logic that reads state, checks a condition, and writes based on that check is vulnerable to race conditions when concurrent workflow runs share the same resource. Design around idempotency rather than assuming exclusivity."
 
-constraint lesson__2026_03_single_assignment_authority_6:
+constraint lesson.2026-03-single-assignment-authority-6:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Concurrent triggers compound the risk. Workflows that trigger on high-frequency events (`check_suite`, `schedule`) are likely to run concurrently. Treat them as concurrent by default."
 
-constraint lesson__2026_03_single_assignment_authority_7:
+constraint lesson.2026-03-single-assignment-authority-7:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Limbo assignments are silent failures. An issue that is assigned but never started does not produce an error — it simply stalls. Add assignment age monitoring to surface limbo states."
 
-constraint lesson__2026_03_single_assignment_authority_8:
+constraint lesson.2026-03-single-assignment-authority-8:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Removed Copilot assignment from `tech-doc-writer.yml`; it now creates issues unassigned"
 
-constraint lesson__2026_03_single_assignment_authority_9:
+constraint lesson.2026-03-single-assignment-authority-9:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Documented single assignment authority in `standards/pr-workflow.md`"
 
-constraint lesson__2026_03_single_assignment_authority_10:
+constraint lesson.2026-03-single-assignment-authority-10:
   severity: error
+  source: "lessons-learned/2026-03-single-assignment-authority.md"
   message: "Added `copilotBusy` guard (checks both assigned issues and open Copilot PRs) to `copilot-pr-lifecycle.yml`"
 
 # ══════════════════════════════════════════════════════════════════════
 # STANDARDS (from standards/)
 # ══════════════════════════════════════════════════════════════════════
 
-constraint standard__adr:
+constraint standard.adr:
   severity: warning
+  source: "standards/adr.md"
   message: "Follow guidance from: Architecture Decision Records (ADR)"
 
-constraint standard__api_design:
+constraint standard.api-design:
   severity: warning
+  source: "standards/api-design.md"
   message: "Follow guidance from: API Design Guidelines"
 
-constraint standard__ci_cd:
+constraint standard.ci-cd:
   severity: warning
+  source: "standards/ci-cd.md"
   message: "Follow guidance from: CI/CD Standards"
 
-constraint standard__code_style:
+constraint standard.code-style:
   severity: warning
+  source: "standards/code-style.md"
   message: "Follow guidance from: Code Style"
 
-constraint standard__commit_conventions:
+constraint standard.commit-conventions:
   severity: warning
+  source: "standards/commit-conventions.md"
   message: "Follow guidance from: Commit Conventions"
 
-constraint standard__issue_management:
+constraint standard.issue-management:
   severity: warning
+  source: "standards/issue-management.md"
   message: "Follow guidance from: Issue Management"
 
-constraint standard__monorepo:
+constraint standard.monorepo:
   severity: warning
+  source: "standards/monorepo.md"
   message: "Follow guidance from: Monorepo Patterns"
 
-constraint standard__performance:
+constraint standard.performance:
   severity: warning
+  source: "standards/performance.md"
   message: "Follow guidance from: Performance Benchmarking Standards"
 
-constraint standard__pr_workflow:
+constraint standard.pr-workflow:
   severity: warning
+  source: "standards/pr-workflow.md"
   message: "Follow guidance from: PR Workflow"
 
-constraint standard__praxis_gates:
+constraint standard.praxis-gates:
   severity: warning
+  source: "standards/praxis-gates.md"
   message: "Follow guidance from: Praxis Gates Standards"
 
-constraint standard__praxis_modules:
+constraint standard.praxis-modules:
   severity: warning
+  source: "standards/praxis-modules.md"
   message: "Follow guidance from: Praxis Modules Standards"
 
-constraint standard__praxis_rules:
+constraint standard.praxis-rules:
   severity: warning
+  source: "standards/praxis-rules.md"
   message: "Follow guidance from: Praxis Rules Standards"
 
-constraint standard__repo_setup:
+constraint standard.repo-setup:
   severity: warning
+  source: "standards/repo-setup.md"
   message: "Follow guidance from: Repo Setup Standards"
 
-constraint standard__security:
+constraint standard.security:
   severity: warning
+  source: "standards/security.md"
   message: "Follow guidance from: Security Standards"
+
+# ══════════════════════════════════════════════════════════════════════
+# DESIGNS (from design/)
+# ══════════════════════════════════════════════════════════════════════
+
+constraint design.autonomous-pipeline-architecture:
+  severity: warning
+  source: "design/AUTONOMOUS-PIPELINE-ARCHITECTURE.md"
+  message: "Follow guidance from: Autonomous Pipeline Architecture"
+
+constraint design.constraint-source-protocol:
+  severity: warning
+  source: "design/CONSTRAINT-SOURCE-PROTOCOL.md"
+  message: "Follow guidance from: Constraint Source Protocol"
+
+constraint design.development-coordinator:
+  severity: warning
+  source: "design/DEVELOPMENT-COORDINATOR.md"
+  message: "Follow guidance from: DEVELOPMENT-COORDINATOR.md"
+
+constraint design.development-lifecycle:
+  severity: warning
+  source: "design/DEVELOPMENT-LIFECYCLE.md"
+  message: "Follow guidance from: Plures Development Lifecycle"
+
+constraint design.knowledge-governance:
+  severity: warning
+  source: "design/KNOWLEDGE-GOVERNANCE.md"
+  message: "Follow guidance from: Knowledge Governance: The Attorney-Client Model"
+
+constraint design.org-health-monitoring:
+  severity: warning
+  source: "design/ORG-HEALTH-MONITORING.md"
+  message: "Follow guidance from: Org Health Monitoring"
+
+constraint design.pares-agens:
+  severity: warning
+  source: "design/PARES-AGENS.md"
+  message: "Follow guidance from: Pares Agens — Reactive Agent Architecture"
+
+constraint design.pares-arcae-nexus:
+  severity: warning
+  source: "design/PARES-ARCAE-NEXUS.md"
+  message: "Follow guidance from: Pares Arcae Nexus — Decentralized PluresDB Object Registry"
+
+constraint design.plures-foundation:
+  severity: warning
+  source: "design/PLURES-FOUNDATION.md"
+  message: "Follow guidance from: Plures Foundation Architecture"
+
+constraint design.plures-lm-mobile:
+  severity: warning
+  source: "design/PLURES-LM-MOBILE.md"
+  message: "Follow guidance from: Plures LM Mobile — Design Document"
+
+constraint design.pluresdb-native-procedures:
+  severity: warning
+  source: "design/PLURESDB-NATIVE-PROCEDURES.md"
+  message: "Follow guidance from: Design: Native PluresDB Procedures as Memory Processing Engine"
+
+constraint design.praxis-intent-language:
+  severity: warning
+  source: "design/PRAXIS-INTENT-LANGUAGE.md"
+  message: "Follow guidance from: Praxis Intent Language (`.px`) — Design Document"
+
+constraint design.praxis-logic-coprocessor-plureslm:
+  severity: warning
+  source: "design/PRAXIS-LOGIC-COPROCESSOR-PLURESLM.md"
+  message: "Follow guidance from: Praxis Logic Coprocessor via PluresLM (Augments Pares Agens)"
+
+constraint design.praxis-single-source-derivation:
+  severity: warning
+  source: "design/PRAXIS-SINGLE-SOURCE-DERIVATION.md"
+  message: "Follow guidance from: Praxis Single-Source Derivation (SSoD)"
+
+constraint design.radix-orchestration:
+  severity: warning
+  source: "design/RADIX-ORCHESTRATION.md"
+  message: "Follow guidance from: Radix Orchestration via `.px` Procedures"
+
+constraint design.realm-topology-and-ai-governance:
+  severity: warning
+  source: "design/REALM-TOPOLOGY-AND-AI-GOVERNANCE.md"
+  message: "Follow guidance from: Realm Topology, AI Memory Scoping, and Decision Governance"
+
+constraint design.three-agent-cognitive-architecture:
+  severity: warning
+  source: "design/THREE-AGENT-COGNITIVE-ARCHITECTURE.md"
+  message: "Follow guidance from: Design: Three-Agent Cognitive Architecture"
 
 # ══════════════════════════════════════════════════════════════════════
 # ADRS (from docs/adr/)
 # ══════════════════════════════════════════════════════════════════════
 
-constraint adr__0009_readme_quality_standard:
+constraint adr.0009-readme-quality-standard:
   severity: warning
+  source: "docs/adr/0009-readme-quality-standard.md"
   message: "Follow guidance from: 0009. README Quality Standard"
 
-constraint adr__0010_test_exists_standard:
+constraint adr.0010-test-exists-standard:
   severity: warning
+  source: "docs/adr/0010-test-exists-standard.md"
   message: "Follow guidance from: 0010. Test Exists Standard"
 
-constraint adr__0011_test_coverage_standard:
+constraint adr.0011-test-coverage-standard:
   severity: warning
+  source: "docs/adr/0011-test-coverage-standard.md"
   message: "Follow guidance from: 0011. Test Coverage Standard"
 
-constraint adr__0012_api_documented_standard:
+constraint adr.0012-api-documented-standard:
   severity: warning
+  source: "docs/adr/0012-api-documented-standard.md"
   message: "Follow guidance from: 0012. API Documentation Standard"
 
-constraint adr__0013_no_known_vulns_standard:
+constraint adr.0013-no-known-vulns-standard:
   severity: warning
+  source: "docs/adr/0013-no-known-vulns-standard.md"
   message: "Follow guidance from: 0013. No-Known-Vulns Standard"
 
-constraint adr__0014_readme_quality_v2_standard:
+constraint adr.0014-readme-quality-v2-standard:
   severity: warning
+  source: "docs/adr/0014-readme-quality-v2-standard.md"
   message: "Follow guidance from: 0014. README Quality Standard — CI Badge"
 
-constraint adr__0015_version_published_standard:
+constraint adr.0015-version-published-standard:
   severity: warning
+  source: "docs/adr/0015-version-published-standard.md"
   message: "Follow guidance from: 0015. Version-Published Standard"
 
-constraint adr__0016_lint_clean_standard:
+constraint adr.0016-lint-clean-standard:
   severity: warning
+  source: "docs/adr/0016-lint-clean-standard.md"
   message: "Follow guidance from: 0016. Lint-Clean Standard"
 
-constraint adr__0017_readme_quality_v3_standard:
+constraint adr.0017-readme-quality-v3-standard:
   severity: warning
+  source: "docs/adr/0017-readme-quality-v3-standard.md"
   message: "Follow guidance from: 0017. README Quality Standard — Dev Tooling and CI Tests"
 
-constraint adr__0018_type_safety_standard:
+constraint adr.0018-type-safety-standard:
   severity: warning
+  source: "docs/adr/0018-type-safety-standard.md"
   message: "Follow guidance from: 0018. Type-Safety Standard"
 
 # ═══════════════════════════════════════════════════════════════════════
-# Total: 126 constraints generated from practices, lessons-learned, standards, docs/adr
+# Total: 144 constraints generated from practices, lessons-learned, standards, design, docs/adr
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Syncs the canonical plures-dev-guide.px from development-guide/constraints/ per C-DRIFT-001 and refactors outdated .px procedure files.

### Changes

**Synced:**
- praxis/skills/plures-dev-guide.px: 28KB to 38KB (canonical from development-guide)

**Refactored (cross-platform):**
- praxis/procedures/health_check.px: Was Linux-only. Now detects OS and uses platform-appropriate commands.
- praxis/procedures/self-test.px: Was Linux-only. Now uses get_temp_dir() helper and cross-platform commands.
- praxis/directives.px: Was stubs (just db_get + emit). Now has real procedural logic:
  - route_code: Routing with confidence levels
  - prioritize_work: P0-P4 priority framework
  - validate_architecture: Checks routing, SSoT (ADR-0010), 7 pillars
  - guide_lifecycle: Stage-aware guidance
  - detect_anti_patterns: Checks against lessons-learned DB

### Context
- Canonical source: plures/development-guide/constraints/plures-dev-guide.px
- Related: pares-agens PR syncing the same file