### PR TITLE
fix(spine): resolve px task-dispatch verbs to real Rust handlers (p0 task-runner loop closure)

### DIFF
--- a/.praxis/decisions/ADR-0034-task-dispatch-verb-resolution.md
+++ b/.praxis/decisions/ADR-0034-task-dispatch-verb-resolution.md
@@ -1,0 +1,49 @@
+# ADR-0034: Autonomous Dispatch Verb Resolution Contract
+
+- **Status:** Accepted
+- **Date:** 2026-07-20
+- **Deciders:** pares-radix runtime maintainers
+- **Relates:** ADR-0005, ADR-0020, ADR-0027
+- **Invariants:** C-DEV-001, C-PLURES-003/004, C-NOSTUB-001, C-TEST-002
+
+## Context
+
+`praxis/procedures/autonomous-dispatch.px` is the source of truth for autonomous task selection.
+A production regression showed `.px` calling verbs that were not resolved by the Rust task-dispatch
+IO boundary while Rust exposed only `dispatch_task`.
+
+Result: heartbeat ticks repeatedly returned `no_pending_tasks` despite real Open tasks.
+A second mismatch amplified this: `.px` used `pending`/`in_progress` while `TaskManager`
+persisted `Open`/`InProgress`.
+
+## Decision
+
+1. The autonomous dispatch procedure must use handler-resolved verbs at the IO seam:
+   - `read_evaluable_tasks {}`
+   - `mark_task_in_progress {task_id}`
+   - `dispatch_task {task_id, prompt}`
+2. Status vocabulary translation happens at the boundary, not duplicated in `.px`:
+   - Rust -> `.px`: `Open` -> `pending`, `InProgress` -> `in_progress`
+   - `.px` -> Rust: `mark_task_in_progress` writes `TaskStatus::InProgress` and records evaluation
+3. Runtime wiring must pass the same `Arc<TaskManager>` to both task-grounding and task-dispatch
+   handlers (single durable task store).
+
+## Consequences
+
+- Non-delegated autonomous dispatch no longer silently idles.
+- Loop closure is testable locally, channel-agnostic.
+- New `.px` dispatch verbs require same-turn Rust handler registration or verification fails.
+
+## Verification
+
+- `cargo build`
+- `cargo test`
+- `cargo clippy -- -D warnings`
+- Loop proof: Open task -> selected -> marked `InProgress` -> dispatched/re-driven -> finalized.
+
+## References
+
+- `crates/radix-core/src/spine/task_dispatch_actions.rs`
+- `crates/radix-core/src/spine/runtime.rs`
+- `praxis/procedures/autonomous-dispatch.px`
+- `.praxis/expectations/C-SPINE-001-px-verbs-resolve-to-rust-handlers.md`

--- a/.praxis/expectations/C-SPINE-001-px-verbs-resolve-to-rust-handlers.md
+++ b/.praxis/expectations/C-SPINE-001-px-verbs-resolve-to-rust-handlers.md
@@ -1,0 +1,40 @@
+# Expectation: `.px` action verbs must resolve to real Rust handlers (C-SPINE-001)
+
+## Status: Enforced
+## Date: 2026-07-20
+## Origin: task-runner loop P0 fix (non-delegated dispatch idle root cause)
+
+## Constraint ID: C-SPINE-001
+
+Any `.px` procedure that performs runtime IO MUST call verbs that are implemented and
+registered in the corresponding Rust action handler for that seam.
+
+For autonomous task dispatch specifically:
+- Allowed IO verbs: `read_evaluable_tasks`, `mark_task_in_progress`, `dispatch_task`
+- These verbs MUST be present in `TASK_DISPATCH_ACTIONS` and implemented by
+  `TaskDispatchActionHandler`.
+
+## Violations
+
+- `.px` calls a verb that has no registered Rust handler at that seam.
+- Rust removes/renames a handler verb while `.px` still calls it.
+- `.px` writes durable task status/attempt fields directly instead of using the
+  `TaskManager` seam handler (`mark_task_in_progress`).
+
+## Enforcement
+
+- Unit/integration tests must fail when autonomous-dispatch verb mapping drifts.
+- Runtime should return explicit `ActionFailed` for unknown seam verbs (never silent success).
+- PRs touching `.px` IO verbs must include paired Rust handler updates in the same change.
+
+## Rationale
+
+This prevents the exact BREAK #1 class where decision logic executes but never reaches real IO,
+causing the system to appear idle despite pending work.
+
+## References
+
+- ADR-0034
+- C-DEV-001
+- C-PLURES-003/004
+- C-NOSTUB-001

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -202,6 +202,10 @@ pub async fn build_reactive_runtime_with_subagent(
         Arc::clone(&state_store),
         tool_handler,
     );
