### PR TITLE
docs(ADR-0035): design-dojo vendored-shim drift audit - ownership boundary + prioritized gaps (design only)

### DIFF
--- a/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
+++ b/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
@@ -1,0 +1,200 @@
+# ADR-0035: Resolving `@plures/design-dojo` Vendored-Shim Drift
+
+- **Status:** Proposed (DESIGN stage only — no bulk copy/implementation authorized by this ADR)
+- **Date:** 2026-07-23
+- **Deciders:** kbristol (strategic directive), dev-lead orchestrator
+- **Relates:** ADR-0024 §5 (design-dojo as canonical UI home), ADR-0032 (GraphView primitive),
+  ADR-0033 (px composition language)
+- **Invariants:** C-NOSTUB-001 (no stub/shim debt masquerading as done), C-TEST-001/002
+
+---
+
+## 1. Context
+
+`pares-radix` depends on `@plures/design-dojo` two ways simultaneously:
+
+1. **npm dependency** — `@plures/design-dojo-npm: npm:@plures/design-dojo@^0.17.0` (registry
+   currently tops out at published `0.17.1`).
+2. **Local vendored shim** — `packages/design-dojo/` (`workspace:*`), a **hand-maintained
+   compatibility package** whose `package.json` description literally says:
+   > "Local shim - re-exports npm @plures/design-dojo + adds missing components. Remove when npm
+   > is updated to v0.13+"
+
+The shim's `src/index.ts` re-exports most components from the npm package and then locally defines
+16 components the npm package allegedly lacked: `SettingsPanel`, `Sidebar`, `Input`, `Select`,
+`Dialog`, `DashboardGrid`, `FirstRunWizard`, `Heading`, `TextArea`, `Link`, `CodeBlock`, `Canvas2D`,
+`PluginContentArea`, `DataGrid`, `SchemaForm`, `GraphView`.
+
+Meanwhile, the **standalone `@plures/design-dojo` source repo** (`C:\Projects\design-dojo`,\nindependently versioned, currently at package.json `1.55.34`, git HEAD `4fa2153`, 2026-07-21) is\nalive, organized (`src/lib/{primitives,layout,overlays,data,surfaces,feedback,app,...}`), and has
+**361 source files** vs. the vendor shim's flat 24.
+
+### Actual divergence found (not assumed)
+
+| Vendored component | Exists in standalone repo? | Line-diff vs. standalone counterpart |
+|---|---|---|
+| SettingsPanel | ✅ `src/lib/app/SettingsPanel.svelte` | not diffed (bulk) |
+| Sidebar | ✅ `src/lib/layout/Sidebar.svelte` | **285** differing lines |
+| Input | ✅ `src/lib/primitives/Input.svelte` | **532** differing lines |
+| Select | ✅ `src/lib/primitives/Select.svelte` | not diffed (bulk) |
+| Dialog | ✅ `src/lib/overlays/Dialog.svelte` | **342** differing lines |
+| DashboardGrid | ✅ `src/lib/layout/DashboardGrid.svelte` | **223** differing lines |
+| FirstRunWizard | ✅ `src/lib/app/FirstRunWizard.svelte` | **656** differing lines |
+| Heading | ✅ `src/lib/typography/Heading.svelte` | not diffed (bulk) |
+| TextArea | ✅ `src/lib/primitives/TextArea.svelte` | not diffed (bulk) |
+| Link | ✅ `src/lib/primitives/Link.svelte` | not diffed (bulk) |
+| CodeBlock | ✅ `src/lib/primitives/CodeBlock.svelte` | not diffed (bulk) |
+| Canvas2D | ✅ `src/lib/canvas/Canvas2D.svelte` | not diffed (bulk) |
+| PluginContentArea | ✅ `src/lib/layout/PluginContentArea.svelte` | not diffed (bulk) |
+| GraphView | ✅ `src/lib/app/GraphView.svelte` | **30** differing lines (closest match — recently ported, ADR-0032) |
+| **DataGrid** | ❌ **not present upstream** | genuinely local-only (Phase B, schema-driven, built directly against `types-local.ts`) |
+| **SchemaForm** | ❌ **not present upstream** | genuinely local-only (Phase B, same origin as DataGrid) |
+
+Key findings:
+
+- **13 of 16 "missing" components now exist upstream** — the shim's founding premise ("npm doesn't
+  have these yet") is **stale**. npm registry is at `0.17.1`; the shim comment references
+  "v0.13+" as the removal trigger, which has long since passed, yet the shim was never removed.
+- **Every diffable component has drifted independently and substantially** (200–650+ line diffs),
+  not just by formatting — these are now **effectively forked implementations**, not stale copies
+  of the same code. `git log` on the vendored path shows repeated deliberate restoration commits
+  (`20acb73 fix: restore Sidebar + SettingsPanel to local shim — npm API incompatible`,
+  `0eb0734 fix: stable state — v0.17.0 npm + local Sidebar/SettingsPanel`) — i.e., the team already
+  tried removing the shim components and reverted because the **npm-published API didn't match
+  what pares-radix call sites expected**. This is real API drift, not just laziness.
+- `GraphView` is the newest addition (ADR-0032, 2026-07-11) and has the smallest diff (30 lines) —
+  evidence that when a component is added going *forward*, it can stay close to upstream if the
+  upstream repo gets the change promptly; drift accumulates only when one side changes without the
+  other.
+- `DataGrid`/`SchemaForm` are legitimately pares-radix-native primitives (schema-driven grid/form,
+  Phase B) with no upstream equivalent — these are **not drift**, they are **unpublished
+  contributions** that should flow *into* design-dojo, not be reconciled against it.
+- `types-local.ts` in the vendor package defines local-only types (`DataGridProps`, `SchemaField`,
+  etc.) that duplicate/shadow what should be part of the design-dojo public type surface once
+  DataGrid/SchemaForm are upstreamed.
+
+### Additional risk found: dual resolution path (canvas-runtime)
+
+`packages/canvas-runtime/package.json` depends on `@plures/design-dojo": "*"` **directly**,
+bypassing the vendor shim entirely, while the main app depends on the shim
+(`packages/design-dojo`, `workspace:*`). With both `@plures/design-dojo` (npm, hoisted) and
+`@plures/design-dojo-npm` present in `node_modules`, **canvas-runtime and the main app shell are
+not guaranteed to resolve the same implementation of overlapping components** (e.g. `GraphView`,
+which is confirmed byte/line-diverged between the shim and standalone repo above). This is a
+concrete correctness/consistency risk independent of the drift-cleanup plan below — it should be
+resolved *first* (either point `canvas-runtime` at the shim too, or resolve everything to
+upstream directly) so there is exactly one resolution path while the reconciliation work in §2
+proceeds. No app screen currently imports the shim-only `DataGrid`/`SchemaForm`, so today's
+blast radius for the dual-path risk is centered on the 14 overlapping components, `GraphView`
+most acutely since its divergence is already confirmed.
+
+### Cross-check against ADR-0019 (installer/packaging)
+
+ADR-0019's multiplatform installer/packaging design is entirely Rust/Tauri/CI-side (`src-tauri`,
+`release.yml`) and adds no new design-dojo consumers or requirements. The one relevant forward
+link is ROADMAP Phase 4 ("Svelte GUI parity with Svelte TUI — design-dojo terminal theme"): no
+terminal-theme components exist in either the shim or the standalone repo yet, so that item
+remains a future design-dojo epic, not something this drift cleanup unblocks or blocks.
+
+### Root cause
+There is **no enforcement** preventing a plugin/consumer repo from silently forking UI primitives:
+- No CI check diffing vendored files against the published/standalone package.
+- No ownership boundary — `packages/design-dojo/src/*.svelte` are ordinary files anyone can edit
+  in place during a pares-radix change, with no signal that they are a fork of another repo.
+- No process for promoting local-only primitives (DataGrid, SchemaForm) upstream once proven.
+- The shim's own removal criterion ("npm v0.13+") was met by `0.17.1` and nobody revisited it.
+
+## 2. Decision
+
+Adopt a three-part strategy: **stop the bleeding (ownership), reconcile (migration), then enforce
+(prevent recurrence).** This ADR authorizes DESIGN only; no bulk copy/deletion happens until this
+strategy is reviewed and a follow-up implementation ADR/PR is accepted.
+
+### 2.1 Ownership & release strategy
+- `@plures/design-dojo` (standalone repo) is the **single source of truth** for all shared UI
+  primitives (per ADR-0024 §5). `packages/design-dojo/` in pares-radix is **not** a parallel
+  product — it is a **compatibility shim only**, and must shrink to zero as fast as upstream sync
+  allows.
+- Any component that exists in both places must have **at most one authoritative source**: the
+  standalone repo. Vendored copies are transitional bridges, never permanent forks.
+- `DataGrid` and `SchemaForm` are reclassified as **upstream contributions owed**, not vendor
+  drift — they get a dedicated small PR into `C:\Projects\design-dojo` (own review, own semver\n  bump), not a copy-paste reconciliation.\n- Release cadence: design-dojo standalone repo cuts a release for every component it gains from
+  pares-radix contributions or fixes drift-discovered bugs; pares-radix bumps its
+  `@plures/design-dojo-npm` pin promptly after (target: within one sprint) rather than papering
+  over the gap with a local shim edit.
+
+### 2.2 Migration approach (for follow-up implementation PR — not this ADR)
+1. **Triage per component** (not bulk): for each of the 13 drifted components, determine whether
+   the *pares-radix* variant or the *standalone* variant is closer to "correct" per current
+   requirements — likely mixed, since some diffs are pares-radix bugfixes never upstreamed and
+   some are standalone improvements never pulled down.
+2. **Upstream first** for genuinely-local primitives: PR `DataGrid` + `SchemaForm` (with
+   `types-local.ts` types folded into the public type surface) into the standalone repo before
+   touching anything else.
+3. **Reconcile drifted components one at a time**, smallest-diff first (`GraphView` at 30 lines is
+   the trivial pilot case to prove the reconciliation workflow), each as its own small PR with its
+   own diff review and test pass — never a single mass "sync everything" commit.
+4. **Delete from the vendor shim only after** the reconciled/upstreamed version is published to npm
+   and pares-radix's pin is bumped and verified (`svelte-check`, existing route/story smoke tests)
+   against the npm version, matching the exact pattern already tried in `20acb73`/`0eb0734` but
+   this time backed by enforcement (below) so it doesn't silently re-drift.
+5. Target end state: `packages/design-dojo/` shrinks to nothing (or a thin re-export file kept only
+   if a genuine local override is still required, clearly labeled and covered by the CI check in
+   §2.3), and `pares-radix` package.json depends on `@plures/design-dojo` directly (no shim
+   indirection layer).
+
+### 2.3 Enforcement to prevent renewed drift
+- **CI drift check**: a scheduled/PR-triggered job that, for every file in `packages/design-dojo/`
+  whose basename matches a file in the standalone repo (path resolved via a manifest checked into
+  `packages/design-dojo/UPSTREAM_MAP.json` mapping vendor filename → standalone repo path), fails
+  the build if the vendored copy differs from the pinned npm-published version's corresponding
+  source and the diff isn't accompanied by a `DRIFT.md` entry explaining why (temporary override,
+  upstream PR link, expected removal date).
+- **No silent local edits**: any change to a file under `packages/design-dojo/src/*.svelte` that
+  has an upstream counterpart must be accompanied by either (a) a linked upstream PR/issue in
+  `design-dojo`, or (b) removal of the local override once upstream ships. Enforced via PR
+  template checklist + the CI check above (fails without a `DRIFT.md` entry).
+- **Shim removal criterion becomes a tracked, dated obligation**, not a comment nobody revisits:
+  each entry in `UPSTREAM_MAP.json` carries a `removeAfterNpmVersion` field; CI flags (does not
+  necessarily hard-fail, but surfaces loudly) any entry where the current npm pin already satisfies
+  `removeAfterNpmVersion` — this alone would have caught today's stale shim (target `0.13+` vs.
+  actual pin `0.17.x`).
+- **Ban new local-only primitives in the vendor package** going forward: any *new* shared UI need
+  gets built directly in the standalone `design-dojo` repo (consumed via `workspace:*`/local link
+  during co-development if needed) rather than added to `packages/design-dojo/src/*.svelte` as a
+  "temporary" addition — this is exactly how `DataGrid`/`SchemaForm` ended up stranded.
+
+## 3. Consequences
+
+**Positive** — single source of truth restored; the 200–650-line-diffed components stop silently
+diverging further; `DataGrid`/`SchemaForm` become available to every design-dojo consumer, not just
+pares-radix; CI enforcement makes "shim never gets removed" structurally harder to repeat; smallest
+diff (`GraphView`) provides a low-risk pilot for the reconciliation workflow before tackling the
+large diffs (`FirstRunWizard` at 656 lines will need the most care/dedicated review).
+
+**Costs/risks** — reconciling 13 drifted components is real work spread over multiple PRs/sprints,
+not a single sweep; some pares-radix-side fixes embedded in the drifted diffs may be lost or need
+re-discovery if not carefully triaged before reconciliation; standalone repo maintainers must accept
+and prioritize the `DataGrid`/`SchemaForm` + fix-upstreaming PRs promptly or pares-radix will be
+tempted to re-fork under deadline pressure — this ADR's enforcement mechanism only works if upstream
+turnaround is fast enough to not be a bigger friction than the shim was.
+
+## 4. Explicitly out of scope for this ADR
+- No files are copied, deleted, or modified in either repo by this ADR.
+- No `UPSTREAM_MAP.json`, CI job, or PR template is created yet — those are implementation-stage
+  deliverables of the accepted follow-up PR.
+- No component-by-component reconciliation begins until this design is reviewed and accepted.
+
+## 5. Next steps (pending review/acceptance of this ADR)
+1. Review/accept this ADR.
+2. Open implementation PR #1: `UPSTREAM_MAP.json` + CI drift-check job (enforcement scaffolding,
+   no component changes).
+3. Open upstream PR: `DataGrid` + `SchemaForm` → standalone `design-dojo` repo.
+4. Open reconciliation PR: `GraphView` (pilot, smallest diff) — prove the workflow.
+5. Sequence remaining 12 components by diff size / risk, each its own PR.
+6. Retire `packages/design-dojo/` shim once all entries are reconciled and the npm pin covers them.
+
+## 6. References
+ADR-0024 §5 (design-dojo canonical UI home, subpath consumption pattern), ADR-0032 (GraphView,
+most recent addition — smallest drift, proof that fast upstream sync prevents divergence);
+`C:\Projects\pares-radix\packages\design-dojo\package.json` (shim description, stale removal\ncriterion); `C:\Projects\design-dojo` git HEAD `4fa2153` (2026-07-21); pares-radix git history\n`20acb73`/`0eb0734` (prior attempted-then-reverted shim removal, evidence of real API drift, not
+just process laziness); C-NOSTUB-001.

