### PR TITLE
ci(release): add concurrency guard to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         required: false
         default: false
+concurrency:
+  group: release-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
Adds a concurrency guard (cancel-in-progress: false) to the release workflow so overlapping merges/tags don't cancel a mid-publish release run. Part of org:release-trigger-autobump mechanical sweep.