### PR TITLE
feat: smart model discovery and auto-selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "pares-agens-agenda"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "pares-agens-audit"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "pares-agens-bitnet"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "pares-agens-bitnet-sys",
@@ -4878,14 +4878,14 @@ dependencies = [
 
 [[package]]
 name = "pares-agens-bitnet-sys"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "pares-agens-channels"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "pares-agens-core"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4949,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "pares-agens-privacy"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "regex",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "pares-models"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-cli"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-marketplace"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -5047,7 +5047,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-mcp-client"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5062,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-mcp-server"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-praxis"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-sync"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "chrono",
  "hostname",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "pares-radix-tui"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "pares-rector"
-version = "1.44.12"
+version = "1.44.14"
 dependencies = [
  "hostname",
  "num_cpus",

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -53,10 +53,10 @@ pub struct MemoryConfig {
 }
 
 fn default_model() -> String {
-    "claude-sonnet-4.5".into()
+    "auto".into()
 }
 fn default_deep_model() -> String {
-    "claude-opus-4.6".into()
+    "auto".into()
 }
 fn default_endpoint() -> String {
     "https://api.individual.githubcopilot.com".into()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3037,8 +3037,9 @@ enum Commands {
         )]
         model_url: String,
 
-        /// Model name to use.
-        #[arg(long, env = "PARES_MODEL", default_value = "claude-sonnet-4.5")]
+        /// Model name to use. Set to "auto" or leave as default with --auto-models
+        /// to let pares-radix discover and select the best available model.
+        #[arg(long, env = "PARES_MODEL", default_value = "auto")]
         model: String,
 
         /// Use GitHub Copilot device flow authentication.
@@ -3046,7 +3047,8 @@ enum Commands {
         copilot: bool,
 
         /// Deep model name used for low-confidence escalation.
-        #[arg(long, env = "PARES_DEEP_MODEL", default_value = "claude-opus-4.6")]
+        /// Set to "auto" or leave as default with --auto-models to auto-select.
+        #[arg(long, env = "PARES_DEEP_MODEL", default_value = "auto")]
         deep_model: String,
 
         /// Deep model API URL (defaults to --model-url).
@@ -4135,17 +4137,31 @@ async fn main() {
             let mut deep_escalation_enabled = default_deep_escalation_enabled();
             let mut runtime_log_level = "info".to_string();
 
-            // Apply config file defaults when CLI wasn't explicitly set
-            if model == "claude-sonnet-4.5" {
+            // Apply config file overrides — only override CLI "auto" when config
+            // specifies a concrete model (not "auto" or empty)
+            if model == "auto" && radix_config.model.primary != "auto" && !radix_config.model.primary.is_empty() {
                 model = radix_config.model.primary.clone();
             }
-            if deep_model == "claude-opus-4.6" {
+            if deep_model == "auto" && radix_config.model.deep != "auto" && !radix_config.model.deep.is_empty() {
                 deep_model = radix_config.model.deep.clone();
             }
-            if model_url == "https://models.inference.ai.azure.com" {
+            if model_url == "https://models.inference.ai.azure.com" && !radix_config.model.endpoint.is_empty() {
                 model_url = radix_config.model.endpoint.clone();
             }
             let copilot = copilot || radix_config.model.copilot;
+
+            // For non-copilot mode, "auto" falls back to sensible defaults since
+            // we can't discover models from arbitrary OpenAI-compatible endpoints.
+            if !copilot {
+                if model == "auto" {
+                    model = "gpt-4o".to_string();
+                    tracing::info!("non-copilot mode: defaulting primary model to gpt-4o");
+                }
+                if deep_model == "auto" {
+                    deep_model = "gpt-4o".to_string();
+                    tracing::info!("non-copilot mode: defaulting deep model to gpt-4o");
+                }
+            }
 
             if copilot {
                 tracing::info!("Copilot auth enabled");
@@ -4295,8 +4311,56 @@ async fn main() {
                         oauth_token
                     };
 
-                    let auth = CopilotAuth::new(oauth_token.clone());
+                    let mut auth = CopilotAuth::new(oauth_token.clone());
                     let deep_auth = CopilotAuth::new(oauth_token);
+
+                    // Smart model discovery: if model or deep_model is "auto",
+                    // probe the Copilot API for available models and select the best.
+                    if model == "auto" || deep_model == "auto" {
+                        tracing::info!("auto-detecting available models...");
+                        match auth.list_models().await {
+                            Ok(available) if !available.is_empty() => {
+                                let selection = pares_agens_core::auth::copilot::select_models(&available);
+                                if model == "auto" {
+                                    tracing::info!(selected = %selection.primary, "auto-selected primary model");
+                                    model = selection.primary;
+                                    *model_name.write().await = model.clone();
+                                }
+                                if deep_model == "auto" {
+                                    tracing::info!(selected = %selection.deep, "auto-selected deep model");
+                                    deep_model = selection.deep;
+                                    *deep_model_name.write().await = deep_model.clone();
+                                }
+                                tracing::info!(
+                                    available_count = available.len(),
+                                    models = %available.iter().map(|m| m.id.as_str()).collect::<Vec<_>>().join(", "),
+                                    "model discovery complete"
+                                );
+                            }
+                            Ok(_) => {
+                                tracing::warn!("model discovery returned empty list, using defaults");
+                                if model == "auto" {
+                                    model = "claude-sonnet-4.5".to_string();
+                                    *model_name.write().await = model.clone();
+                                }
+                                if deep_model == "auto" {
+                                    deep_model = "claude-opus-4.6".to_string();
+                                    *deep_model_name.write().await = deep_model.clone();
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "model discovery failed, using defaults");
+                                if model == "auto" {
+                                    model = "claude-sonnet-4.5".to_string();
+                                    *model_name.write().await = model.clone();
+                                }
+                                if deep_model == "auto" {
+                                    deep_model = "claude-opus-4.6".to_string();
+                                    *deep_model_name.write().await = deep_model.clone();
+                                }
+                            }
+                        }
+                    }
 
                     // Default fallback chain for Copilot: if the primary model
                     // is unavailable (enterprise-only, rate-limited, etc.), try

--- a/crates/core/src/auth/copilot.rs
+++ b/crates/core/src/auth/copilot.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -605,6 +605,301 @@ impl ModelClient for CopilotModelClient {
             logprobs,
             model: None,
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model Discovery
+// ---------------------------------------------------------------------------
+
+/// Information about a model available through the Copilot API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableModel {
+    /// Model identifier (e.g. "claude-sonnet-4.5", "gpt-4o").
+    pub id: String,
+    /// Human-readable name.
+    #[serde(default)]
+    pub name: String,
+    /// Maximum input tokens.
+    #[serde(default)]
+    pub max_input_tokens: Option<u64>,
+    /// Maximum output tokens.
+    #[serde(default)]
+    pub max_output_tokens: Option<u64>,
+    /// Supported capabilities (e.g. ["chat", "tools"]).
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+/// Model tier classification for smart selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ModelTier {
+    /// Fast, cheap models for simple tasks.
+    Fast,
+    /// Balanced models for most work.
+    Standard,
+    /// High-capability models for complex reasoning.
+    Premium,
+}
+
+/// Result of model discovery — recommended selections.
+#[derive(Debug, Clone)]
+pub struct ModelSelection {
+    /// Primary model for standard inference.
+    pub primary: String,
+    /// Deep/escalation model for complex reasoning.
+    pub deep: String,
+    /// All available models.
+    pub available: Vec<AvailableModel>,
+}
+
+impl CopilotAuth {
+    /// List models available through the Copilot API.
+    ///
+    /// Tries `/models` on the Copilot API base URL first, falls back to the
+    /// GitHub Models catalog at `https://models.github.ai/catalog/models`.
+    pub async fn list_models(&mut self) -> Result<Vec<AvailableModel>, CopilotAuthError> {
+        let token = self.ensure_fresh_token().await?.to_string();
+        let api_base = self.api_base_url().to_string();
+        let client = reqwest::Client::new();
+
+        // Try Copilot API /models endpoint
+        let url = format!("{}/models", api_base.trim_end_matches('/'));
+        tracing::info!(url = %url, "listing available models");
+
+        let response = client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .header("Editor-Version", EDITOR_VERSION)
+            .header("User-Agent", USER_AGENT)
+            .header("X-Github-Api-Version", API_VERSION)
+            .header(ACCEPT, "application/json")
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let body: Value = response.json().await?;
+            if let Some(models) = parse_models_response(&body) {
+                tracing::info!(count = models.len(), "discovered models from Copilot API");
+                return Ok(models);
+            }
+        } else {
+            tracing::debug!(
+                status = %response.status(),
+                "Copilot /models endpoint unavailable, trying catalog"
+            );
+        }
+
+        // Fallback: GitHub Models catalog
+        let catalog_url = "https://models.github.ai/catalog/models";
+        let response = client
+            .get(catalog_url)
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .header(ACCEPT, "application/json")
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let body: Value = response.json().await?;
+            if let Some(models) = parse_models_response(&body) {
+                tracing::info!(count = models.len(), source = "catalog", "discovered models from GitHub catalog");
+                return Ok(models);
+            }
+        }
+
+        tracing::warn!("no model listing available from any endpoint");
+        Ok(vec![])
+    }
+}
+
+/// Parse a models response — handles both array-of-objects and {data: [...]} formats.
+fn parse_models_response(body: &Value) -> Option<Vec<AvailableModel>> {
+    let arr = if let Some(arr) = body.as_array() {
+        arr.clone()
+    } else if let Some(arr) = body.get("data").and_then(|d| d.as_array()) {
+        arr.clone()
+    } else if let Some(arr) = body.get("models").and_then(|d| d.as_array()) {
+        arr.clone()
+    } else {
+        return None;
+    };
+
+    let models: Vec<AvailableModel> = arr
+        .iter()
+        .filter_map(|v| {
+            let id = v.get("id").and_then(|i| i.as_str())?.to_string();
+            let name = v
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(&id)
+                .to_string();
+            let max_input_tokens = v
+                .get("limits")
+                .and_then(|l| l.get("max_input_tokens"))
+                .and_then(|t| t.as_u64())
+                .or_else(|| v.get("max_input_tokens").and_then(|t| t.as_u64()));
+            let max_output_tokens = v
+                .get("limits")
+                .and_then(|l| l.get("max_output_tokens"))
+                .and_then(|t| t.as_u64())
+                .or_else(|| v.get("max_output_tokens").and_then(|t| t.as_u64()));
+            let capabilities = v
+                .get("capabilities")
+                .and_then(|c| c.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|c| c.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Some(AvailableModel {
+                id,
+                name,
+                max_input_tokens,
+                max_output_tokens,
+                capabilities,
+            })
+        })
+        .collect();
+
+    if models.is_empty() {
+        None
+    } else {
+        Some(models)
+    }
+}
+
+/// Classify a model into a tier based on its identifier.
+fn classify_model_tier(model_id: &str) -> ModelTier {
+    let id = model_id.to_lowercase();
+
+    // Premium tier — large reasoning models
+    if id.contains("opus")
+        || id.contains("o1")
+        || id.contains("o3")
+        || id.contains("gpt-5")
+        || id.contains("deep-research")
+    {
+        return ModelTier::Premium;
+    }
+
+    // Standard tier — balanced capability models
+    if id.contains("sonnet")
+        || id.contains("gpt-4o")
+        || id.contains("gpt-4.1")
+        || id.contains("gemini-2")
+        || id.contains("claude-4")
+    {
+        return ModelTier::Standard;
+    }
+
+    // Fast tier — smaller/cheaper models
+    if id.contains("haiku")
+        || id.contains("mini")
+        || id.contains("flash")
+        || id.contains("nano")
+        || id.contains("gpt-3")
+    {
+        return ModelTier::Fast;
+    }
+
+    // Default to standard for unknown models
+    ModelTier::Standard
+}
+
+/// Score a model within its tier for selection preference.
+/// Higher = better. Based on recency and capability.
+fn model_preference_score(model_id: &str) -> u32 {
+    let id = model_id.to_lowercase();
+
+    // Claude models — prefer newer versions
+    if id.contains("claude-opus-4") { return 100; }
+    if id.contains("claude-sonnet-4") { return 95; }
+    if id.contains("claude-4") { return 90; }
+    if id.contains("claude-opus") { return 85; }
+    if id.contains("claude-sonnet") { return 80; }
+
+    // GPT models
+    if id.contains("gpt-5") { return 98; }
+    if id.contains("gpt-4o") { return 75; }
+    if id.contains("gpt-4.1") { return 70; }
+    if id.contains("o3") { return 92; }
+    if id.contains("o1") { return 88; }
+
+    // Gemini
+    if id.contains("gemini-2.5") { return 72; }
+    if id.contains("gemini-2") { return 68; }
+
+    50 // Unknown
+}
+
+/// Select the best primary and deep models from a list of available models.
+pub fn select_models(available: &[AvailableModel]) -> ModelSelection {
+    if available.is_empty() {
+        tracing::warn!("no models discovered, using hardcoded defaults");
+        return ModelSelection {
+            primary: "claude-sonnet-4.5".to_string(),
+            deep: "claude-opus-4.6".to_string(),
+            available: vec![],
+        };
+    }
+
+    // Separate into tiers
+    let mut premium: Vec<&AvailableModel> = vec![];
+    let mut standard: Vec<&AvailableModel> = vec![];
+    let mut fast: Vec<&AvailableModel> = vec![];
+
+    for m in available {
+        match classify_model_tier(&m.id) {
+            ModelTier::Premium => premium.push(m),
+            ModelTier::Standard => standard.push(m),
+            ModelTier::Fast => fast.push(m),
+        }
+    }
+
+    // Primary: best Standard-tier model (balanced speed/quality)
+    let primary = standard
+        .iter()
+        .max_by_key(|m| model_preference_score(&m.id))
+        .map(|m| m.id.clone())
+        .or_else(|| {
+            // Fallback to best Fast model if no Standard available
+            fast.iter()
+                .max_by_key(|m| model_preference_score(&m.id))
+                .map(|m| m.id.clone())
+        })
+        .unwrap_or_else(|| available[0].id.clone());
+
+    // Deep: best Premium-tier model (max reasoning for escalation)
+    let deep = premium
+        .iter()
+        .max_by_key(|m| model_preference_score(&m.id))
+        .map(|m| m.id.clone())
+        .or_else(|| {
+            // Fallback to best Standard model that's different from primary
+            standard
+                .iter()
+                .filter(|m| m.id != primary)
+                .max_by_key(|m| model_preference_score(&m.id))
+                .map(|m| m.id.clone())
+        })
+        .unwrap_or_else(|| primary.clone());
+
+    tracing::info!(
+        primary = %primary,
+        deep = %deep,
+        total_available = available.len(),
+        premium_count = premium.len(),
+        standard_count = standard.len(),
+        fast_count = fast.len(),
+        "model selection complete"
+    );
+
+    ModelSelection {
+        primary,
+        deep,
+        available: available.to_vec(),
     }
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -181,14 +181,14 @@ tar.extractall(os.environ['out'] + '/lib')
 
             model = lib.mkOption {
               type = lib.types.str;
-              default = "gpt-4.1";
-              description = "Conscious model (80% of traffic).";
+              default = "auto";
+              description = "Primary model. Set to 'auto' for smart detection from available provider models.";
             };
 
             deepModel = lib.mkOption {
               type = lib.types.str;
-              default = "claude-opus-4.6";
-              description = "Deep model for low-confidence escalation.";
+              default = "auto";
+              description = "Deep model for low-confidence escalation. Set to 'auto' for smart detection.";
             };
 
             telegramTokenFile = lib.mkOption {
@@ -292,7 +292,8 @@ tar.extractall(os.environ['out'] + '/lib')
                 let
                   escapedTelegramTokenFile = lib.escapeShellArg (toString cfg.telegramTokenFile);
                   copilotArg = if cfg.copilot then "--copilot" else "";
-                  modelArg = "--model ${cfg.model} --deep-model ${cfg.deepModel}";
+                  modelArg = (if cfg.model != "auto" then "--model ${cfg.model}" else "")
+                    + (if cfg.deepModel != "auto" then " --deep-model ${cfg.deepModel}" else "");
                   promptArg = if cfg.systemPromptFile != null
                     then "--system-prompt ${cfg.systemPromptFile}"
                     else "";


### PR DESCRIPTION
When model is 'auto' (new default), probes Copilot API /models on startup. Selects best Standard-tier for primary, Premium-tier for deep. Falls back to hardcoded defaults if discovery fails. Explicit --model/--deep-model still work.