--- a/docs/adr/ADR-0019-multiplatform-installer-packaging.md
+++ b/docs/adr/ADR-0019-multiplatform-installer-packaging.md
@@ -1,0 +1,198 @@
+# ADR-0019: Multiplatform Installer Packaging (Design Stage)
+
+- Status: Proposed (design only — no implementation in this change)
+- Date: 2026-07-23
+- Supersedes: none
+- Related: ROADMAP.md Phase 4 ("Multi-arch packaging"), `design/TAURI-BEST-PRACTICES.md`
+  (development-guide), `.github/workflows/release.yml`, `plures/.github` reusable
+  `release-reusable.yml`
+
+## Context
+
+pares-radix is a **svelte-Tauri** application (GUI + Svelte-TUI + svelte-ratatui + MCP,
+no traditional CLI — see `PLURES-FOUNDATION.md` → "svelte-Tauri Application Template").
+ROADMAP Phase 4 calls for "Multi-arch packaging (Linux, Windows, macOS; Android/iOS via
+Tauri where supported)". Today:
+
+- `src-tauri/` is scaffolded (`tauri.conf.json`, `capabilities/`, icons for desktop +
+  Android) and implements the frontend bridge contract (`navigate`,
+  `get_window_state`, `set_tray_menu`, `save_window_state` + events).
+- The Windows installer (NSIS + MSI) has been **built locally** but is not yet wired
+  into CI (ROADMAP "Current State").
+- `.github/workflows/release.yml` delegates all version/tag/changelog/publish logic to
+  the org-shared `plures/.github/.github/workflows/release-reusable.yml`; it carries
+  **no Tauri bundle matrix today** — no per-OS build job builds/signs/publishes
+  installers.
+- No `.deb`/`.rpm`/`.AppImage`/`.dmg`/APK artifacts exist yet anywhere in the repo or
+  workflow definitions. iOS/Android `gen/` scaffolds are not present (only icon assets).
+- `design/TAURI-BEST-PRACTICES.md` (development-guide, verified 2026-06-27 against
+  v2.tauri.app) is the authoritative source for Tauri 2 packaging mechanics already
+  evaluated for this repo; this ADR is the pares-radix-local decision record that
+  consumes it and turns it into a concrete release-pipeline plan.
+
+This is a **design-stage** ADR per the dev-lifecycle/dev-guide gates: it defines the
+target/form-factor matrix, the cross-platform shell/bundling choice with evidence, and
+the CI/release implications, and enumerates real validation paths. It intentionally
+ships **no installer artifacts, no placeholder CI jobs, and no stub code** — only the
+decision record and the acceptance criteria a follow-on implementation task must meet.
+
+## Decision drivers
+
+1. **No traditional CLI, no cross-compiled bundles.** A Tauri bundle can only be built
+   on its own host OS (Tauri's bundler shells out to platform-native tooling — NSIS/
+   WiX on Windows, `hdiutil`/codesign on macOS, `dpkg`/`rpmbuild`/`appimagetool` on
+   Linux). There is no cross-compile path for installer formats themselves (Rust
+   cross-compiles; the packaging step does not).
+2. **Evented, thin Rust core** (ADR: events-not-commands, already established). The
+   packaging decision must not require adding business logic to `src-tauri`.
+3. **Even/odd release parity law** already governs the version/publish pipeline
+   (`release-reusable.yml`); installer publishing must slot into that model
+   (stable vs prerelease update feeds), not invent a second one.
+4. **Cost/complexity gating is real**: Apple and Android signing require paid
+   developer accounts, hardware/cert infrastructure, and dedicated runners. The
+   design must explicitly gate what ships unsigned vs signed, and what is
+   PR-fast vs release-only.
+
+## Cross-platform shell choice — evaluated with evidence
+
+Three shell options were evaluated for pares-radix specifically:
+
+| Option | Verdict | Evidence |
+|---|---|---|
+| **Tauri 2** (current) | **Selected — no change** | Already the scaffolded shell (`src-tauri/`, Tauri 2 crates in `Cargo.toml`, bridge contract implemented per `TAURI-BEST-PRACTICES.md`). Uses the OS webview (WebView2/WebKitGTK/WKWebView) — no bundled Chromium, smallest binary footprint of the three, matches the "svelte-Tauri Application Template" org mandate (`PLURES-FOUNDATION.md`) that **every** new Plures app scaffolds from `svelte-tauri-template`. Supports desktop (Win/macOS/Linux) + mobile (Android/iOS) from one codebase, matching ROADMAP Phase 4 scope without a rewrite. |
+| **Electron** | Rejected | Would require replacing the entire `src-tauri` Rust core and bridge (`tauri.ts` events-not-commands contract), duplicate work already done and already an org mandate violation (svelte-tauri-template is prescribed org-wide). Bundles a full Chromium+Node runtime per install (100+ MB baseline vs Tauri's OS-webview reuse) — directly opposed to the size-optimization work already landed in `TAURI-BEST-PRACTICES.md` §2. No mobile story without a second stack (Capacitor/React Native), doubling the CI matrix. No evidence of any org repo using Electron; would be a net-new, unsupported pattern. |
+| **Native per-platform (WinUI/SwiftUI/GTK)** | Rejected | 3x the UI codebase (no shared Svelte GUI/TUI), abandons the already-built Svelte GUI + `svelte-ratatui` TUI parity goal in ROADMAP Phase 4 ("Svelte GUI parity with Svelte TUI"). No shared bridge/event model; would need bespoke IPC per platform. No mobile reuse. Highest total engineering cost of the three for a single-maintainer-scale project. |
+
+**Conclusion: keep Tauri 2.** No shell migration is in scope. The remaining design
+work is entirely the **packaging matrix and release pipeline**, not the app shell.
+
+## Target / form-factor packaging matrix
+
+| Target | Bundle format(s) | Build host | Gate | Signing | Update channel |
+|---|---|---|---|---|---|
+| Windows x64 desktop | `.exe` (NSIS) + `.msi` | `windows-latest` | PR: build unsigned; Release: signed | Authenticode via Azure Trusted Signing (preferred over hardware EV — no HSM on hosted runners) | `latest.json` (even/stable) or `latest-prerelease.json` (odd) |
+| macOS (Apple Silicon) desktop | `.app` + `.dmg` | `macos-latest` | PR: ad-hoc signed (`signingIdentity: "-"`) fast build; Release: signed+notarized | Developer ID Application cert + `codesign` + `notarytool` (secrets-present gated) | same as above |
+| macOS (Intel) desktop | `.app` + `.dmg` (`--target x86_64-apple-darwin`) | `macos-latest` (cross-arch build on Apple Silicon runner) | Release only (cost: doubles Apple build time) | Same Developer ID cert as Silicon | same as above |
+| Linux x64 desktop | `.deb` + `.AppImage` (+ `.rpm` if a fedora/rhel consumer is confirmed) | `ubuntu-22.04` pinned (oldest supported glibc/webkit2gtk — **not** `ubuntu-latest`) | PR: build unsigned; Release: build + publish | No OS-level signing concept; updater `.sig` is the integrity mechanism | same as above |
+| Linux Flatpak | `org.plures.Radix` Flatpak | `ubuntu-22.04`, separate `flatpak-builder` step *after* the `.deb`/binary is built (Flatpak is not a native `bundle.targets` value) | Release only, opt-in | Flatpak repo signing (deferred — not required for first ship) | Flatpak's own update mechanism (separate from Tauri updater) |
+| NixOS | Flake package (`packages.<system>.pares-radix`) | N/A — consumer builds/runs via `nix build`/`nix run` from the flake | Release only; validated by `nix flake check` / `nix build` in CI, not a Tauri "bundle target" | N/A (Nix store hash is the integrity mechanism) | Flake input pin, not the Tauri updater |
+| Android APK/AAB | `.apk` (sideload/testing) + `.aab` (Play Store) | `ubuntu-latest` (Gradle-driven, via `src-tauri/gen/android` which does not exist yet) | **Release/tag-only**, label-gated; not on every PR (ROADMAP + `TAURI-BEST-PRACTICES.md` §7: cold Gradle+NDK build is 20–40+ min) | Java keystore (`ANDROID_KEY_ALIAS`/`ANDROID_KEY_PASSWORD`/`ANDROID_KEY_BASE64`), secrets-present gated | Play Store internal track initially; Tauri updater not typically used for mobile |
+| iOS `.ipa` | App Store / TestFlight | `macos-latest`, full Xcode (not just CLT); via `src-tauri/gen/apple` (does not exist yet) | **Release/tag-only**, label-gated | Apple Distribution cert + provisioning profile (App Store Connect API key), secrets-present gated | TestFlight / App Store review, not the Tauri updater |
+| GUI (Svelte, existing) | N/A — bundled inside every desktop/mobile target above | — | — | — | — |
+| TUI (svelte-ratatui) | Ships as part of the same binary (render-mode switch, not a separate installer) | same as desktop targets | Covered by the same builds | Same as parent binary | Same as parent binary |
+| Headless / MCP server (`packages/mcp-dev-server`) | **No installer** — stdio JSON-RPC process, distributed as an npm/pnpm package or a thin binary via `cargo install`/CI artifact, not a Tauri bundle | Existing Node/Cargo build, no new host requirement | Already covered by existing `ci.yml`; out of scope for this ADR's installer matrix (tracked separately if a standalone headless distributable is ever requested) | N/A | npm registry versioning |
+
+**PR-fast lane vs release-heavy lane** (mirrors `TAURI-BEST-PRACTICES.md` §8 matrix
+recommendation, now scoped to pares-radix's actual repo state):
+
+- **PR / CI build**: Windows (unsigned), macOS Silicon-only (ad-hoc signed), Linux
+  `ubuntu-22.04` (deb+AppImage). No LTO profile. No mobile. Fast feedback.
+- **Release / publish** (triggered by `release.yml` → `release-reusable.yml`, on
+  `main` push / `v*` tag / `promote` dispatch): full desktop matrix (both macOS
+  arches), Flatpak, size-optimized `[profile.release]`, updater artifacts +
+  `latest.json`/`latest-prerelease.json` split by even/odd minor parity (existing
+  law — no new versioning scheme introduced). Mobile (Android + iOS) gated behind a
+  release label/secrets-present check, **not** run on every release by default given
+  cost/flakiness (`TAURI-BEST-PRACTICES.md` §7 cold-build evidence).
+
+## CI / release pipeline implications
+
+1. **New workflow surface needed** (implementation task, not this ADR): a
+   `platform-release` job matrix in (or called from) `.github/workflows/release.yml`,
+   invoked *after* `release-reusable.yml` cuts the version/tag, so installers are
+   built against the tagged commit/version — avoiding a race between version bump
+   and bundle version embedding (`tauri.conf.json` version should be sourced from
+   `Cargo.toml`, itself set by the reusable pipeline).
+2. **Caching is mandatory before this is viable in CI wall-clock/cost terms**:
+   `Swatinem/rust-cache@v2` per-OS-per-target-triple, pnpm store cache, and (for the
+   deferred mobile lane) Gradle/NDK and CocoaPods/SwiftPM caches — all specified in
+   `TAURI-BEST-PRACTICES.md` §3/§7. Without these, a full matrix run cold is
+   30–60+ minutes and mobile alone can eat the default job timeout.
+3. **Secrets-present gating, not hard failures**: every signing step (Windows Azure
+   Trusted Signing, macOS cert+notarize, Android keystore, iOS Distribution cert)
+   must be conditional on the relevant secret existing, so forked/PR builds still
+   produce runnable (unsigned/ad-hoc-signed) artifacts.
+4. **`bundle.targets` must be host-scoped explicitly** in `tauri.conf.json` (or an
+   env-driven override) — `"all"` on the wrong OS silently fails or produces nothing;
+   the design specifies per-runner explicit target lists (matrix table above), not a
+   blanket `"all"`.
+5. **Flatpak and NixOS are not Tauri `bundle.targets`** — they are post-processing
+   steps consuming the already-built Linux binary/`.deb`. They must be modeled as
+   separate CI steps/jobs, not folded into the Tauri bundler invocation.
+6. **No `src-tauri/gen/android` or `gen/apple` exist yet.** Mobile packaging cannot
+   start until `pnpm tauri android init` / `pnpm tauri ios init` are run and reviewed
+   in a follow-on implementation PR — that scaffolding is itself implementation, out
+   of scope here.
+7. **Update manifest ownership**: `latest.json` / `latest-prerelease.json` generation
+   and publish must be added to the release job, mapped to the existing even=stable /
+   odd=prerelease parity law already enforced by `release-reusable.yml` — no new
+   channel concept.
+
+## Real validation paths (no placeholders)
+
+Concrete, checkable acceptance criteria for the implementation task that follows this
+ADR — each must be independently verifiable, not asserted:
+
+1. **Windows**: `pnpm tauri build` on a `windows-latest` runner produces both a
+   `.exe` (NSIS) and `.msi` under `src-tauri/target/release/bundle/`; the artifact
+   installs (`Start-Process -Wait` silent install flag) and the resulting
+   `pares-radix.exe` launches and emits `app-booted` (verified via existing Playwright
+   e2e harness pointed at the installed binary, not the dev server).
+2. **macOS**: `pnpm tauri build --target aarch64-apple-darwin` produces a `.dmg`
+   whose mounted `.app` passes `spctl --assess` (ad-hoc: expected-fail with a clear
+   "unsigned" reason on PR builds; expected-pass on signed release builds) and
+   launches headless via `open -W`.
+3. **Linux**: the `.deb` installs cleanly in a fresh `ubuntu:22.04` container
+   (`dpkg -i` + `apt-get install -f`) with no missing shared-library errors, and the
+   `.AppImage` runs directly (`chmod +x && ./*.AppImage --appimage-extract-and-run`)
+   in a container with **no** desktop environment beyond the required webkit2gtk
+   deps, proving the dependency list in `TAURI-BEST-PRACTICES.md` §8 is complete.
+4. **Flatpak**: `flatpak-builder --repo=repo build-dir org.plures.Radix.yml` succeeds
+   and `flatpak run org.plures.Radix` (from the local repo) launches the app.
+5. **NixOS**: `nix build .#pares-radix` succeeds from a clean `nix build` (no
+   pre-warmed cache) and `nix run .#pares-radix` launches the binary; `nix flake
+   check` passes.
+6. **Updater manifest**: a scripted round-trip — build two versions (N, N+1) with the
+   updater keys, publish `latest.json` for N, point a running N binary at a local
+   static server serving that manifest, and confirm the updater flow (per
+   `tauri-plugin-updater` docs) reports an update available and installs N+1 without
+   manual file surgery.
+7. **Mobile (deferred, tag/release-only)**: after `gen/android`/`gen/apple` scaffolds
+   land in a follow-on PR, validation is: `pnpm tauri android build --apk` installs
+   on an emulator/device via `adb install` and boots to the same `app-booted` event;
+   equivalent for iOS via `xcrun simctl install`/`launch` on a simulator. Not
+   required for this ADR's acceptance — captured here so the follow-on task inherits
+   a concrete bar instead of "make mobile work."
+
+None of the above are satisfied by a CI job merely *existing* or by a bundler command
+*exiting zero* with an empty output directory — each requires the artifact to actually
+install/run and be functionally probed, per the org's C-NOSTUB-001 no-stub / no-ghost-
+binary constraint already cited in `TAURI-BEST-PRACTICES.md`.
+
+## Consequences
+
+- **Positive**: single shell (Tauri) across every target keeps the GUI/TUI parity
+  goal, the events-not-commands Rust core, and the org svelte-tauri-template mandate
+  intact — zero migration risk. The matrix makes explicit what is PR-fast vs
+  release-only vs deferred, preventing an accidental "build everything on every PR"
+  cost blowup.
+- **Negative / risk**: macOS Intel doubles macOS CI time; mobile is explicitly
+  deferred (no Android/iOS scaffolds exist yet), so ROADMAP Phase 4's "Android/iOS
+  via Tauri where supported" is only partially addressed by the first
+  implementation wave — this ADR records that gap rather than papering over it with
+  a placeholder mobile job.
+- **Follow-on work** (tracked separately, NOT part of this design-only ADR):
+  1. Add the `platform-release` CI matrix (Windows/macOS/Linux desktop only) with
+     caching + secrets-gated signing.
+  2. Wire the updater manifest publish step into `release-reusable.yml` consumption.
+  3. Add the Flatpak post-build step.
+  4. Add the NixOS flake package + `nix flake check` CI job.
+  5. Scaffold `src-tauri/gen/android` + `gen/apple`, then add the tag/release-only
+     mobile jobs per the deferred validation criteria above.
+
+## References
+
+- `design/TAURI-BEST-PRACTICES.md` (development-guide repo, verified 2026-06-27)
+- `ROADMAP.md` Phase 4
+- `.github/workflows/release.yml`, `plures/.github/.github/workflows/release-reusable.yml`
+- Tauri 2 docs: https://v2.tauri.app (configuration, size, updater, signing, pipelines)


### PR DESCRIPTION
## Summary

Design-stage audit (no component implementation) closing out the P2 design-dojo-components epic retry.

### What was inventoried
- 22 pares-radix app files consuming `@plures/design-dojo` via the vendor shim (`packages/design-dojo/`)
- The shim's 16 locally-defined "missing from npm" components vs the standalone `design-dojo` repo (`C:\Projects\design-dojo`, HEAD `4fa2153`)\n- `packages/canvas-runtime`'s separate direct `@plures/design-dojo": "*"` dependency (bypasses the shim entirely)
- Cross-check against ADR-0019 (installer/packaging) for any GUI-surface overlap

### Key findings
1. **13 of 16 shim components now exist upstream** and have drifted independently (200-656 line diffs) — the shim's own stated removal criterion (npm >= 0.13) has been satisfied since long before the current 0.17.1 pin, but nobody removed it. Prior revert history (`20acb73`/`0eb0734`) shows this was tried once and reverted due to real API incompatibility — not just neglect.
2. **`DataGrid`/`SchemaForm` are genuinely local-only** (no upstream equivalent) — these are unpublished contributions owed to the standalone repo, not drift.
3. **New risk found this pass**: `canvas-runtime` depends on design-dojo directly (`"*"`) while the main app goes through the shim — two live resolution paths for the same components (GraphView confirmed diverged) inside one dependency graph. This needs to be resolved before/alongside the reconciliation work.
4. ADR-0019 (installer/packaging) adds no new design-dojo surface — no cross-blocking dependency either direction. Phase 4's design-dojo terminal theme (GUI/TUI parity) has no components yet in either tree; tracked separately.

### Decision proposed
Three-part strategy: ownership (standalone repo is sole source of truth; vendor shim is a transitional bridge only), migration (triage-per-component reconciliation, smallest-diff pilot first, upstream DataGrid/SchemaForm before touching drifted components), enforcement (CI drift-check job + dated shim-removal obligations + ban on new local-only primitives going forward).

### Explicitly out of scope
No files copied/deleted/modified in either repo. No CI job, no UPSTREAM_MAP.json, no component reconciliation — those are follow-on implementation PRs pending review/acceptance of this ADR.

See `.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md` for full detail.
