### PR TITLE
fix(spine): make resolve_state_dir_honors_env test portable (Linux CI fix)

### DIFF
--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -251,9 +251,15 @@ mod tests {
     #[test]
     fn resolve_state_dir_honors_env() {
         // SAFETY: single-threaded test; we set then immediately read.
-        std::env::set_var(STATE_DIR_ENV, r"C:\some\override\state");
+        // Build the override with the OS-native separator so the assertion is
+        // portable: a hardcoded "C:\\..\\state" string is a SINGLE path
+        // component on Linux (backslash is not a separator there), which made
+        // `ends_with("state")` fail in CI. Use a real joined path instead.
+        let override_dir = std::env::temp_dir().join("radix-override").join("state");
+        std::env::set_var(STATE_DIR_ENV, &override_dir);
         let dir = resolve_state_dir();
         assert!(dir.ends_with("state"));
+        assert_eq!(dir, override_dir);
         std::env::remove_var(STATE_DIR_ENV);
     }
 


### PR DESCRIPTION
## Problem
`spine::runtime::tests::resolve_state_dir_honors_env` fails on **Linux CI** (passes on the Windows DevBox) — surfaced by the CI run on PR #461 (`test result: FAILED. 778 passed; 1 failed` at `runtime.rs:256`: `assertion failed: dir.ends_with("state")`).

## Root cause
The test hardcoded a Windows path `C:\some\override\state` and asserted `dir.ends_with("state")`. On Linux the backslashes are **literal** (not path separators), so the entire string is a single path component and `ends_with("state")` is false. Pure test non-portability — **production `resolve_state_dir()` is already correct** (it just does `PathBuf::from(env_var)`).

## Fix
Build the override path with the OS-native separator via `std::env::temp_dir().join("radix-override").join("state")` so the assertion holds on every platform, and add an `assert_eq!` on the full path to lock in that the env override is honored verbatim. Test-only change; zero production logic touched.

## Verification (on disk, this branch)
- `cargo test -p pares-radix-core --lib resolve_state_dir_honors_env` → **1 passed**
- `cargo clippy -p pares-radix-core --lib -- -D warnings` → clean

This unblocks the `ci / rust` gate (it was the sole real failure; the rest of that run's noise was a transient sccache outage with successful no-sccache retry).