### PR TITLE
feat(core): durable task custody store with sled CAS (ADR-0036 M3)

### DIFF
--- a/.praxis/decisions/ADR-0036-durable-task-custody.md
+++ b/.praxis/decisions/ADR-0036-durable-task-custody.md
@@ -1,0 +1,24 @@
+# ADR-0036: Durable task custody and atomic claims
+
+- Status: Accepted
+- Date: 2026-07-21
+
+## Context
+
+`TaskManager` persisted whole task JSON documents but used unconditional read/modify/write. `Unassigned` and `Self` were relative labels, so two hosts could independently select and execute the same replicated task. Chat history is not durable custody evidence.
+
+## Decision
+
+Keep execution status and custody orthogonal. A one-to-one custody record carries owner, target, stable handoff id, monotonic generation, digest, worker, and opaque claim token. The storage boundary exposes conditional compare-and-swap; callers never emulate CAS with get followed by put.
+
+Export prepares `transfer_pending` once and emits a canonical integrity envelope. Import validates schema, target, and digest before atomically accepting ownership. Duplicate identical operations are idempotent; stale generations, changed payloads, and competing workers conflict. Claimed blocked/completed/failed writes require the winning token. Owner-filtered discovery excludes transfer-pending, blocked, terminal, and foreign tasks.
+
+The first production primitive uses sled's native `compare_and_swap`, which is durable and process-safe for the host-local store used by the explicit file transfer protocol. Eventual multi-writer CRDT replication is not certified as a distributed lock; enabling shared-store claiming requires a separately modeled authority/consensus design.
+
+## Consequences
+
+- Restart preserves custody and the winning claim.
+- Explicit canonical JSON is channel-neutral and auditable.
+- Transport is outside the correctness boundary; Telegram/chat is not used.
+- Agens exposes only a thin machine-readable interface over the radix service.
+- CAS conflicts are typed errors, never silent no-ops.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +754,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1118,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -4649,6 +4675,7 @@ version = "1.55.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "blake3",
  "chrono",
  "futures-util",
  "hostname",
@@ -4670,6 +4697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sled",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ tauri-plugin-updater = "2"
 walkdir = "2"
 toml = "0.8"
 libc = "0.2"
+sled = "0.34"
+blake3 = "1.5"
 
 # Size-optimized release profile (applies to the whole graph). Per
 # development-guide/design/TAURI-BEST-PRACTICES.md §2 — the single biggest lever

--- a/crates/radix-core/Cargo.toml
+++ b/crates/radix-core/Cargo.toml
@@ -58,6 +58,8 @@ pares-radix-audit = { path = "../audit" }
 regex = "1"
 regex-lite = "0.1"
 futures-util = "0.3"
+sled.workspace = true
+blake3.workspace = true
 
 # OpenTelemetry (optional, behind "otel" feature)
 opentelemetry = { version = "0.28", optional = true }

--- a/crates/radix-core/src/lib.rs
+++ b/crates/radix-core/src/lib.rs
@@ -28,10 +28,10 @@ pub mod executor;
 pub mod handlers;
 /// License key validation and Pro feature gates.
 pub mod license;
-/// LLM model client and tool dispatcher abstractions.
-pub mod model;
 /// Handler-facing memory interface (trait + DTOs; impl lives in cognition).
 pub mod memory;
+/// LLM model client and tool dispatcher abstractions.
+pub mod model;
 
 pub mod memory_client;
 
@@ -42,10 +42,10 @@ pub mod optimization;
 pub mod otel;
 #[cfg(feature = "otel")]
 pub mod otel_metrics;
-/// Praxis decision ledger and approval gate procedures.
-pub mod praxis;
 /// Platform bridge to the PluresDB procedure engine (procedure/constraint execution).
 pub mod pluresdb_bridge;
+/// Praxis decision ledger and approval gate procedures.
+pub mod praxis;
 /// Procedure registry and priority-based event dispatch.
 pub mod procedure;
 /// Shipped default PluresLM procedure bundles (JSON library).
