### PR TITLE
fix(nix): update ONNX Runtime 1.23.2 → 1.24.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,10 @@
 
       # Prefetch ONNX Runtime static library for ort-sys.
       onnxruntimeLib = { pkgs }: pkgs.stdenvNoCC.mkDerivation {
-        name = "onnxruntime-prebuilt-1.23.2";
+        name = "onnxruntime-prebuilt-1.24.2";
         src = pkgs.fetchurl {
-          url = "https://cdn.pyke.io/0/pyke:ort-rs/ms@1.23.2/x86_64-unknown-linux-gnu.tar.lzma2";
-          hash = "sha256-jFfQWaqu5AeBKlaY1nBseeCQrWnhoUIEMJ6ALcu6o18=";
+          url = "https://cdn.pyke.io/0/pyke:ort-rs/ms@1.24.2/x86_64-unknown-linux-gnu.tar.lzma2";
+          hash = "sha256-rMHLp5wzdZTq0diMpyUWFHqmAFTIQhe1M5mjHKpbpnE=";
         };
         nativeBuildInputs = [ pkgs.python3 ];
         dontUnpack = true;


### PR DESCRIPTION
ort 2.0.0-rc.12 (via fastembed 5.16.0) requires ORT API v24. Prebuilt was v1.23.2 (API 1-23). Crash on praxisbot: 'The requested API version [24] is not available'