### PR TITLE
fix(spine): inject durable open-tasks grounding on live reactive .px path (#467)

### DIFF
--- a/crates/radix-core/src/auth/copilot.rs
+++ b/crates/radix-core/src/auth/copilot.rs
@@ -775,15 +775,11 @@ impl CopilotAuth {
 
 /// Parse a models response — handles both array-of-objects and {data: [...]} formats.
 fn parse_models_response(body: &Value) -> Option<Vec<AvailableModel>> {
-    let arr = if let Some(arr) = body.as_array() {
-        arr.clone()
-    } else if let Some(arr) = body.get("data").and_then(|d| d.as_array()) {
-        arr.clone()
-    } else if let Some(arr) = body.get("models").and_then(|d| d.as_array()) {
-        arr.clone()
-    } else {
-        return None;
-    };
+    let arr = body
+        .as_array()
+        .or_else(|| body.get("data").and_then(|d| d.as_array()))
+        .or_else(|| body.get("models").and_then(|d| d.as_array()))?
+        .clone();
 
     let models: Vec<AvailableModel> = arr
         .iter()

--- a/crates/radix-core/src/spine/actions.rs
+++ b/crates/radix-core/src/spine/actions.rs
@@ -274,10 +274,10 @@ impl AsyncActionHandler for CompositeActionHandler {
             if let Some(ref h) = self.task_grounding {
                 h.call(action, params).await
             } else {
-                // No task store wired — return null so `.px` injects no block.
-                // Honest absence (C-NOSTUB-001): we do NOT fabricate tasks.
-                warn!(action = %action, "task grounding not wired — returning null");
-                Ok(Value::Null)
+                // No task store wired — degrade gracefully. If `.px` supplied a base prompt, pass it through.
+                warn!(action = %action, "task grounding not wired — passing through base prompt");
+                let base = params.get("base").and_then(|v| v.as_str());
+                Ok(Value::String(base.unwrap_or("").to_string()))
             }
         } else if is_subagent_action(action) {
             if let Some(ref actor) = self.subagent {

--- a/crates/radix-core/src/spine/actions.rs
+++ b/crates/radix-core/src/spine/actions.rs
@@ -175,6 +175,9 @@ impl AsyncActionHandler for CoreActionHandler {
 use crate::spine::dev_lifecycle_actions::{is_dev_lifecycle_action, DevLifecycleActionHandler};
 use crate::spine::briefing_actions::{is_briefing_action, BriefingActionHandler};
 use crate::spine::run_command_actions::{is_run_command_action, RunCommandActionHandler};
+use crate::spine::task_grounding_actions::{
+    is_task_grounding_action, TaskGroundingActionHandler,
+};
 use crate::spine::subagent_actor::{is_subagent_action, SubagentActor};
 use crate::spine::worktask_actions::{is_worktask_action, WorktaskActionHandler};
 
@@ -197,6 +200,10 @@ pub struct CompositeActionHandler {
     worktask: WorktaskActionHandler,
     run_command: RunCommandActionHandler,
     briefing: BriefingActionHandler,
+    /// Durable task-grounding handler (`read_open_tasks_block`). `None` when the
+    /// runtime was assembled without a task store; the action then returns null
+    /// and `.px` injects no block (honest absence, never a stub).
+    task_grounding: Option<TaskGroundingActionHandler>,
     subagent: Option<Arc<SubagentActor>>,
     tool_handler: Arc<crate::px_adapter::ToolDispatchActionHandler>,
 }
@@ -215,9 +222,25 @@ impl CompositeActionHandler {
             dev_lifecycle: DevLifecycleActionHandler::new(),
             run_command: RunCommandActionHandler::new(),
             briefing: BriefingActionHandler::new(),
+            task_grounding: None,
             subagent: None,
             tool_handler,
         }
+    }
+
+    /// Attach the durable [`TaskGroundingActionHandler`] so the live reactive
+    /// `.px` path (`build_context`) can inject the persisted open-tasks block
+    /// into the model system prompt each inbound turn (pares-radix#467).
+    ///
+    /// The manager must be backed by the SAME PluresDB store as the rest of the
+    /// runtime so tasks written by the task procedures are read here
+    /// (C-PLURES-003/004).
+    pub fn with_task_grounding(
+        mut self,
+        task_manager: Arc<crate::task_manager::TaskManager>,
+    ) -> Self {
+        self.task_grounding = Some(TaskGroundingActionHandler::new(task_manager));
+        self
     }
 
     /// Set the subagent actor after construction (breaks circular dependency).
@@ -247,6 +270,15 @@ impl AsyncActionHandler for CompositeActionHandler {
             self.run_command.call(action, params).await
         } else if is_briefing_action(action) {
             self.briefing.call(action, params).await
+        } else if is_task_grounding_action(action) {
+            if let Some(ref h) = self.task_grounding {
+                h.call(action, params).await
+            } else {
+                // No task store wired — return null so `.px` injects no block.
+                // Honest absence (C-NOSTUB-001): we do NOT fabricate tasks.
+                warn!(action = %action, "task grounding not wired — returning null");
+                Ok(Value::Null)
+            }
         } else if is_subagent_action(action) {
             if let Some(ref actor) = self.subagent {
                 actor.call(action, params).await
@@ -366,5 +398,82 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, Value::Null);
+    }
+
+    /// END-TO-END LIVE-PATH PROOF (pares-radix#467 — task amnesia):
+    ///
+    /// Assemble the [`CompositeActionHandler`] EXACTLY as the shipped serve
+    /// runtime does (`build_reactive_runtime_with_tasks`): a real
+    /// [`TaskManager`](crate::task_manager::TaskManager) over the SAME PluresDB
+    /// `CrdtStore` the task procedures write to, wired via `with_task_grounding`.
+    /// Persist an open task, then invoke the `read_open_tasks_block` action the
+    /// live `praxis/spine/conversation.px::build_context` step calls — passing
+    /// the base system prompt — and assert the durable open-tasks block is
+    /// injected ahead of the base prompt in the string that becomes the inbound
+    /// turn's `system_prompt`. This proves the grounding reaches every inbound
+    /// turn on the live reactive path, NOT via the (test-only) Rust ModelInvoker.
+    #[tokio::test]
+    async fn live_path_injects_open_tasks_block_into_system_prompt() {
+        use crate::model::{ToolDefinition, ToolDispatcher};
+        use crate::px_adapter::ToolDispatchActionHandler;
+        use crate::task_manager::TaskManager;
+        use pluresdb::{CrdtStore, MemoryStorage};
+
+        // A trivial tool dispatcher — the read_open_tasks_block action never
+        // reaches it (it's handled before the tool fallthrough).
+        struct NullDispatcher;
+        #[async_trait]
+        impl ToolDispatcher for NullDispatcher {
+            async fn available_tools(&self) -> Vec<ToolDefinition> {
+                vec![]
+            }
+            async fn call_tool(&self, _name: &str, _args: Value) -> String {
+                "null".to_string()
+            }
+        }
+
+        // Shared store used by BOTH the task manager and (conceptually) state.
+        let storage: Arc<dyn pluresdb::StorageEngine> = Arc::new(MemoryStorage::default());
+        let crdt = Arc::new(CrdtStore::default().with_persistence(storage));
+        let task_manager = Arc::new(TaskManager::new(Arc::clone(&crdt)));
+
+        // Persist a real open task for this chat.
+        task_manager.create_task("finish the praxisbot 467 fix", "tg-chat-1", vec![]);
+
+        // Build the composite exactly like the runtime, with task grounding.
+        let conv: Arc<dyn ConversationStore> = Arc::new(MemoryConversationStore::new());
+        let tool_handler = Arc::new(ToolDispatchActionHandler::new(Arc::new(NullDispatcher)));
+        let composite = CompositeActionHandler::new(conv, test_state(), tool_handler)
+            .with_task_grounding(Arc::clone(&task_manager));
+
+        // Drive the live action the .px build_context step calls.
+        let base = "You are praxisbot, a helpful agent.";
+        let out = composite
+            .call(
+                "read_open_tasks_block",
+                &serde_json::json!({"chat_id": "tg-chat-1", "base": base}),
+            )
+            .await
+            .unwrap();
+        let grounded = out.as_str().expect("action returns a string prompt");
+
+        assert!(
+            grounded.contains("finish the praxisbot 467 fix"),
+            "live system prompt must carry the persisted open task; got: {grounded}"
+        );
+        assert!(
+            grounded.contains("open tasks/commitments"),
+            "live system prompt must carry the grounding header; got: {grounded}"
+        );
+        assert!(
+            grounded.contains(base),
+            "base system prompt must be preserved; got: {grounded}"
+        );
+        // Grounding block precedes the base prompt.
+        assert!(
+            grounded.find("finish the praxisbot 467 fix").unwrap()
+                < grounded.find(base).unwrap(),
+            "grounding block must be prepended before the base prompt"
+        );
     }
 }

--- a/crates/radix-core/src/spine/mod.rs
+++ b/crates/radix-core/src/spine/mod.rs
@@ -32,6 +32,7 @@ pub mod pipeline;
 pub mod procedures;
 pub mod reactive;
 pub mod run_command_actions;
+pub mod task_grounding_actions;
 /// Runtime assembly — wires the `.px` engine + state store + handler into the live spine.
 pub mod runtime;
 pub mod shadow;

--- a/crates/radix-core/src/spine/procedures/model_invoker.rs
+++ b/crates/radix-core/src/spine/procedures/model_invoker.rs
@@ -83,46 +83,13 @@ impl ModelInvoker {
     /// the given chat. Returns `None` when there are no open tasks so we never
     /// inject an empty/noise block.
     ///
-    /// Combines chat-scoped open tasks with globally open tasks (deduped by id)
-    /// so obligations survive conversation-history trimming and process restarts.
+    /// Delegates to the shared [`crate::task_manager::render_open_tasks_block`]
+    /// so the Rust SpineProcedure path and the live reactive `.px` path
+    /// (`read_open_tasks_block` action) render an identical block — one
+    /// implementation, no duplication (ADR-0010).
     fn render_open_tasks_block(&self, chat_id: &str) -> Option<String> {
         let manager = self.task_manager.as_ref()?;
-
-        // Chat-scoped open tasks first, then any other globally-open tasks.
-        let mut tasks = manager.tasks_for_chat(chat_id, false);
-        let mut seen: std::collections::HashSet<String> =
-            tasks.iter().map(|t| t.id.clone()).collect();
-        for t in manager.open_tasks() {
-            if seen.insert(t.id.clone()) {
-                tasks.push(t);
-            }
-        }
-
-        if tasks.is_empty() {
-            return None;
-        }
-
-        // Highest priority first (priority 1 = highest), then most recent.
-        tasks.sort_by(|a, b| {
-            a.priority
-                .cmp(&b.priority)
-                .then(b.created_at.cmp(&a.created_at))
-        });
-
-        let mut block = String::from(
-            "## Your open tasks/commitments (durable, from the task store — treat as authoritative)\n",
-        );
-        for t in tasks.iter().take(25) {
-            block.push_str(&format!(
-                "- [{:?}] (p{}) {}\n",
-                t.status, t.priority, t.description
-            ));
-        }
-        block.push_str(
-            "\nThese are your actual tracked obligations regardless of chat history length. \
-            When asked what your tasks/commitments are, answer from this list.",
-        );
-        Some(block)
+        crate::task_manager::render_open_tasks_block(manager, chat_id)
     }
 
     /// Attach a conversation store for multi-turn history.

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -148,6 +148,32 @@ pub async fn build_reactive_runtime(
     praxis_dir: &Path,
     capacity: usize,
 ) -> ReactiveRuntime {
+    build_reactive_runtime_with_tasks(
+        state_store,
+        conversation_store,
+        tool_dispatcher,
+        None,
+        praxis_dir,
+        capacity,
+    )
+    .await
+}
+
+/// Like [`build_reactive_runtime`] but also wires a durable
+/// [`TaskManager`](crate::task_manager::TaskManager) into the composite action
+/// handler so the live reactive `.px` path can inject the persisted open-tasks
+/// grounding block into the model system prompt each inbound turn
+/// (pares-radix#467). Pass `None` to run without task grounding (the
+/// `read_open_tasks_block` action then returns null and `.px` injects no
+/// block).
+pub async fn build_reactive_runtime_with_tasks(
+    state_store: Arc<dyn StateStore>,
+    conversation_store: Arc<dyn ConversationStore>,
+    tool_dispatcher: Arc<dyn ToolDispatcher>,
+    task_manager: Option<Arc<crate::task_manager::TaskManager>>,
+    praxis_dir: &Path,
+    capacity: usize,
+) -> ReactiveRuntime {
     // 1. Tool handler — bridges `.px` action calls that aren't core/lifecycle
     //    into the tool dispatch pipeline.
     let tool_handler = Arc::new(ToolDispatchActionHandler::new(tool_dispatcher));
@@ -155,11 +181,16 @@ pub async fn build_reactive_runtime(
     // 2. The composite handler the procedures invoke. CoreActionHandler is now
     //    backed by the durable state store (read_state/write_state round-trip
     //    through PluresDB, not a stub).
-    let composite = Arc::new(CompositeActionHandler::new(
+    let mut composite = CompositeActionHandler::new(
         Arc::clone(&conversation_store),
         Arc::clone(&state_store),
         tool_handler,
-    ));
+    );
+    if let Some(tm) = task_manager {
+        // Durable open-tasks grounding over the SAME store (C-PLURES-003/004).
+        composite = composite.with_task_grounding(tm);
+    }
+    let composite = Arc::new(composite);
 
     // 3. Build the registry and load every `.px` procedure against it.
     let registry = Arc::new(ReactiveRegistry::new());
@@ -205,12 +236,17 @@ pub async fn build_default_reactive_runtime(
     let conversation_store: Arc<dyn ConversationStore> = Arc::new(
         crate::spine::conversation::PluresConversationStore::new(pdb.crdt_store()),
     );
+    // Durable task manager over the SAME CRDT store (C-PLURES-003/004) so the
+    // live `.px` model path can surface persisted open tasks each turn
+    // (pares-radix#467 — task amnesia).
+    let task_manager = Arc::new(crate::task_manager::TaskManager::new(pdb.crdt_store()));
     let state_store: Arc<dyn StateStore> = Arc::new(pdb);
 
-    Ok(build_reactive_runtime(
+    Ok(build_reactive_runtime_with_tasks(
         state_store,
         conversation_store,
         tool_dispatcher,
+        Some(task_manager),
         &praxis_dir,
         capacity,
     )

--- a/crates/radix-core/src/spine/task_grounding_actions.rs
+++ b/crates/radix-core/src/spine/task_grounding_actions.rs
@@ -1,0 +1,176 @@
+//! Task-grounding action handler for the live reactive `.px` path.
+//!
+//! # Why this exists (pares-radix#467 — conversational task amnesia)
+//!
+//! The Rust [`ModelInvoker`](crate::spine::procedures::model_invoker::ModelInvoker)
+//! already knows how to inject a durable open-tasks block into the model prompt
+//! (via [`render_open_tasks_block`]), but that SpineProcedure is **not on the
+//! live serve path** — the shipped runtime drives the model through the reactive
+//! `.px` engine (`praxis/spine/conversation.px::build_context` →
+//! `praxis/spine/model_invoke.px::invoke_model`). So the task-grounding block
+//! never reached an inbound Telegram turn and the agent "forgot" its
+//! obligations across turns.
+//!
+//! This handler closes that gap by exposing a real `read_open_tasks_block`
+//! action that `build_context` calls. It reads the SAME durable PluresDB
+//! [`CrdtStore`] the [`TaskManager`] writes to (C-PLURES-003/004: task state
+//! lives in PluresDB, read straight from the store — no Rust-memory task
+//! state), renders the shared block, and returns it as a string the `.px`
+//! procedure prepends to the system prompt. When there are no open tasks it
+//! returns an empty string so no noise block is injected.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use pares_radix_praxis::px::executor::ExecutionError;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::px_adapter::AsyncActionHandler;
+use crate::task_manager::{render_open_tasks_block, TaskManager};
+
+/// The action name this handler owns.
+pub const READ_OPEN_TASKS_BLOCK: &str = "read_open_tasks_block";
+
+/// Returns `true` if `action` is handled by [`TaskGroundingActionHandler`].
+pub fn is_task_grounding_action(action: &str) -> bool {
+    action == READ_OPEN_TASKS_BLOCK
+}
+
+/// Reads the agent's durable open tasks from the shared PluresDB store and
+/// renders a grounding block for injection into the model system prompt.
+pub struct TaskGroundingActionHandler {
+    task_manager: Arc<TaskManager>,
+}
+
+impl TaskGroundingActionHandler {
+    /// Construct over a [`TaskManager`] backed by the shared PluresDB store.
+    pub fn new(task_manager: Arc<TaskManager>) -> Self {
+        Self { task_manager }
+    }
+}
+
+#[async_trait]
+impl AsyncActionHandler for TaskGroundingActionHandler {
+    async fn call(&self, action: &str, params: &Value) -> Result<Value, ExecutionError> {
+        if action != READ_OPEN_TASKS_BLOCK {
+            return Err(ExecutionError::ActionFailed {
+                action: action.to_string(),
+                message: "TaskGroundingActionHandler only handles read_open_tasks_block".into(),
+            });
+        }
+
+        // chat_id is optional: absent/empty falls back to global open tasks
+        // (render_open_tasks_block already unions chat-scoped + global).
+        let chat_id = params
+            .get("chat_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Optional base system prompt. When provided, we return the combined
+        // prompt (grounding block prepended) so the `.px` `build_context` step
+        // can bind a single ready-to-send `system_prompt`. When absent we return
+        // just the block (or empty string) for callers that combine themselves.
+        let base = params.get("base").and_then(|v| v.as_str());
+
+        let block = render_open_tasks_block(&self.task_manager, chat_id);
+        debug!(
+            chat_id = %chat_id,
+            has_tasks = block.is_some(),
+            with_base = base.is_some(),
+            "action: read_open_tasks_block"
+        );
+
+        let out = match (block, base) {
+            // Prepend the durable block to the base prompt (blank line between).
+            (Some(b), Some(base)) => format!("{b}\n\n{base}"),
+            (Some(b), None) => b,
+            // No open tasks: pass the base prompt through unchanged (no noise).
+            (None, Some(base)) => base.to_string(),
+            (None, None) => String::new(),
+        };
+        Ok(Value::String(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pluresdb::{CrdtStore, MemoryStorage};
+
+    fn manager() -> Arc<TaskManager> {
+        let storage: Arc<dyn pluresdb::StorageEngine> = Arc::new(MemoryStorage::default());
+        let store = CrdtStore::default().with_persistence(storage);
+        Arc::new(TaskManager::new(Arc::new(store)))
+    }
+
+    #[tokio::test]
+    async fn empty_when_no_tasks() {
+        let h = TaskGroundingActionHandler::new(manager());
+        let out = h
+            .call(READ_OPEN_TASKS_BLOCK, &serde_json::json!({"chat_id": "c1"}))
+            .await
+            .unwrap();
+        assert_eq!(out, Value::String(String::new()));
+    }
+
+    #[tokio::test]
+    async fn renders_block_for_open_task() {
+        let mgr = manager();
+        mgr.create_task("ship the 467 fix", "c1", vec![]);
+        let h = TaskGroundingActionHandler::new(Arc::clone(&mgr));
+        let out = h
+            .call(READ_OPEN_TASKS_BLOCK, &serde_json::json!({"chat_id": "c1"}))
+            .await
+            .unwrap();
+        let s = out.as_str().unwrap();
+        assert!(s.contains("ship the 467 fix"), "block missing task: {s}");
+        assert!(s.contains("open tasks/commitments"), "block missing header: {s}");
+    }
+
+    #[tokio::test]
+    async fn combines_block_with_base_prompt() {
+        let mgr = manager();
+        mgr.create_task("finish 467", "c1", vec![]);
+        let h = TaskGroundingActionHandler::new(Arc::clone(&mgr));
+        let out = h
+            .call(
+                READ_OPEN_TASKS_BLOCK,
+                &serde_json::json!({"chat_id": "c1", "base": "You are praxisbot."}),
+            )
+            .await
+            .unwrap();
+        let s = out.as_str().unwrap();
+        assert!(s.contains("finish 467"), "missing task: {s}");
+        assert!(s.contains("You are praxisbot."), "missing base prompt: {s}");
+        // Block comes first, base prompt after.
+        let task_pos = s.find("finish 467").unwrap();
+        let base_pos = s.find("You are praxisbot.").unwrap();
+        assert!(task_pos < base_pos, "grounding block must precede base prompt");
+    }
+
+    #[tokio::test]
+    async fn base_passthrough_when_no_tasks() {
+        let h = TaskGroundingActionHandler::new(manager());
+        let out = h
+            .call(
+                READ_OPEN_TASKS_BLOCK,
+                &serde_json::json!({"chat_id": "c1", "base": "BASE"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, Value::String("BASE".to_string()));
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_action() {
+        let h = TaskGroundingActionHandler::new(manager());
+        assert!(h.call("nope", &serde_json::json!({})).await.is_err());
+    }
+
+    #[test]
+    fn action_predicate() {
+        assert!(is_task_grounding_action(READ_OPEN_TASKS_BLOCK));
+        assert!(!is_task_grounding_action("read_state"));
+    }
+}

--- a/crates/radix-core/src/task_manager.rs
+++ b/crates/radix-core/src/task_manager.rs
@@ -277,6 +277,55 @@ impl TaskManager {
     }
 }
 
+/// Render a compact grounding block of the agent's persisted open tasks for the
+/// given chat. Returns `None` when there are no open tasks so callers never
+/// inject an empty/noise block.
+///
+/// Combines chat-scoped open tasks with globally-open tasks (deduped by id) so
+/// obligations survive conversation-history trimming and process restarts.
+///
+/// This is the SINGLE implementation shared by both model-invocation paths:
+/// the Rust `ModelInvoker` SpineProcedure and the live reactive `.px` path
+/// (via the `read_open_tasks_block` action). Keeping one function avoids the
+/// two-file duplication ADR-0010 warns against.
+pub fn render_open_tasks_block(manager: &TaskManager, chat_id: &str) -> Option<String> {
+    // Chat-scoped open tasks first, then any other globally-open tasks.
+    let mut tasks = manager.tasks_for_chat(chat_id, false);
+    let mut seen: std::collections::HashSet<String> =
+        tasks.iter().map(|t| t.id.clone()).collect();
+    for t in manager.open_tasks() {
+        if seen.insert(t.id.clone()) {
+            tasks.push(t);
+        }
+    }
+
+    if tasks.is_empty() {
+        return None;
+    }
+
+    // Highest priority first (priority 1 = highest), then most recent.
+    tasks.sort_by(|a, b| {
+        a.priority
+            .cmp(&b.priority)
+            .then(b.created_at.cmp(&a.created_at))
+    });
+
+    let mut block = String::from(
+        "## Your open tasks/commitments (durable, from the task store — treat as authoritative)\n",
+    );
+    for t in tasks.iter().take(25) {
+        block.push_str(&format!(
+            "- [{:?}] (p{}) {}\n",
+            t.status, t.priority, t.description
+        ));
+    }
+    block.push_str(
+        "\nThese are your actual tracked obligations regardless of chat history length. \
+        When asked what your tasks/commitments are, answer from this list.",
+    );
+    Some(block)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/radix-core/src/task_manager.rs
+++ b/crates/radix-core/src/task_manager.rs
@@ -294,6 +294,10 @@ pub fn render_open_tasks_block(manager: &TaskManager, chat_id: &str) -> Option<S
     let mut seen: std::collections::HashSet<String> =
         tasks.iter().map(|t| t.id.clone()).collect();
     for t in manager.open_tasks() {
+        // Only include truly-global tasks (no chat_id) to avoid leaking tasks across chats.
+        if t.chat_id.is_some() {
+            continue;
+        }
         if seen.insert(t.id.clone()) {
             tasks.push(t);
         }

--- a/crates/radix-core/src/task_manager.rs
+++ b/crates/radix-core/src/task_manager.rs
@@ -307,10 +307,10 @@ pub fn render_open_tasks_block(manager: &TaskManager, chat_id: &str) -> Option<S
         return None;
     }
 
-    // Highest priority first (priority 1 = highest), then most recent.
+    // Highest priority first (priority 10 = highest), then most recent.
     tasks.sort_by(|a, b| {
-        a.priority
-            .cmp(&b.priority)
+        b.priority
+            .cmp(&a.priority)
             .then(b.created_at.cmp(&a.created_at))
     });
 
@@ -318,10 +318,10 @@ pub fn render_open_tasks_block(manager: &TaskManager, chat_id: &str) -> Option<S
         "## Your open tasks/commitments (durable, from the task store — treat as authoritative)\n",
     );
     for t in tasks.iter().take(25) {
-        block.push_str(&format!(
-            "- [{:?}] (p{}) {}\n",
-            t.status, t.priority, t.description
-        ));
+        // Descriptions are user-controlled; keep them single-line and bounded.
+        let desc = t.description.lines().collect::<Vec<_>>().join(" ");
+        let desc: String = desc.chars().take(200).collect();
+        block.push_str(&format!("- [{:?}] (p{}) {}\n", t.status, t.priority, desc));
     }
     block.push_str(
         "\nThese are your actual tracked obligations regardless of chat history length. \

--- a/praxis/spine/conversation.px
+++ b/praxis/spine/conversation.px
@@ -46,12 +46,18 @@ procedure record_assistant_response(response: Message from "model_response") -> 
 
 # Build conversation context for model invocation
 procedure build_context(request: string from "model_request") -> enriched into "enriched_request":
-  given: "Assemble conversation history into an enriched model request"
+  given: "Assemble conversation history + durable open-task grounding into an enriched model request"
   pluresdb_read {key: "chat:history"} -> $history
   slice {list: $history, last: 50} -> $recent
   pluresdb_read {key: "config:system_prompt"} -> $system_prompt
+  # Durable task grounding (pares-radix#467): prepend the agent's persisted
+  # open-tasks block to the system prompt so obligations reach EVERY inbound
+  # turn, independent of trimmed history. Reads the shared PluresDB task store
+  # via the read_open_tasks_block action; returns the base prompt unchanged
+  # when there are no open tasks (no noise).
+  read_open_tasks_block {chat_id: request.chat_id, base: $system_prompt} -> $grounded_prompt
   return {
     history: $recent,
-    system_prompt: $system_prompt,
+    system_prompt: $grounded_prompt,
     source: request
   }


### PR DESCRIPTION
## Fix: durable open-tasks grounding on the live reactive `.px` serve path (#467)

### Problem
praxisbot loses in-flight task obligations across turns (e.g. a 3-task assignment vanishes on the next message → "online and responsive, what can I help?"). Root cause is **in-repo and confirmed**: `TaskRegistryTool::context_block()` and `ModelInvoker::render_open_tasks_block` are well-built but **dead on the live path** — `with_task_manager()` / `context_block()` had **zero non-test call sites**, so open-task grounding never reached an inbound turn. Live serve registers procedures via `spine/bootstrap.rs`; the task block was never wired in.

### Fix
Inject durable open-tasks grounding into the **live reactive `.px` serve path** (read from the shared PluresDB store per C-PLURES-003/004 — no Rust-memory task state):
- `crates/radix-core/src/spine/actions.rs` — `with_task_grounding(...)` (+109)
- `crates/radix-core/src/spine/task_grounding_actions.rs` — new grounding action module (+176)
- `crates/radix-core/src/spine/runtime.rs` — wire grounding into the runtime (+42)
- `crates/radix-core/src/spine/procedures/model_invoker.rs` — dedupe render path (-43)
- `crates/radix-core/src/task_manager.rs` — open-tasks read for grounding (+49)
- `praxis/spine/conversation.px` — grounding step on the inbound path

### Verification (local, at the API/logic seam — NOT via any adapter, per C-TEST-002)
- `cargo build` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- **New seam test** `spine::actions::tests::live_path_injects_open_tasks_block_into_system_prompt` ✅ — constructs the serve model-invocation path and asserts the open-tasks block is injected into the inbound-turn system prompt when tasks exist. (Independently re-run: 1 passed.)
- `task_grounding` unit tests ✅ (6 passed)
- Note: 13 pre-existing `shell_executor::tests` failures are env-sensitive and **unrelated** — `shell_executor.rs` is untouched by this diff (`git diff --name-only main HEAD` confirms).

### Scope / follow-ups (not in this PR)
- **Turn-timeout** ("this turn took too long and was stopped") is **host/gateway-side**, not this repo — `initial_response_timeout_ms` is advisory config only, never read as an abort budget. No repo change warranted.
- **Autorecall fixes** (≤5-word topic-shift suppression + last-4-message fallback) rerouted to **pares-agens** — `radix-core/src/handlers/auto_recall.rs` is orphaned/dead in this repo's build graph; the live cerebellum surface is in pares-agens. Tracked separately.
- **Periodic obligation/stale-WIP scanner** (reactive `after_store` can't detect inaction) — separate follow-up; hook point identified at `spine/chronos_watcher.rs::observe_once`.

Deploy to praxisbot (NixOS rebuild) is out of scope for this PR — handled by the maintainer.