@@ -71,6 +71,7 @@ pub use classifier::{
 
 /// Re-export PluresDB primitives for consumers that need the shared CrdtStore.
 pub use pluresdb::{CrdtStore, MemoryStorage, SledStorage, StorageEngine};
+pub mod approval;
 /// Channel capability contracts for output rendering.
 pub mod channel_contract;
 /// Event spine — bridges pares-radix to PluresDB's AgensRuntime.
@@ -80,7 +81,6 @@ pub mod lifecycle;
 pub mod renderers;
 /// Tool execution governance — policies, timeouts, blocked-command filtering.
 pub mod tool_governance;
-pub mod approval;
 
 pub mod model_download;
 /// Plugin framework — application platform for schema-driven apps.
@@ -107,5 +107,6 @@ pub mod shell_executor;
 pub mod spine;
 /// Platform-owned sub-agent spawn seam (trait + DTOs implemented by cognition).
 pub mod subagent_spawn;
+pub mod task_handoff;
 /// Thread engine — multi-topic conversation threading.
 pub mod threading;

--- a/crates/radix-core/src/task_handoff.rs
+++ b/crates/radix-core/src/task_handoff.rs
@@ -1,0 +1,585 @@
+//! Durable, channel-neutral task custody transfer with storage-native CAS.
+//!
+//! This deliberately does not use the CRDT last-writer-wins document API as a lock.
+//! Explicit export/import uses separate host-local stores and sled's compare-and-swap
+//! as the atomic claim boundary.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Arc;
+use thiserror::Error;
+use uuid::Uuid;
+
+const TREE: &str = "radix-task-custody-v1";
+const SCHEMA: &str = "plures.task-handoff.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CustodyState {
+    Owned,
+    TransferPending,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionState {
+    Open,
+    InProgress,
+    Blocked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl ExecutionState {
+    fn terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransferableTask {
+    pub task_id: String,
+    pub objective: String,
+    pub repo: String,
+    pub priority: String,
+    pub constraints: Vec<String>,
+    pub acceptance_criteria: Vec<String>,
+    pub next_action: String,
+    pub provenance: String,
+    pub artifacts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CustodyRecord {
+    pub task: TransferableTask,
+    pub owner_agent_id: String,
+    pub target_agent_id: Option<String>,
+    pub handoff_id: Option<Uuid>,
+    pub handoff_generation: u64,
+    pub custody_state: CustodyState,
+    pub execution_state: ExecutionState,
+    pub claimed_by_worker: Option<String>,
+    pub claim_token: Option<Uuid>,
+    pub blocked_reason: Option<String>,
+    pub result: Option<String>,
+    pub source_revision: String,
+    pub content_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HandoffEnvelope {
+    pub schema: String,
+    pub record: CustodyRecord,
+    pub digest: String,
+}
+
+impl HandoffEnvelope {
+    pub fn canonical_json(&self) -> Result<Vec<u8>, HandoffError> {
+        Ok(serde_json::to_vec(self)?)
+    }
+
+    pub fn verify(&self) -> Result<(), HandoffError> {
+        if self.schema != SCHEMA {
+            return Err(HandoffError::InvalidEnvelope("unsupported schema".into()));
+        }
+        let expected = digest_record(&self.record)?;
+        if expected != self.digest || self.record.content_digest.as_deref() != Some(&self.digest) {
+            return Err(HandoffError::IntegrityConflict);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Claim {
+    pub task_id: String,
+    pub worker_id: String,
+    pub token: Uuid,
+    pub generation: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum HandoffError {
+    #[error("storage error: {0}")]
+    Storage(#[from] sled::Error),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("task not found: {0}")]
+    NotFound(String),
+    #[error("conditional write conflict")]
+    Conflict,
+    #[error("task already claimed by another worker")]
+    AlreadyClaimed,
+    #[error("claim token does not authorize this update")]
+    InvalidClaimToken,
+    #[error("handoff integrity conflict")]
+    IntegrityConflict,
+    #[error("invalid handoff envelope: {0}")]
+    InvalidEnvelope(String),
+    #[error("invalid custody transition: {0}")]
+    InvalidTransition(String),
+}
+
+/// A durable conditional store. `compare_and_swap` is delegated directly to sled;
+/// no process-local mutex or unconditional get-then-put sequence is used.
+#[derive(Clone)]
+pub struct ConditionalTaskStore {
+    tree: Arc<sled::Tree>,
+}
+
+impl ConditionalTaskStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, HandoffError> {
+        let db = sled::open(path)?;
+        let tree = db.open_tree(TREE)?;
+        Ok(Self {
+            tree: Arc::new(tree),
+        })
+    }
+
+    fn key(task_id: &str) -> Vec<u8> {
+        format!("task-custody:{task_id}").into_bytes()
+    }
+
+    fn read_raw(&self, task_id: &str) -> Result<Option<Vec<u8>>, HandoffError> {
+        Ok(self.tree.get(Self::key(task_id))?.map(|v| v.to_vec()))
+    }
+
+    pub fn inspect(&self, task_id: &str) -> Result<Option<CustodyRecord>, HandoffError> {
+        self.read_raw(task_id)?
+            .map(|v| serde_json::from_slice(&v).map_err(HandoffError::from))
+            .transpose()
+    }
+
+    fn cas(
+        &self,
+        task_id: &str,
+        expected: Option<&[u8]>,
+        next: &[u8],
+    ) -> Result<bool, HandoffError> {
+        let result = self
+            .tree
+            .compare_and_swap(Self::key(task_id), expected, Some(next))?;
+        if result.is_ok() {
+            self.tree.flush()?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn seed_owned(
+        &self,
+        task: TransferableTask,
+        owner: &str,
+    ) -> Result<CustodyRecord, HandoffError> {
+        validate_nonempty("task_id", &task.task_id)?;
+        validate_nonempty("owner", owner)?;
+        let record = CustodyRecord {
+            source_revision: digest_task(&task)?,
+            task,
+            owner_agent_id: owner.to_owned(),
+            target_agent_id: None,
+            handoff_id: None,
+            handoff_generation: 0,
+            custody_state: CustodyState::Owned,
+            execution_state: ExecutionState::Open,
+            claimed_by_worker: None,
+            claim_token: None,
+            blocked_reason: None,
+            result: None,
+            content_digest: None,
+        };
+        let bytes = serde_json::to_vec(&record)?;
+        if self.cas(&record.task.task_id, None, &bytes)? {
+            Ok(record)
+        } else if self.inspect(&record.task.task_id)?.as_ref() == Some(&record) {
+            Ok(record)
+        } else {
+            Err(HandoffError::Conflict)
+        }
+    }
+
+    pub fn prepare_handoff(
+        &self,
+        task_id: &str,
+        source: &str,
+        target: &str,
+        handoff_id: Uuid,
+        expected_generation: u64,
+    ) -> Result<HandoffEnvelope, HandoffError> {
+        validate_nonempty("source", source)?;
+        validate_nonempty("target", target)?;
+        if source == target {
+            return Err(HandoffError::InvalidTransition(
+                "source equals target".into(),
+            ));
+        }
+        loop {
+            let raw = self
+                .read_raw(task_id)?
+                .ok_or_else(|| HandoffError::NotFound(task_id.into()))?;
+            let mut record: CustodyRecord = serde_json::from_slice(&raw)?;
+            if record.custody_state == CustodyState::TransferPending {
+                if record.owner_agent_id == source
+                    && record.target_agent_id.as_deref() == Some(target)
+                    && record.handoff_id == Some(handoff_id)
+                    && record.handoff_generation == expected_generation + 1
+                {
+                    return envelope(record);
+                }
+                return Err(HandoffError::Conflict);
+            }
+            if record.execution_state.terminal()
+                || record.execution_state != ExecutionState::Open
+                || record.owner_agent_id != source
+                || record.handoff_generation != expected_generation
+            {
+                return Err(HandoffError::InvalidTransition(
+                    "source, generation, or execution state mismatch".into(),
+                ));
+            }
+            record.custody_state = CustodyState::TransferPending;
+            record.target_agent_id = Some(target.to_owned());
+            record.handoff_id = Some(handoff_id);
+            record.handoff_generation += 1;
+            record.content_digest = None;
+            let digest = digest_record(&record)?;
+            record.content_digest = Some(digest);
+            let next = serde_json::to_vec(&record)?;
+            if self.cas(task_id, Some(&raw), &next)? {
+                return envelope(record);
+            }
+        }
+    }
+
+    pub fn accept_handoff(
+        &self,
+        envelope: &HandoffEnvelope,
+        target: &str,
+    ) -> Result<CustodyRecord, HandoffError> {
+        envelope.verify()?;
+        if envelope.record.custody_state != CustodyState::TransferPending
+            || envelope.record.target_agent_id.as_deref() != Some(target)
+        {
+            return Err(HandoffError::InvalidTransition("target mismatch".into()));
+        }
+        let mut accepted = envelope.record.clone();
+        accepted.owner_agent_id = target.to_owned();
+        accepted.target_agent_id = None;
+        accepted.custody_state = CustodyState::Owned;
+        let next = serde_json::to_vec(&accepted)?;
+        let id = &accepted.task.task_id;
+        if self.cas(id, None, &next)? {
+            return Ok(accepted);
+        }
+        let existing = self
+            .inspect(id)?
+            .ok_or_else(|| HandoffError::NotFound(id.clone()))?;
+        if existing == accepted {
+            Ok(existing)
+        } else {
+            Err(HandoffError::Conflict)
+        }
+    }
+
+    pub fn claim_task(
+        &self,
+        task_id: &str,
+        agent_id: &str,
+        worker_id: &str,
+        generation: u64,
+    ) -> Result<Claim, HandoffError> {
+        loop {
+            let raw = self
+                .read_raw(task_id)?
+                .ok_or_else(|| HandoffError::NotFound(task_id.into()))?;
+            let mut record: CustodyRecord = serde_json::from_slice(&raw)?;
+            if record.execution_state == ExecutionState::InProgress {
+                if record.owner_agent_id == agent_id
+                    && record.claimed_by_worker.as_deref() == Some(worker_id)
+                {
+                    return Ok(Claim {
+                        task_id: task_id.into(),
+                        worker_id: worker_id.into(),
+                        token: record.claim_token.ok_or(HandoffError::InvalidClaimToken)?,
+                        generation,
+                    });
+                }
+                return Err(HandoffError::AlreadyClaimed);
+            }
+            if record.custody_state != CustodyState::Owned
+                || record.execution_state != ExecutionState::Open
+                || record.owner_agent_id != agent_id
+                || record.handoff_generation != generation
+            {
+                return Err(HandoffError::InvalidTransition(
+                    "task is not evaluable by this owner/generation".into(),
+                ));
+            }
+            let token = Uuid::new_v4();
+            record.execution_state = ExecutionState::InProgress;
+            record.claimed_by_worker = Some(worker_id.to_owned());
+            record.claim_token = Some(token);
+            let next = serde_json::to_vec(&record)?;
+            if self.cas(task_id, Some(&raw), &next)? {
+                return Ok(Claim {
+                    task_id: task_id.into(),
+                    worker_id: worker_id.into(),
+                    token,
+                    generation,
+                });
+            }
+        }
+    }
+
+    pub fn set_blocked(
+        &self,
+        task_id: &str,
+        token: Uuid,
+        reason: &str,
+    ) -> Result<CustodyRecord, HandoffError> {
+        validate_nonempty("blocked reason", reason)?;
+        self.update_claimed(
+            task_id,
+            token,
+            ExecutionState::Blocked,
+            Some(reason.to_owned()),
+            None,
+        )
+    }
+
+    pub fn complete_claimed(
+        &self,
+        task_id: &str,
+        token: Uuid,
+        result: String,
+    ) -> Result<CustodyRecord, HandoffError> {
+        self.update_claimed(
+            task_id,
+            token,
+            ExecutionState::Completed,
+            None,
+            Some(result),
+        )
+    }
+
+    pub fn fail_claimed(
+        &self,
+        task_id: &str,
+        token: Uuid,
+        error: String,
+    ) -> Result<CustodyRecord, HandoffError> {
+        self.update_claimed(task_id, token, ExecutionState::Failed, None, Some(error))
+    }
+
+    fn update_claimed(
+        &self,
+        task_id: &str,
+        token: Uuid,
+        next_state: ExecutionState,
+        blocked_reason: Option<String>,
+        result: Option<String>,
+    ) -> Result<CustodyRecord, HandoffError> {
+        loop {
+            let raw = self
+                .read_raw(task_id)?
+                .ok_or_else(|| HandoffError::NotFound(task_id.into()))?;
+            let mut record: CustodyRecord = serde_json::from_slice(&raw)?;
+            if record.claim_token != Some(token) {
+                return Err(HandoffError::InvalidClaimToken);
+            }
+            if record.execution_state.terminal() {
+                if record.execution_state == next_state
+                    && record.blocked_reason == blocked_reason
+                    && record.result == result
+                {
+                    return Ok(record);
+                }
+                return Err(HandoffError::InvalidTransition(
+                    "terminal state is monotonic".into(),
+                ));
+            }
+            if record.execution_state != ExecutionState::InProgress {
+                return Err(HandoffError::InvalidTransition(
+                    "only an in-progress claim may be updated".into(),
+                ));
+            }
+            record.execution_state = next_state.clone();
+            record.blocked_reason = blocked_reason.clone();
+            record.result = result.clone();
+            let next = serde_json::to_vec(&record)?;
+            if self.cas(task_id, Some(&raw), &next)? {
+                return Ok(record);
+            }
+        }
+    }
+
+    pub fn evaluable_tasks(&self, agent_id: &str) -> Result<Vec<CustodyRecord>, HandoffError> {
+        let mut out = Vec::new();
+        for entry in self.tree.scan_prefix(b"task-custody:") {
+            let (_, value) = entry?;
+            let record: CustodyRecord = serde_json::from_slice(&value)?;
+            if record.owner_agent_id == agent_id
+                && record.custody_state == CustodyState::Owned
+                && record.execution_state == ExecutionState::Open
+            {
+                out.push(record);
+            }
+        }
+        out.sort_by(|a, b| a.task.task_id.cmp(&b.task.task_id));
+        Ok(out)
+    }
+}
+
+fn validate_nonempty(field: &str, value: &str) -> Result<(), HandoffError> {
+    if value.trim().is_empty() {
+        Err(HandoffError::InvalidTransition(format!("{field} is empty")))
+    } else {
+        Ok(())
+    }
+}
+
+fn digest_task(task: &TransferableTask) -> Result<String, HandoffError> {
+    Ok(blake3::hash(&serde_json::to_vec(task)?)
+        .to_hex()
+        .to_string())
+}
+
+fn digest_record(record: &CustodyRecord) -> Result<String, HandoffError> {
+    let mut unsigned = record.clone();
+    unsigned.content_digest = None;
+    Ok(blake3::hash(&serde_json::to_vec(&unsigned)?)
+        .to_hex()
+        .to_string())
+}
+
+fn envelope(record: CustodyRecord) -> Result<HandoffEnvelope, HandoffError> {
+    let digest = digest_record(&record)?;
+    if record.content_digest.as_deref() != Some(&digest) {
+        return Err(HandoffError::IntegrityConflict);
+    }
+    Ok(HandoffEnvelope {
+        schema: SCHEMA.into(),
+        record,
+        digest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("radix-handoff-{name}-{}", Uuid::new_v4()))
+    }
+
+    fn task() -> TransferableTask {
+        TransferableTask {
+            task_id: "TASK-ATOMIC".into(),
+            objective: "ship one bounded change".into(),
+            repo: "plures/example".into(),
+            priority: "P1".into(),
+            constraints: vec!["no stubs".into()],
+            acceptance_criteria: vec!["tests pass".into()],
+            next_action: "implement".into(),
+            provenance: "certification".into(),
+            artifacts: vec![],
+        }
+    }
+
+    #[test]
+    fn export_import_are_idempotent_and_owner_filtered() {
+        let source_path = path("source");
+        let target_path = path("target");
+        let source = ConditionalTaskStore::open(&source_path).unwrap();
+        let target = ConditionalTaskStore::open(&target_path).unwrap();
+        source.seed_owned(task(), "openclaw").unwrap();
+        let id = Uuid::new_v4();
+        let first = source
+            .prepare_handoff("TASK-ATOMIC", "openclaw", "praxisbot", id, 0)
+            .unwrap();
+        let second = source
+            .prepare_handoff("TASK-ATOMIC", "openclaw", "praxisbot", id, 0)
+            .unwrap();
+        assert_eq!(
+            first.canonical_json().unwrap(),
+            second.canonical_json().unwrap()
+        );
+        assert!(source.evaluable_tasks("openclaw").unwrap().is_empty());
+        let accepted = target.accept_handoff(&first, "praxisbot").unwrap();
+        assert_eq!(
+            accepted,
+            target.accept_handoff(&first, "praxisbot").unwrap()
+        );
+        assert_eq!(target.evaluable_tasks("praxisbot").unwrap().len(), 1);
+        drop(source);
+        drop(target);
+        let _ = std::fs::remove_dir_all(source_path);
+        let _ = std::fs::remove_dir_all(target_path);
+    }
+
+    #[test]
+    fn duplicate_claim_has_one_winner_and_token_guards_updates_across_restart() {
+        let store_path = path("claim");
+        let source = ConditionalTaskStore::open(path("claim-source")).unwrap();
+        let store = ConditionalTaskStore::open(&store_path).unwrap();
+        source.seed_owned(task(), "openclaw").unwrap();
+        let env = source
+            .prepare_handoff("TASK-ATOMIC", "openclaw", "praxisbot", Uuid::new_v4(), 0)
+            .unwrap();
+        store.accept_handoff(&env, "praxisbot").unwrap();
+        let store = Arc::new(store);
+        let barrier = Arc::new(Barrier::new(3));
+        let mut threads = Vec::new();
+        for worker in ["a", "b"] {
+            let s = store.clone();
+            let b = barrier.clone();
+            let w = worker.to_owned();
+            threads.push(thread::spawn(move || {
+                b.wait();
+                s.claim_task("TASK-ATOMIC", "praxisbot", &w, 1)
+            }));
+        }
+        barrier.wait();
+        let results: Vec<_> = threads.into_iter().map(|t| t.join().unwrap()).collect();
+        assert_eq!(results.iter().filter(|r| r.is_ok()).count(), 1);
+        let winner = results.into_iter().find_map(Result::ok).unwrap();
+        assert!(matches!(
+            store.complete_claimed("TASK-ATOMIC", Uuid::new_v4(), "bad".into()),
+            Err(HandoffError::InvalidClaimToken)
+        ));
+        drop(store);
+        let reopened = ConditionalTaskStore::open(&store_path).unwrap();
+        let done = reopened
+            .complete_claimed("TASK-ATOMIC", winner.token, "ok".into())
+            .unwrap();
+        assert_eq!(done.execution_state, ExecutionState::Completed);
+        drop(reopened);
+        let _ = std::fs::remove_dir_all(store_path);
+    }
+
+    #[test]
+    fn blocked_requires_reason_and_is_durable() {
+        let store_path = path("blocked");
+        let store = ConditionalTaskStore::open(&store_path).unwrap();
+        store.seed_owned(task(), "praxisbot").unwrap();
+        let claim = store
+            .claim_task("TASK-ATOMIC", "praxisbot", "worker", 0)
+            .unwrap();
+        assert!(store.set_blocked("TASK-ATOMIC", claim.token, " ").is_err());
+        store
+            .set_blocked("TASK-ATOMIC", claim.token, "waiting for review")
+            .unwrap();
+        drop(store);
+        let reopened = ConditionalTaskStore::open(&store_path).unwrap();
+        let record = reopened.inspect("TASK-ATOMIC").unwrap().unwrap();
+        assert_eq!(record.execution_state, ExecutionState::Blocked);
+        assert_eq!(record.blocked_reason.as_deref(), Some("waiting for review"));
+        assert!(reopened.evaluable_tasks("praxisbot").unwrap().is_empty());
+        drop(reopened);
+        let _ = std::fs::remove_dir_all(store_path);
+    }
+}

--- a/crates/radix-core/src/task_handoff.rs
+++ b/crates/radix-core/src/task_handoff.rs
@@ -299,11 +299,14 @@ impl ConditionalTaskStore {
                 if record.owner_agent_id == agent_id
                     && record.claimed_by_worker.as_deref() == Some(worker_id)
                 {
+                    if record.handoff_generation != generation {
+                        return Err(HandoffError::InvalidTransition("generation mismatch".into()));
+                    }
                     return Ok(Claim {
                         task_id: task_id.into(),
                         worker_id: worker_id.into(),
                         token: record.claim_token.ok_or(HandoffError::InvalidClaimToken)?,
-                        generation,
+                        generation: record.handoff_generation,
                     });
                 }
                 return Err(HandoffError::AlreadyClaimed);

--- a/praxis/procedures/task-handoff.px
+++ b/praxis/procedures/task-handoff.px
@@ -1,0 +1,39 @@
+# Executable orchestration for durable task handoff. Atomicity is provided by the Rust action handlers.
+
+procedure handoff_export(request: HandoffRequest from "handoff_requests") -> HandoffEnvelope into "handoff_envelopes":
+  given: "Prepare source custody and return canonical JSON without using a chat adapter"
+  prepare_task_handoff request -> $prepared
+  canonicalize_handoff_envelope $prepared -> $envelope
+  return $envelope
+
+procedure handoff_import(envelope: HandoffEnvelope from "handoff_envelopes") -> TaskCustody into "task_custody":
+  given: "Verify integrity and atomically accept only on the named target"
+  verify_task_handoff_digest envelope -> $verified
+  accept_task_handoff $verified -> $accepted
+  return $accepted
+
+procedure handoff_claim(request: ClaimRequest from "claim_requests") -> TaskCustody into "task_custody":
+  given: "Claim one owner-filtered open task exactly once"
+  conditional_claim_task request -> $claimed
+  return $claimed
+
+procedure handoff_update(request: ClaimedTaskUpdate from "claimed_updates") -> TaskCustody into "task_custody":
+  given: "Apply blocked or terminal state only with the winning token"
+  conditional_update_claimed_task request -> $updated
+  return $updated
+
+constraint blocked_update_has_reason:
+  scope: task_handoff
+  phase: pre_write
+  when: update.status == "blocked"
+  require: update.blocked_reason != ""
+  severity: error
+  message: "Blocked task updates require a reason."
+
+constraint claimed_update_has_token:
+  scope: task_handoff
+  phase: pre_write
+  when: update.status == "in_progress" OR update.status == "completed" OR update.status == "failed" OR update.status == "blocked"
+  require: update.claim_token != ""
+  severity: error
+  message: "Claimed task state updates require the winning claim token."

--- a/praxis/procedures/task-handoff.px
+++ b/praxis/procedures/task-handoff.px
@@ -24,16 +24,12 @@ procedure handoff_update(request: ClaimedTaskUpdate from "claimed_updates") -> T
 
 constraint blocked_update_has_reason:
   scope: task_handoff
-  phase: pre_write
-  when: update.status == "blocked"
-  require: update.blocked_reason != ""
+  require: if update.status == "blocked": update.blocked_reason != "" else: true
   severity: error
   message: "Blocked task updates require a reason."
 
 constraint claimed_update_has_token:
   scope: task_handoff
-  phase: pre_write
-  when: update.status == "in_progress" OR update.status == "completed" OR update.status == "failed" OR update.status == "blocked"
-  require: update.claim_token != ""
+  require: if update.status == "in_progress" || update.status == "completed" || update.status == "failed" || update.status == "blocked": update.claim_token != "" else: true
   severity: error
   message: "Claimed task state updates require the winning claim token."


### PR DESCRIPTION
## Summary
Wires the previously-uncommitted `task_handoff.rs` (585 lines, from a prior attempt) into the build. This was blocked for multiple retry attempts on two missing Cargo.toml dependencies.

## Root cause fixed
- `crates/radix-core/Cargo.toml` never declared `sled` or `blake3` as direct dependencies of `pares-radix-core`, even though `task_handoff.rs` used them directly (sled was only reachable transitively via vendored `pluresdb-storage`).
- Added `sled = "0.34"` and `blake3 = "1.5"` to the workspace root `[workspace.dependencies]`, and referenced them via `sled.workspace = true` / `blake3.workspace = true` in `crates/radix-core/Cargo.toml`.
- Reverted ~50 unrelated files with pure formatting-only diffs that had accumulated uncommitted in the prior attempt's worktree (drift from a whole-crate fmt run), keeping this PR scoped to the actual change.

## What's in
- `ConditionalTaskStore`: sled-backed store using `Tree::compare_and_swap` as the sole atomic boundary for custody claim/handoff/blocked/complete transitions (per ADR-0036).
- `HandoffEnvelope` with blake3 digest verification for transfer integrity.
- `CustodyState` / `ExecutionState` state machine matching ADR-0036.

## Verification
- `cargo build --package pares-radix-core` — clean.
- `cargo test --package pares-radix-core task_handoff::` — 3/3 passing:
  - `export_import_are_idempotent_and_owner_filtered`
  - `duplicate_claim_has_one_winner_and_token_guards_updates_across_restart` (concurrent-claim race via thread barrier)
  - `blocked_requires_reason_and_is_durable` (persists across store reopen)

## Out of scope (next step per ADR-0036 follow-up plan)
Action-handler registration wiring `task-handoff.px` verbs (`prepare_task_handoff`, `accept_task_handoff`, `conditional_claim_task`, etc.) to these Rust functions, and the `pares-agens` CLI surface (`handoff-export`/`handoff-import`/`inspect`/`claim`). Today the `.px` procedures declare these verbs but have no registered Rust handler; that is the next concrete blocker and is intentionally not folded into this dependency/compile fix.

Refs: `.praxis/decisions/ADR-0036-durable-task-custody.md`, `praxis/procedures/task-handoff.px`.