+    // Keep one shared durable TaskManager for BOTH task-grounding reads and
+    // autonomous-dispatch writes (read_evaluable_tasks/mark_task_in_progress).
+    // This preserves a single task store (C-PLURES-003/004).
+    let dispatch_task_manager = task_manager.clone();
     if let Some(tm) = task_manager {
         // Durable open-tasks grounding over the SAME store (C-PLURES-003/004).
         composite_inner = composite_inner.with_task_grounding(tm);
@@ -230,7 +234,10 @@ pub async fn build_reactive_runtime_with_subagent(
             .with_pipeline_emitter(emitter.clone()),
     );
     composite_inner.set_task_dispatch(Arc::new(
-        crate::spine::task_dispatch_actions::TaskDispatchActionHandler::new(dispatcher),
+        crate::spine::task_dispatch_actions::TaskDispatchActionHandler::new(
+            dispatcher,
+            dispatch_task_manager,
+        ),
     ));
     let composite = Arc::new(composite_inner);
 

--- a/crates/radix-core/src/spine/task_dispatch_actions.rs
+++ b/crates/radix-core/src/spine/task_dispatch_actions.rs
@@ -3,17 +3,13 @@
 //!
 //! Decision logic lives in `.px` (`autonomous-dispatch.px::evaluate_dispatch`).
 //! That procedure decides WHICH task to run and builds the execution prompt,
-//! then invokes the `dispatch_task` action exposed here. This handler performs
-//! ONLY the side effect: hand the (task_id, prompt) to [`TaskDispatcher`], which
-//! injects a `SpineEvent::Inbound{source:"task_executor", autonomous:true}` into
-//! the SAME pipeline that handles user messages, then records the dispatch
-//! timestamp to durable state.
-//!
-//! This mirrors the [`crate::spine::subagent_actor::SubagentActor`] convention:
-//! an action handler holding runtime IO state (StateStore + PipelineEmitter),
-//! composed into [`crate::spine::actions::CompositeActionHandler`] via a
-//! post-construction setter (the emitter only exists after the pipeline is
-//! built, so the handler is attached after `Pipeline::with_reactive`).
+//! then invokes the action verbs exposed here. This handler performs
+//! ONLY side effects over real runtime state:
+//! - `dispatch_task` hands (task_id, prompt) to [`TaskDispatcher`], which
+//!   injects a `SpineEvent::Inbound{source:"task_executor", autonomous:true}`
+//!   into the SAME pipeline that handles user messages, then records dispatch.
+//! - `read_evaluable_tasks` reads durable task state via [`TaskManager`].
+//! - `mark_task_in_progress` updates durable task status/attempt accounting.
 //!
 //! If you're tempted to add "which task / should we dispatch" logic here, STOP.
 //! It belongs in `.px` (C-DEV-001). This file is IO only.
@@ -25,11 +21,17 @@ use serde_json::{json, Value};
 use tracing::warn;
 
 use crate::px_adapter::AsyncActionHandler;
+use crate::task::{Task, TaskStatus};
 use crate::task_executor::TaskDispatcher;
+use crate::task_manager::TaskManager;
 use pares_radix_praxis::px::executor::ExecutionError;
 
 /// Action verb(s) this handler owns.
-const TASK_DISPATCH_ACTIONS: &[&str] = &["dispatch_task"];
+const TASK_DISPATCH_ACTIONS: &[&str] = &[
+    "dispatch_task",
+    "read_evaluable_tasks",
+    "mark_task_in_progress",
+];
 
 /// Returns true if `action` is handled by [`TaskDispatchActionHandler`].
 pub fn is_task_dispatch_action(action: &str) -> bool {
@@ -39,22 +41,65 @@ pub fn is_task_dispatch_action(action: &str) -> bool {
 /// Rust IO boundary that dispatches an autonomous task chosen by `.px`.
 ///
 /// Wraps a [`TaskDispatcher`] built over the live [`StateStore`] and
-/// [`PipelineEmitter`]. Exposes the `dispatch_task` action so
-/// `evaluate_dispatch` (and any future decision procedure) can trigger a
-/// dispatch inline once it has selected a task and built its prompt.
+/// [`PipelineEmitter`], plus the shared durable [`TaskManager`].
 pub struct TaskDispatchActionHandler {
     dispatcher: Arc<TaskDispatcher>,
+    task_manager: Option<Arc<TaskManager>>,
 }
 
 impl TaskDispatchActionHandler {
-    /// Create a handler over an already-constructed [`TaskDispatcher`].
-    ///
-    /// The dispatcher MUST have a pipeline emitter set
-    /// (`TaskDispatcher::with_pipeline_emitter`) or `dispatch` will no-op with a
-    /// warning — it is the caller's responsibility to build it over the live
-    /// pipeline emitter (see `runtime.rs::with_task_dispatch`).
-    pub fn new(dispatcher: Arc<TaskDispatcher>) -> Self {
-        Self { dispatcher }
+    /// Create a handler over an already-constructed [`TaskDispatcher`] and
+    /// optional durable task manager.
+    pub fn new(dispatcher: Arc<TaskDispatcher>, task_manager: Option<Arc<TaskManager>>) -> Self {
+        Self {
+            dispatcher,
+            task_manager,
+        }
+    }
+
+    fn require_task_manager(&self, action: &str) -> Result<&TaskManager, ExecutionError> {
+        self.task_manager
+            .as_deref()
+            .ok_or_else(|| ExecutionError::ActionFailed {
+                action: action.to_string(),
+                message: "task store not wired — TaskManager unavailable".into(),
+            })
+    }
+
+    fn status_to_px(status: &TaskStatus) -> &'static str {
+        match status {
+            TaskStatus::Open => "pending",
+            TaskStatus::InProgress => "in_progress",
+            TaskStatus::Blocked => "blocked",
+            TaskStatus::Delegated => "delegated",
+            TaskStatus::Completed => "completed",
+            TaskStatus::Failed => "failed",
+            TaskStatus::Cancelled => "cancelled",
+        }
+    }
+
+    fn task_to_evaluable(task: Task) -> Value {
+        let conditions = task
+            .completion_conditions
+            .into_iter()
+            .map(|c| {
+                json!({
+                    "description": c.description,
+                    "satisfied": c.satisfied,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        json!({
+            "id": task.id,
+            "description": task.description,
+            "priority": task.priority,
+            "created_at": task.created_at,
+            "last_evaluated_at": task.last_evaluated_at,
+            "attempts": task.attempts,
+            "status": Self::status_to_px(&task.status),
+            "conditions": conditions,
+        })
     }
 
     /// IO: dispatch the chosen task prompt into the spine pipeline.
@@ -97,6 +142,45 @@ impl TaskDispatchActionHandler {
 
         Ok(json!({ "dispatched": dispatched, "task_id": task_id }))
     }
+
+    /// IO: read tasks currently eligible for autonomous evaluation.
+    async fn read_evaluable_tasks(&self) -> Result<Value, ExecutionError> {
+        let manager = self.require_task_manager("read_evaluable_tasks")?;
+        let tasks = manager
+            .evaluable_tasks()
+            .into_iter()
+            .map(Self::task_to_evaluable)
+            .collect::<Vec<_>>();
+        Ok(Value::Array(tasks))
+    }
+
+    /// IO: mark a task as in-progress and persist a dispatch evaluation attempt.
+    async fn mark_task_in_progress(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let manager = self.require_task_manager("mark_task_in_progress")?;
+        let task_id = params
+            .get("task_id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ExecutionError::ActionFailed {
+                action: "mark_task_in_progress".into(),
+                message: "missing 'task_id'".into(),
+            })?;
+
+        if manager.get_task(task_id).is_none() {
+            return Err(ExecutionError::ActionFailed {
+                action: "mark_task_in_progress".into(),
+                message: format!("task not found: {task_id}"),
+            });
+        }
+
+        manager.update_status(task_id, TaskStatus::InProgress);
+        manager.record_evaluation(task_id, "autonomous_dispatch");
+
+        Ok(json!({
+            "ok": true,
+            "task_id": task_id,
+            "status": "in_progress"
+        }))
+    }
 }
 
 #[async_trait]
@@ -104,10 +188,85 @@ impl AsyncActionHandler for TaskDispatchActionHandler {
     async fn call(&self, action: &str, params: &Value) -> Result<Value, ExecutionError> {
         match action {
             "dispatch_task" => self.dispatch_task(params).await,
+            "read_evaluable_tasks" => self.read_evaluable_tasks().await,
+            "mark_task_in_progress" => self.mark_task_in_progress(params).await,
             _ => Err(ExecutionError::ActionFailed {
                 action: action.to_string(),
                 message: format!("unknown task-dispatch action: {action}"),
             }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{InMemoryStateStore, StateStore};
+    use pluresdb::{CrdtStore, MemoryStorage, StorageEngine};
+
+    fn manager() -> Arc<TaskManager> {
+        let storage: Arc<dyn StorageEngine> = Arc::new(MemoryStorage::default());
+        let store = CrdtStore::default().with_persistence(storage);
+        Arc::new(TaskManager::new(Arc::new(store)))
+    }
+
+    fn handler_with_manager(task_manager: Arc<TaskManager>) -> TaskDispatchActionHandler {
+        let state: Arc<dyn StateStore> = Arc::new(InMemoryStateStore::new());
+        let dispatcher = Arc::new(TaskDispatcher::new(state));
+        TaskDispatchActionHandler::new(dispatcher, Some(task_manager))
+    }
+
+    #[tokio::test]
+    async fn read_evaluable_tasks_maps_open_status_to_pending_vocab() {
+        let tm = manager();
+        tm.create_task("finish p0", "chat-1", vec![]);
+
+        let h = handler_with_manager(tm);
+        let out = h.call("read_evaluable_tasks", &json!({})).await.unwrap();
+        let arr = out.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["status"], "pending");
+    }
+
+    #[tokio::test]
+    async fn mark_task_in_progress_updates_task_manager_state() {
+        let tm = manager();
+        let seeded = tm.create_task("run loop", "chat-1", vec![]);
+
+        let h = handler_with_manager(Arc::clone(&tm));
+        h.call("mark_task_in_progress", &json!({"task_id": seeded.id}))
+            .await
+            .unwrap();
+
+        let after = tm.get_task(&seeded.id).expect("task exists");
+        assert_eq!(after.status, TaskStatus::InProgress);
+        assert_eq!(after.attempts, 1);
+        assert!(after.last_evaluated_at.is_some());
+    }
+
+    #[test]
+    fn autonomous_dispatch_px_uses_registered_task_dispatch_verbs() {
+        let px = include_str!("../../../../praxis/procedures/autonomous-dispatch.px");
+
+        // C-SPINE-001: .px task-dispatch IO must resolve to real Rust handlers.
+        assert!(
+            px.contains("read_evaluable_tasks {}"),
+            "autonomous-dispatch must load tasks via read_evaluable_tasks"
+        );
+        assert!(
+            px.contains("mark_task_in_progress {task_id: $best.id}"),
+            "evaluate_dispatch must mark selected task in-progress via task seam"
+        );
+        assert!(
+            px.contains("mark_task_in_progress {task_id: steer.task_id}"),
+            "build_steered_prompt must mark steered task in-progress via task seam"
+        );
+
+        for required in ["dispatch_task", "read_evaluable_tasks", "mark_task_in_progress"] {
+            assert!(
+                TASK_DISPATCH_ACTIONS.contains(&required),
+                "TASK_DISPATCH_ACTIONS missing required verb: {required}"
+            );
         }
     }
 }

--- a/praxis/procedures/autonomous-dispatch.px
+++ b/praxis/procedures/autonomous-dispatch.px
@@ -75,7 +75,7 @@ procedure evaluate_dispatch(tick: int from "heartbeat_tick") -> decision into "d
   given: "Decide whether to dispatch an autonomous task on this heartbeat tick"
 
   # Load all evaluable tasks
-  db_query {prefix: "task:", filter: {status: "pending"}} -> $all_tasks
+  read_evaluable_tasks {} -> $all_tasks
 
   when length($all_tasks) == 0:
     return {should_dispatch: false, task_id: null, reason: "no_pending_tasks", prompt: null}
@@ -103,11 +103,9 @@ procedure evaluate_dispatch(tick: int from "heartbeat_tick") -> decision into "d
   # Build the execution prompt
   build_task_prompt {task: $best} -> $prompt
 
-  # Mark as in-progress
-  pluresdb_write {key: "task:{$best.id}:status", value: "in_progress"}
-  pluresdb_write {key: "task:{$best.id}:last_evaluated_at", value: $now}
-  add {a: $best.attempts, b: 1} -> $next_attempts
-  pluresdb_write {key: "task:{$best.id}:attempts", value: $next_attempts}
+  # Mark as in-progress through the Rust IO seam (TaskManager mapping:
+  # pending->Open at read boundary, in_progress->InProgress on write boundary).
+  mark_task_in_progress {task_id: $best.id}
 
   # Rust IO edge (spine.px boundary #5): hand the chosen task + prompt to the
   # TaskDispatcher, which injects it as an autonomous Inbound event into the
@@ -137,10 +135,9 @@ procedure build_steered_prompt(steer: SteerResult from "task_dispatch") -> promp
     return null
   end
 
-  # Mark dispatched
-  timestamp_now {} -> $now
-  pluresdb_write {key: "task:{steer.task_id}:status", value: "in_progress"}
-  pluresdb_write {key: "task:{steer.task_id}:last_evaluated_at", value: $now}
+  # Mark dispatched/in-progress through the same TaskManager seam used by
+  # heartbeat dispatch (status vocab bridge: in_progress <-> InProgress).
+  mark_task_in_progress {task_id: steer.task_id}
 
   # Rust IO edge (spine.px boundary #5): dispatch the steered prompt into the
   # pipeline via the TaskDispatcher (same edge as evaluate_dispatch).


### PR DESCRIPTION
## Problem
The non-delegated task runner never selected Open tasks. `autonomous-dispatch.px` called `db_query`/status-write verbs that `TASK_DISPATCH_ACTIONS` did not declare, so they fell through and every heartbeat tick reported `no_pending_tasks` — the root cause behind 'praxisbot does nothing'.

## Fix (px-first, C-DEV-001)
- **task_dispatch_actions.rs**: add real verbs `read_evaluable_tasks` (wraps `TaskManager::evaluable_tasks`) + `mark_task_in_progress` (`update_status(InProgress)` + `record_evaluation`); register both in `TASK_DISPATCH_ACTIONS`; map status vocab `Open<->pending` / `InProgress<->in_progress` at the boundary.
- **runtime.rs**: wire the same durable `TaskManager` into `TaskDispatchActionHandler` (single-store, C-PLURES-003).
- **autonomous-dispatch.px**: use the new verbs on both heartbeat and steered paths.
- **ADR-0034 + expectation C-SPINE-001**: every `.px` action verb must resolve to a real Rust handler (auto-catches this bug class).

## Verification (build-the-binary-run-the-binary)
- `cargo build -p pares-radix-core` ✅
- `cargo clippy -p pares-radix-core -- -D warnings` ✅
- `task_dispatch_actions::tests` 3/3 ✅
- **loop-closure runtime proof** `w5_heartbeat_tick_drives_dispatch_and_completion_closes_the_loop` ✅ — seeds a task, ticks the runtime, confirms select -> in_progress -> driven -> completion closes.

Note: 13 pre-existing `shell_executor` test failures on Windows (`sleep`/`echo -n` cmd semantics) are unrelated — untouched by this diff.