### PR TITLE
feat(vscode): register radix MCP server for Copilot .px evaluation (#2919091)

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,14 @@
+{
+  "servers": {
+    "radix-praxis": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "tsx", "src/index.ts"],
+      "cwd": "${workspaceFolder}/packages/mcp-dev-server",
+      "env": {
+        "RADIX_DEV": "1"
+      },
+      "tools": ["praxis.evaluate", "praxis.listRules", "praxis.addConstraint", "praxis.addRule"]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `.vscode/mcp.json` registering the **existing** radix MCP dev server so **GitHub Copilot agent mode in VS Code can evaluate this repo's `.px` constraints** via `praxis.evaluate`.

This is the first concrete deliverable of the ".px -> VS Code + Copilot" reuse map (ADO #2919091). It reuses the shipped `@plures/radix-mcp-server` (`packages/mcp-dev-server`) **verbatim** - no new engine code.

## The config

```jsonc
{ "servers": { "radix-praxis": {
  "type": "stdio",
  "command": "npx", "args": ["-y", "tsx", "src/index.ts"],
  "cwd": "${workspaceFolder}/packages/mcp-dev-server",
  "env": { "RADIX_DEV": "1" },
  "tools": ["praxis.evaluate", "praxis.listRules", "praxis.addConstraint", "praxis.addRule"] } } }
```

## Proof (build-the-binary-run-the-binary)

- Server verified running (`RADIX_DEV=1`, hand-rolled stdio JSON-RPC).
- `tools/call praxis.evaluate` -> **evaluated 27 real constraints**, returned real violations, e.g.
  `{ "constraint": "atomic-propagation", "severity": "error", "message": "All config changes must be atomic..." }`.
- Config validated: valid JSON, `cwd` resolves to `packages/mcp-dev-server/src/index.ts`, zero newline mangling.

## How to verify in VS Code

1. `pnpm install` at the repo root (the server needs its deps + constraint store; an uninstalled checkout starts but evaluates empty).
2. Open the repo in VS Code -> Copilot Chat -> **agent mode**. It discovers the `radix-praxis` MCP server.
3. Ask Copilot to evaluate the praxis constraints (or invoke the `praxis.evaluate` tool). It returns the live violations.

## Honest scope (NO-STUBS)

`praxis.evaluate` today uses a DB-backed store + a **light in-TS `when`/`require` check** - real and working, but **not** the canonical Rust engine. Backing it with `@plures/px-napi`.`checkConstraints` (proven: returns `{name,severity,status,message}`) so MCP + IDE + CI share one evaluator is a **separate staged task**, deliberately not bundled here.

## Roadmap

- **#2919091 (this PR):** MCP-into-VS-Code path -> Copilot evaluates `.px` now.
- **#2919090:** in-editor squiggles + `@praxis` Copilot participant (clone `pluresLM-vscode` + retarget `pedantic` LSP on `px-napi`).
- **#2919092:** pre-commit + CI backstop.
