### PR TITLE
fix(ci): handle existing tags in auto-version-bump

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -24,6 +24,14 @@ jobs:
           PATCH=$(echo $VERSION | cut -d. -f3)
           NEW_PATCH=$((PATCH + 1))
           NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+
+          # Skip if this version tag already exists (idempotency)
+          if git tag -l "v$NEW_VERSION" | grep -q .; then
+            echo "Tag v$NEW_VERSION already exists, incrementing further"
+            NEW_PATCH=$((NEW_PATCH + 1))
+            NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+          fi
+
           sed -i "s/^version = \"$VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
@@ -32,6 +40,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml
+          if git diff --cached --quiet; then
+            echo "No version change needed"
+            exit 0
+          fi
           git commit -m "chore: bump version to v$NEW_VERSION [skip ci]"
           git tag "v$NEW_VERSION"
           git push --follow-tags


### PR DESCRIPTION
Fixes the Auto Version Bump workflow failing with 'tag already exists'.

**Root cause:** A previous run created the tag but the push partially failed, leaving a stale tag. Next run tries to create the same tag and fails.

**Fix:** Check if target tag exists before creating it; if it does, increment to the next available version.