### PR TITLE
chore(deps): add dependabot.yml (cargo + npm + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Part of org-wide dependabot-auto-merge rollout (batch 1/5). Adds .github/dependabot.yml scoped to this repo's ecosystems (cargo, npm, github-actions). The dependabot-auto-merge.yml workflow is already present on main and matches the proven org template verbatim (verified: no diff).

NOTE: repo-level 'Allow auto-merge' is currently DISABLED (allow_auto_merge=false) and main has no branch protection configured. The workflow calls 'gh pr merge --auto' which requires auto-merge to be enabled at the repo level to take effect. Recommend enabling Settings > General > Allow auto-merge before this becomes fully functional.