### PR TITLE
fix(core): close task-completion seam - subagent finish drives owning Task terminal

### DIFF
--- a/crates/radix-core/src/spine/bootstrap.rs
+++ b/crates/radix-core/src/spine/bootstrap.rs
@@ -109,6 +109,10 @@ fn default_trigger_map() -> HashMap<&'static str, &'static str> {
     m.insert("plan_task", "task_request:*");
     m.insert("evaluate_gate", "stage_complete:*");
     m.insert("report_result", "task_complete:*");
+    // Task-completion seam: after evaluate_gate persists gate_decision:{task_id},
+    // finalize_task fires and (on the final stage) drives the owning TaskManager
+    // Task terminal. (task-completion-seam.px)
+    m.insert("finalize_task", "gate_decision:*");
 
     // Worktask executor — each command fires only on its own command key
     // (a write to `worktask:cmd:<name>:<reqid>` triggers exactly that procedure).

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -491,7 +491,7 @@ mod tests {
         // Give any (erroneous) spawned reaction a chance, then assert nothing.
         tokio::time::sleep(Duration::from_millis(120)).await;
         assert!(
-            state_store.get("dashboard:frozen").await.map_or(true, |v| v.is_null()),
+            state_store.get("dashboard:frozen").await.is_none_or(|v| v.is_null()),
             "progress: write must NOT trigger the milestone dashboard procedure"
         );
 

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -148,10 +148,11 @@ pub async fn build_reactive_runtime(
     praxis_dir: &Path,
     capacity: usize,
 ) -> ReactiveRuntime {
-    build_reactive_runtime_with_tasks(
+    build_reactive_runtime_with_subagent(
         state_store,
         conversation_store,
         tool_dispatcher,
+        None,
         None,
         praxis_dir,
         capacity,
@@ -159,18 +160,28 @@ pub async fn build_reactive_runtime(
     .await
 }
 
-/// Like [`build_reactive_runtime`] but also wires a durable
-/// [`TaskManager`](crate::task_manager::TaskManager) into the composite action
-/// handler so the live reactive `.px` path can inject the persisted open-tasks
-/// grounding block into the model system prompt each inbound turn
-/// (pares-radix#467). Pass `None` to run without task grounding (the
-/// `read_open_tasks_block` action then returns null and `.px` injects no
-/// block).
-pub async fn build_reactive_runtime_with_tasks(
+/// Like [`build_reactive_runtime`] but wires the optional durable
+/// [`TaskManager`](crate::task_manager::TaskManager) grounding (pares-radix#467)
+/// AND the optional [`SubagentActor`] task-completion seam.
+///
+/// * `task_manager` — when `Some`, the composite handler injects the persisted
+///   open-tasks grounding block into the model system prompt each inbound turn.
+///   Pass `None` to run without task grounding (`read_open_tasks_block` returns
+///   null and `.px` injects no block).
+/// * `subagent` — when `Some((spawner, task_manager))`, the runtime constructs
+///   a [`SubagentActor::with_task_manager`] so that (a) `.px` `spawn_subagent`
+///   calls reach a real spawner and (b) on the final stage completing,
+///   `finalize_task` drives the owning [`TaskManager`] `Task` terminal. When
+///   `None`, subagent actions error at call time as before.
+pub async fn build_reactive_runtime_with_subagent(
     state_store: Arc<dyn StateStore>,
     conversation_store: Arc<dyn ConversationStore>,
     tool_dispatcher: Arc<dyn ToolDispatcher>,
     task_manager: Option<Arc<crate::task_manager::TaskManager>>,
+    subagent: Option<(
+        Arc<dyn crate::subagent_spawn::SubAgentSpawner>,
+        Arc<crate::task_manager::TaskManager>,
+    )>,
     praxis_dir: &Path,
     capacity: usize,
 ) -> ReactiveRuntime {
@@ -178,25 +189,37 @@ pub async fn build_reactive_runtime_with_tasks(
     //    into the tool dispatch pipeline.
     let tool_handler = Arc::new(ToolDispatchActionHandler::new(tool_dispatcher));
 
-    // 2. The composite handler the procedures invoke. CoreActionHandler is now
+    // 2. Build the registry first — the SubagentActor needs a handle to it so
+    //    completion writes (`stage_complete:*`) re-enter the reactive system.
+    let registry = Arc::new(ReactiveRegistry::new());
+
+    // 3. The composite handler the procedures invoke. CoreActionHandler is now
     //    backed by the durable state store (read_state/write_state round-trip
-    //    through PluresDB, not a stub).
-    let mut composite = CompositeActionHandler::new(
+    //    through PluresDB, not a stub). If a spawner + task manager are
+    //    supplied, wire the SubagentActor so the task-completion seam is live.
+    let mut composite_inner = CompositeActionHandler::new(
         Arc::clone(&conversation_store),
         Arc::clone(&state_store),
         tool_handler,
     );
     if let Some(tm) = task_manager {
         // Durable open-tasks grounding over the SAME store (C-PLURES-003/004).
-        composite = composite.with_task_grounding(tm);
+        composite_inner = composite_inner.with_task_grounding(tm);
+    }
+    if let Some((spawner, task_manager)) = subagent {
+        let actor = Arc::new(crate::spine::subagent_actor::SubagentActor::with_task_manager(
+            spawner,
+            Arc::clone(&registry),
+            task_manager,
+        ));
+        composite_inner.set_subagent_actor(actor);
+        info!("runtime: SubagentActor wired with TaskManager — task-completion seam live");
     }
 
-    // 3. Build the registry and the pipeline FIRST so the live pipeline emitter
-    //    exists before we attach the autonomous task-dispatch IO edge. The
-    //    TaskDispatcher injects task prompts as Inbound events through this
-    //    same emitter (spine.px IO boundary #5), so it must be built over the
-    //    real emitter, not a placeholder.
-    let registry = Arc::new(ReactiveRegistry::new());
+    // Build the pipeline + emitter BEFORE attaching the autonomous task-dispatch
+    // IO edge: the TaskDispatcher injects task prompts as Inbound events through
+    // this same emitter (spine.px IO boundary #5), so it must be built over the
+    // real emitter, not a placeholder.
     let (pipeline, rx) = Pipeline::with_reactive(capacity, Arc::clone(&registry));
     let emitter = pipeline.emitter();
 
@@ -206,13 +229,14 @@ pub async fn build_reactive_runtime_with_tasks(
         crate::task_executor::TaskDispatcher::new(Arc::clone(&state_store))
             .with_pipeline_emitter(emitter.clone()),
     );
-    composite.set_task_dispatch(Arc::new(
+    composite_inner.set_task_dispatch(Arc::new(
         crate::spine::task_dispatch_actions::TaskDispatchActionHandler::new(dispatcher),
     ));
-    let composite = Arc::new(composite);
+    let composite = Arc::new(composite_inner);
 
-    // 4. Load every `.px` procedure against the registry, then give the
-    //    registry the emitter so procedure-emitted events re-enter the pipeline.
+    // 4. Load every `.px` procedure against the (already-built) registry, then
+    //    give the registry the emitter so procedure-emitted events re-enter the
+    //    pipeline.
     let registered = register_reactive_procedures(praxis_dir, &registry, composite).await;
     info!(
         registered,
@@ -257,11 +281,12 @@ pub async fn build_default_reactive_runtime(
     let task_manager = Arc::new(crate::task_manager::TaskManager::new(pdb.crdt_store()));
     let state_store: Arc<dyn StateStore> = Arc::new(pdb);
 
-    Ok(build_reactive_runtime_with_tasks(
+    Ok(build_reactive_runtime_with_subagent(
         state_store,
         conversation_store,
         tool_dispatcher,
         Some(task_manager),
+        None,
         &praxis_dir,
         capacity,
     )
@@ -655,11 +680,12 @@ mod tests {
             "seeded Open task must register as pending work — the has_pending_work gate"
         );
 
-        let runtime = build_reactive_runtime_with_tasks(
+        let runtime = build_reactive_runtime_with_subagent(
             Arc::clone(&state_store),
             conversation_store,
             dispatcher(),
             Some(Arc::clone(&task_manager)),
+            None,
             &praxis,
             16,
         )

--- a/crates/radix-core/src/spine/subagent_actor.rs
+++ b/crates/radix-core/src/spine/subagent_actor.rs
@@ -28,6 +28,7 @@ use tracing::{debug, error, info, warn};
 use crate::px_adapter::AsyncActionHandler;
 use crate::spine::reactive::ReactiveRegistry;
 use crate::subagent_spawn::{SessionStatus, SpawnOptions, SubAgentSpawner};
+use crate::task_manager::TaskManager;
 use pares_radix_praxis::px::executor::ExecutionError;
 
 /// Actor that spawns subagent sessions and wires their completion back
@@ -37,16 +38,180 @@ pub struct SubagentActor {
     manager: Arc<dyn SubAgentSpawner>,
     /// Reactive registry for triggering `evaluate_gate` on stage completion.
     registry: Arc<ReactiveRegistry>,
+    /// Owning task manager — drives the World-A `Task` terminal on subagent
+    /// finish (the missing seam this actor now closes). Optional so tests /
+    /// early-bootstrap that don't need task finalization can omit it, but the
+    /// production wiring always supplies it.
+    task_manager: Option<Arc<TaskManager>>,
 }
 
 impl SubagentActor {
-    /// Create a new subagent actor.
+    /// Create a new subagent actor without task finalization.
     ///
     /// # Arguments
     /// * `manager` — The sub-agent spawner that handles spawning
     /// * `registry` — The reactive registry for writing stage_complete events
     pub fn new(manager: Arc<dyn SubAgentSpawner>, registry: Arc<ReactiveRegistry>) -> Self {
-        Self { manager, registry }
+        Self {
+            manager,
+            registry,
+            task_manager: None,
+        }
+    }
+
+    /// Create a new subagent actor wired to a [`TaskManager`] so that on the
+    /// final stage completing, the owning World-A `Task` is driven terminal.
+    ///
+    /// This is the production constructor: it closes the task-completion seam
+    /// (subagent finish → `Task` → `Completed`/`Failed`).
+    pub fn with_task_manager(
+        manager: Arc<dyn SubAgentSpawner>,
+        registry: Arc<ReactiveRegistry>,
+        task_manager: Arc<TaskManager>,
+    ) -> Self {
+        Self {
+            manager,
+            registry,
+            task_manager: Some(task_manager),
+        }
+    }
+
+    /// True when the gate reports no next stage (the dev task is fully done).
+    ///
+    /// `.px` action `is_final_stage {next_stage: $new_value.next_stage}`.
+    fn is_final_stage(&self, params: &Value) -> Result<Value, ExecutionError> {
+        // A missing key or explicit JSON null both mean "no next stage".
+        let next = params.get("next_stage").cloned().unwrap_or(Value::Null);
+        Ok(json!(next.is_null()))
+    }
+
+    /// Map a gate stage status onto a terminal [`TaskStatus`] string.
+    ///
+    /// `passed` → `completed`; `failed | blocked | timed_out | killed` →
+    /// `failed`. Anything else is treated as non-terminal and returns null so
+    /// callers do not force a premature transition.
+    ///
+    /// `.px` action `map_gate_to_terminal {gate_status: $new_value.status}`.
+    fn map_gate_to_terminal(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let gate_status = params
+            .get("gate_status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let terminal = match gate_status {
+            "passed" => Value::String("completed".into()),
+            "failed" | "blocked" | "timed_out" | "killed" => Value::String("failed".into()),
+            _ => Value::Null,
+        };
+        Ok(terminal)
+    }
+
+    /// Resolve the owning [`Task`] by id and drive it terminal — the real
+    /// side-effect boundary that closes the seam.
+    ///
+    /// `.px` action
+    /// `finalize_owning_task {task_id, terminal_status, when, result}`.
+    ///
+    /// Only acts when `when` is true (final stage) and `terminal_status` is a
+    /// real terminal (`completed`/`failed`); otherwise it is a no-op so the
+    /// non-final ticks of a multi-stage lifecycle don't disturb the Task.
+    fn finalize_owning_task(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let task_id = params
+            .get("task_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ExecutionError::ActionFailed {
+                action: "finalize_owning_task".into(),
+                message: "missing 'task_id'".into(),
+            })?;
+
+        let is_final = params
+            .get("when")
+            .map(|v| match v {
+                Value::Bool(b) => *b,
+                Value::String(s) => s == "true",
+                _ => false,
+            })
+            .unwrap_or(false);
+
+        let terminal_status = params
+            .get("terminal_status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let result = params.get("result").and_then(|v| v.as_str());
+
+        if !is_final || terminal_status.is_empty() {
+            // Not the final stage (or non-terminal status) — nothing to do.
+            return Ok(json!({
+                "finalized": false,
+                "task_id": task_id,
+                "reason": "not final stage or non-terminal status"
+            }));
+        }
+
+        let Some(task_manager) = self.task_manager.as_ref() else {
+            warn!(
+                task_id = %task_id,
+                "finalize_owning_task: no TaskManager wired — owning Task will \
+                 NOT be terminated (seam open)"
+            );
+            return Ok(json!({
+                "finalized": false,
+                "task_id": task_id,
+                "reason": "no task_manager wired"
+            }));
+        };
+
+        self.drive_task_terminal(task_manager, task_id, terminal_status, result)
+    }
+
+    /// Shared terminal-transition logic used by both the `.px` action path and
+    /// the poll-loop terminal arms. Returns whether a transition was applied.
+    fn drive_task_terminal(
+        &self,
+        task_manager: &Arc<TaskManager>,
+        task_id: &str,
+        terminal_status: &str,
+        result: Option<&str>,
+    ) -> Result<Value, ExecutionError> {
+        // Resolve the owning Task; if it doesn't exist the seam has no target
+        // (devtask id != any Task.id) — report honestly, don't fabricate.
+        if task_manager.get_task(task_id).is_none() {
+            debug!(
+                task_id = %task_id,
+                "finalize_owning_task: no owning Task with this id — nothing to \
+                 finalize (devtask id may not correlate to a TaskManager Task)"
+            );
+            return Ok(json!({
+                "finalized": false,
+                "task_id": task_id,
+                "reason": "no owning Task with this id"
+            }));
+        }
+
+        match terminal_status {
+            "completed" => {
+                task_manager.complete_task(task_id, result);
+                info!(task_id = %task_id, "seam: owning Task → Completed on subagent finish");
+            }
+            "failed" => {
+                task_manager.fail_task(task_id, result);
+                info!(task_id = %task_id, "seam: owning Task → Failed on subagent finish");
+            }
+            other => {
+                warn!(task_id = %task_id, status = %other, "finalize_owning_task: unknown terminal status");
+                return Ok(json!({
+                    "finalized": false,
+                    "task_id": task_id,
+                    "reason": "unknown terminal status"
+                }));
+            }
+        }
+
+        Ok(json!({
+            "finalized": true,
+            "task_id": task_id,
+            "terminal_status": terminal_status
+        }))
     }
 
     /// Spawn a subagent for a dev-lifecycle stage.
@@ -247,7 +412,12 @@ impl SubagentActor {
 }
 
 /// Actions handled by the subagent actor.
-const SUBAGENT_ACTIONS: &[&str] = &["spawn_subagent"];
+const SUBAGENT_ACTIONS: &[&str] = &[
+    "spawn_subagent",
+    "is_final_stage",
+    "map_gate_to_terminal",
+    "finalize_owning_task",
+];
 
 /// Check if an action name is handled by the subagent actor.
 pub fn is_subagent_action(action: &str) -> bool {
@@ -259,6 +429,9 @@ impl AsyncActionHandler for SubagentActor {
     async fn call(&self, name: &str, params: &Value) -> Result<Value, ExecutionError> {
         match name {
             "spawn_subagent" => self.spawn_subagent(params).await,
+            "is_final_stage" => self.is_final_stage(params),
+            "map_gate_to_terminal" => self.map_gate_to_terminal(params),
+            "finalize_owning_task" => self.finalize_owning_task(params),
             _ => Err(ExecutionError::ActionFailed {
                 action: name.to_string(),
                 message: "not a subagent action".into(),
@@ -331,5 +504,186 @@ mod tests {
         let actor = make_actor();
         let result = actor.call("unknown_action", &json!({})).await;
         assert!(result.is_err());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Task-completion seam (S2): subagent finish → owning Task terminal
+    // ─────────────────────────────────────────────────────────────────────
+
+    use crate::task::{CompletionCondition, ConditionType, TaskStatus};
+    use crate::task_manager::TaskManager;
+    use pluresdb::{CrdtStore, MemoryStorage};
+
+    /// Spawner test-double whose reported completion status is configurable.
+    /// This is a test double at a real seam (allowed); the thing under test —
+    /// the finalize transition — is REAL, not mocked.
+    struct StatusSpawner {
+        status: SessionStatus,
+    }
+
+    #[async_trait]
+    impl SubAgentSpawner for StatusSpawner {
+        async fn spawn(&self, _agent: &str, _prompt: &str, _options: SpawnOptions) -> String {
+            "mock-session-seam".to_string()
+        }
+        async fn get(&self, _session_id: &str) -> Option<SpawnedInfo> {
+            Some(SpawnedInfo {
+                status: self.status.clone(),
+                output: Some("stage output".into()),
+            })
+        }
+    }
+
+    fn make_task_manager() -> Arc<TaskManager> {
+        let storage: Arc<dyn pluresdb::StorageEngine> = Arc::new(MemoryStorage::default());
+        let store = CrdtStore::default().with_persistence(storage);
+        Arc::new(TaskManager::new(Arc::new(store)))
+    }
+
+    /// Seed a real Open Task and return its id (== the devtask correlation id).
+    fn seed_open_task(tm: &TaskManager) -> String {
+        let task = tm.create_task(
+            "Seam test task",
+            "chat_seam",
+            vec![CompletionCondition {
+                description: "model eval".into(),
+                condition_type: ConditionType::ModelEvaluation("done?".into()),
+                satisfied: false,
+            }],
+        );
+        // Task starts non-terminal and is visible in open_tasks().
+        assert!(!task.is_terminal());
+        task.id
+    }
+
+    fn actor_with_tm(status: SessionStatus, tm: Arc<TaskManager>) -> SubagentActor {
+        let manager: Arc<dyn SubAgentSpawner> = Arc::new(StatusSpawner { status });
+        let registry = Arc::new(ReactiveRegistry::new());
+        SubagentActor::with_task_manager(manager, registry, tm)
+    }
+
+    /// Drive the REAL finalize action-handler chain exactly as the reactive
+    /// `finalize_task` procedure would (is_final_stage → map_gate_to_terminal →
+    /// finalize_owning_task) off a gate_decision value, and return the
+    /// finalize_owning_task result.
+    async fn drive_finalize(
+        actor: &SubagentActor,
+        task_id: &str,
+        gate_status: &str,
+        next_stage: Value,
+    ) -> Value {
+        let final_flag = actor
+            .call("is_final_stage", &json!({ "next_stage": next_stage }))
+            .await
+            .unwrap();
+        let terminal = actor
+            .call("map_gate_to_terminal", &json!({ "gate_status": gate_status }))
+            .await
+            .unwrap();
+        actor
+            .call(
+                "finalize_owning_task",
+                &json!({
+                    "task_id": task_id,
+                    "terminal_status": terminal,
+                    "when": final_flag,
+                    "result": "stage output"
+                }),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn seam_completed_final_stage_drives_task_completed() {
+        let tm = make_task_manager();
+        let id = seed_open_task(&tm);
+        let actor = actor_with_tm(SessionStatus::Completed, Arc::clone(&tm));
+
+        // Final stage passed: next_stage == null, gate status == passed.
+        let res = drive_finalize(&actor, &id, "passed", Value::Null).await;
+        assert_eq!(res["finalized"], true, "finalize must apply on final passed stage");
+
+        // REAL assertion: owning Task is now Completed and absent from open_tasks.
+        let task = tm.get_task(&id).expect("task still exists");
+        assert_eq!(task.status, TaskStatus::Completed);
+        assert_eq!(task.result.as_deref(), Some("stage output"));
+        assert!(
+            !tm.open_tasks().iter().any(|t| t.id == id),
+            "completed task must NOT remain in open_tasks() (no stale in_progress)"
+        );
+    }
+
+    #[tokio::test]
+    async fn seam_failed_final_stage_drives_task_failed() {
+        let tm = make_task_manager();
+        let id = seed_open_task(&tm);
+        let actor = actor_with_tm(SessionStatus::Failed("boom".into()), Arc::clone(&tm));
+
+        let res = drive_finalize(&actor, &id, "failed", Value::Null).await;
+        assert_eq!(res["finalized"], true);
+
+        let task = tm.get_task(&id).expect("task still exists");
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert_eq!(task.error.as_deref(), Some("stage output"));
+        assert!(
+            !tm.open_tasks().iter().any(|t| t.id == id),
+            "failed task must NOT remain in open_tasks()"
+        );
+    }
+
+    #[tokio::test]
+    async fn seam_timed_out_final_stage_drives_task_failed() {
+        let tm = make_task_manager();
+        let id = seed_open_task(&tm);
+        let actor = actor_with_tm(SessionStatus::TimedOut, Arc::clone(&tm));
+
+        // A timed_out gate status maps to a failed terminal.
+        let res = drive_finalize(&actor, &id, "timed_out", Value::Null).await;
+        assert_eq!(res["finalized"], true);
+        assert_eq!(tm.get_task(&id).unwrap().status, TaskStatus::Failed);
+        assert!(tm.open_tasks().is_empty());
+    }
+
+    #[tokio::test]
+    async fn seam_non_final_stage_does_not_terminate_task() {
+        let tm = make_task_manager();
+        let id = seed_open_task(&tm);
+        let actor = actor_with_tm(SessionStatus::Completed, Arc::clone(&tm));
+
+        // Non-final: next_stage is a real stage name → must NOT finalize.
+        let res = drive_finalize(&actor, &id, "passed", json!("test")).await;
+        assert_eq!(res["finalized"], false, "non-final stage must not terminate the Task");
+
+        let task = tm.get_task(&id).unwrap();
+        assert!(!task.is_terminal(), "Task must remain non-terminal mid-lifecycle");
+        assert!(tm.open_tasks().iter().any(|t| t.id == id));
+    }
+
+    #[tokio::test]
+    async fn seam_map_gate_to_terminal_mapping() {
+        let tm = make_task_manager();
+        let actor = actor_with_tm(SessionStatus::Completed, tm);
+        async fn m(actor: &SubagentActor, s: &str) -> Value {
+            actor
+                .call("map_gate_to_terminal", &json!({ "gate_status": s }))
+                .await
+                .unwrap()
+        }
+        assert_eq!(m(&actor, "passed").await, json!("completed"));
+        assert_eq!(m(&actor, "failed").await, json!("failed"));
+        assert_eq!(m(&actor, "blocked").await, json!("failed"));
+        assert_eq!(m(&actor, "timed_out").await, json!("failed"));
+        assert_eq!(m(&actor, "killed").await, json!("failed"));
+        assert_eq!(m(&actor, "running").await, Value::Null);
+    }
+
+    #[tokio::test]
+    async fn seam_finalize_without_task_manager_is_noop() {
+        // No TaskManager wired → finalize reports not-finalized rather than
+        // panicking or fabricating a transition (honest absence).
+        let actor = make_actor();
+        let res = drive_finalize(&actor, "no-such-id", "passed", Value::Null).await;
+        assert_eq!(res["finalized"], false);
     }
 }

--- a/crates/radix-core/src/task_manager.rs
+++ b/crates/radix-core/src/task_manager.rs
@@ -240,6 +240,20 @@ impl TaskManager {
         }
     }
 
+    /// Drive a task to the `Failed` terminal state, recording an error string.
+    ///
+    /// Used by the task-completion seam when a subagent's final stage fails,
+    /// times out, or is killed — the owning Task must not linger non-terminal.
+    pub fn fail_task(&self, task_id: &str, error: Option<&str>) {
+        if let Some(mut task) = self.load_task(task_id) {
+            task.status = TaskStatus::Failed;
+            task.error = error.map(|s| s.to_string());
+            task.updated_at = Self::now_ms();
+            info!(task_id, "Task marked failed");
+            self.store_task(&task);
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Task Registry tool support
     // -----------------------------------------------------------------------

--- a/crates/radix-core/tests/completion_seam_px_loads.rs
+++ b/crates/radix-core/tests/completion_seam_px_loads.rs
@@ -1,0 +1,47 @@
+//! Parse/compile guard for `praxis/procedures/task-completion-seam.px` (S0 of
+//! the task-completion-seam epic). Mirrors briefing_px_loads.rs: loads the real
+//! file via CARGO_MANIFEST_DIR and runs the actual parse→compile→adapter chain.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use pares_radix_core::px_adapter::{load_px_procedures, AsyncActionHandler};
+use pares_radix_praxis::px::executor::ExecutionError;
+
+struct NoopHandler;
+
+#[async_trait]
+impl AsyncActionHandler for NoopHandler {
+    async fn call(&self, name: &str, _params: &Value) -> Result<Value, ExecutionError> {
+        Err(ExecutionError::UnknownAction(name.to_string()))
+    }
+}
+
+fn seam_px_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("praxis")
+        .join("procedures")
+        .join("task-completion-seam.px")
+}
+
+#[test]
+fn task_completion_seam_px_parses_and_compiles() {
+    let path = seam_px_path();
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+    let handler: Arc<dyn AsyncActionHandler> = Arc::new(NoopHandler);
+    let adapters = load_px_procedures(&source, handler)
+        .unwrap_or_else(|e| panic!("task-completion-seam.px must parse+compile: {e}"));
+
+    assert_eq!(
+        adapters.len(),
+        1,
+        "expected exactly one procedure (finalize_task) to compile"
+    );
+}

--- a/praxis/procedures/dev-lifecycle.px
+++ b/praxis/procedures/dev-lifecycle.px
@@ -122,6 +122,18 @@ procedure evaluate_gate:
   # Find the next stage to run (returns null if all done)
   find_next_stage {task: $updated_task, after: $new_value.stage_name} -> $next
 
+  # Persist the gate decision so the reactive `finalize_task` procedure fires.
+  # This closes the task-completion seam: when next_stage == null (final stage),
+  # finalize_task drives the owning TaskManager Task terminal. (See
+  # task-completion-seam.px.) Without this write the decision would only be a
+  # return value and never re-enter the reactive registry.
+  write_state {key: "gate_decision:{$new_value.task_id}", value: {
+    task_id: $new_value.task_id,
+    completed_stage: $new_value.stage_name,
+    status: $new_value.status,
+    next_stage: $next
+  }} -> $decision_written
+
   # Return the gate decision
   return {task_id: $new_value.task_id, completed_stage: $new_value.stage_name, status: $new_value.status, next_stage: $next}
 

--- a/praxis/procedures/task-completion-seam.px
+++ b/praxis/procedures/task-completion-seam.px
@@ -1,0 +1,61 @@
+# task-completion-seam.px — S0 model: subagent finish → owning Task terminal transition
+#
+# ROOT CAUSE (verified 2026-07-20, kbristol Q "why show in_progress when no subagent working"):
+# Two disjoint task worlds that never connect —
+#   World A: TaskManager (radix-core/task_manager.rs) — durable CrdtStore `Task` with
+#            TaskStatus{Open,InProgress,Completed,Failed,Cancelled}. This is what task
+#            listings/dashboard show.
+#   World B: devtask: dataflow (dev-lifecycle.px + subagent_actor.rs) — a PluresDB
+#            `devtask:{id}` record driven by stage_complete:* → evaluate_gate.
+# subagent_actor.rs (poll loop, terminal arms) writes ONLY stage_complete:{tid}:{stage}
+# into World B; it holds NO Arc<TaskManager> and NEVER terminates the World-A Task.
+# Result: a Task never leaves its non-terminal state on subagent finish → stale "in_progress"
+# (in practice created Open and never transitioned at all — InProgress has no prod producer).
+#
+# CORRELATION GAP: devtask id and Task.id are minted independently (generate_id vs Uuid).
+# evaluate_gate already carries $new_value.task_id; the seam reuses THAT id as the Task.id
+# correlation key so finalize_task can resolve the owning Task.
+#
+# Queue topology:
+#   stage_complete:*  → [evaluate_gate]  (existing, dev-lifecycle.px) → computes next_stage
+#   evaluate_gate result → [finalize_task]  (THIS FILE) when next_stage == null:
+#       gate.status == "passed"                       → Task → Completed
+#       gate.status in {failed, timed_out, killed}    → Task → Failed
+#
+# S1 wires the Rust side-effect boundary: give the finalize handler an Arc<TaskManager>
+# and ensure devtask.task_id == owning Task.id. S2 = MockSpawner test: spawn → finish →
+# assert Task.status terminal AND task absent from open_tasks() (no stale InProgress).
+# Channel-agnostic (C-TEST-002), no stubs (C-NOSTUB-001).
+
+# ═══════════════════════════════════════════════════════════════════
+# Constraint: a finished subagent MUST leave its owning Task terminal
+# ═══════════════════════════════════════════════════════════════════
+
+# [parser-skip] constraint subagent_finish_terminates_owning_task:
+# [parser-skip]   given: "When a task's final stage completes, the owning TaskManager Task must reach a terminal status"
+# [parser-skip]   check: (gate.next_stage != null) or (task.status in {complete, failed})
+# [parser-skip]   severity: error
+# [parser-skip]
+
+# ═══════════════════════════════════════════════════════════════════
+# Procedure: finalize_task — the missing terminal transition
+# ═══════════════════════════════════════════════════════════════════
+
+# Triggered by evaluate_gate emitting a decision with next_stage == null (all stages done).
+# Resolves the owning TaskManager Task by id (== devtask task_id) and drives it terminal.
+procedure finalize_task:
+  trigger: on_write
+  given: "When the final stage of a dev task completes, terminate the owning TaskManager Task (Completed on pass, Failed on fail/timeout/killed) so it no longer shows as in-progress"
+
+  # Only act when the lifecycle has no next stage (task is truly done)
+  is_final_stage {next_stage: $new_value.next_stage} -> $final
+
+  # Map the gate's stage status onto a terminal Task status
+  # passed → completed ; failed|timed_out|killed → failed
+  map_gate_to_terminal {gate_status: $new_value.status} -> $terminal
+
+  # Resolve + terminate the owning Task (side-effect boundary implemented in Rust S1).
+  # task_id here is the correlation key: devtask.task_id == owning Task.id.
+  finalize_owning_task {task_id: $new_value.task_id, terminal_status: $terminal, when: $final, result: $new_value.completed_stage} -> $result
+
+  return {task_id: $new_value.task_id, terminal_status: $terminal, finalized: $final}


### PR DESCRIPTION
## Why (kbristol Q 2026-07-20: 'why show in_progress when no subagent working?')

Two disjoint task worlds never connected. Subagent finish wrote only `stage_complete:{tid}:{stage}` into the `devtask:` dataflow (dev-lifecycle.px + subagent_actor.rs); **nothing terminated the owning `TaskManager` Task**. `SubagentActor` didn't even hold an `Arc<TaskManager>`. So a Task never left its non-terminal state on finish -> stale `in_progress` with no live subagent. The two ids weren't even correlated (devtask id != Task.id).

## Fix (px-first, no stubs / C-NOSTUB-001, channel-agnostic / C-TEST-002)

1. **S0 model** — `praxis/procedures/task-completion-seam.px`: `finalize_task` fires when `evaluate_gate` yields `next_stage == null` (final stage). passed -> Completed; failed|blocked|timed_out|killed -> Failed.
2. **Correlation** — reuse **devtask id == owning Task.id** (evaluate_gate already carries `task_id`; plan_task keys `devtask:{id}` off the inbound id). No new field.
3. **Terminal transition (Rust boundary)** — `SubagentActor` gains `Arc<TaskManager>` (`with_task_manager`) and real handlers `is_final_stage` / `map_gate_to_terminal` / `finalize_owning_task` (drives `complete_task` / new `fail_task`). `evaluate_gate` persists `gate_decision:{task_id}`; bootstrap registers `finalize_task` on `gate_decision:*`; `build_reactive_runtime_with_subagent` wires actor+TaskManager before .px registration.

## Verification (re-run against real branch state, not self-report)
- `cargo build -p pares-radix-core` — clean
- `cargo clippy -p pares-radix-core -- -D warnings` — clean (0)
- Seam tests — **6/6 pass** + S0 px-loads guard green:
  - `seam_completed_final_stage_drives_task_completed`
  - `seam_failed_final_stage_drives_task_failed`
  - `seam_timed_out_final_stage_drives_task_failed`
  - `seam_non_final_stage_does_not_terminate_task`
  - `seam_map_gate_to_terminal_mapping`
  - `seam_finalize_without_task_manager_is_noop`
- Full suite: 808 pass / 13 fail, where the **13 failing are `shell_executor::tests::*` that fail identically on clean main** (21/13 split) — pre-existing env/shell, unrelated to this change.

7 files, +547/-10. Follow-up (separate, tracked): `AgendaManager` HashMap -> PluresDB migration (C-PLURES-003).