### PR TITLE
docs(adr): ADR-0018 radix runtime-as-service (design only)

### DIFF
--- a/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
+++ b/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
@@ -1,0 +1,200 @@
+# ADR-0035: Resolving `@plures/design-dojo` Vendored-Shim Drift
+
+- **Status:** Proposed (DESIGN stage only — no bulk copy/implementation authorized by this ADR)
+- **Date:** 2026-07-23
+- **Deciders:** kbristol (strategic directive), dev-lead orchestrator
+- **Relates:** ADR-0024 §5 (design-dojo as canonical UI home), ADR-0032 (GraphView primitive),
+  ADR-0033 (px composition language)
+- **Invariants:** C-NOSTUB-001 (no stub/shim debt masquerading as done), C-TEST-001/002
+
+---
+
+## 1. Context
+
+`pares-radix` depends on `@plures/design-dojo` two ways simultaneously:
+
+1. **npm dependency** — `@plures/design-dojo-npm: npm:@plures/design-dojo@^0.17.0` (registry
+   currently tops out at published `0.17.1`).
+2. **Local vendored shim** — `packages/design-dojo/` (`workspace:*`), a **hand-maintained
+   compatibility package** whose `package.json` description literally says:
+   > "Local shim - re-exports npm @plures/design-dojo + adds missing components. Remove when npm
+   > is updated to v0.13+"
+
+The shim's `src/index.ts` re-exports most components from the npm package and then locally defines
+16 components the npm package allegedly lacked: `SettingsPanel`, `Sidebar`, `Input`, `Select`,
+`Dialog`, `DashboardGrid`, `FirstRunWizard`, `Heading`, `TextArea`, `Link`, `CodeBlock`, `Canvas2D`,
+`PluginContentArea`, `DataGrid`, `SchemaForm`, `GraphView`.
+
+Meanwhile, the **standalone `@plures/design-dojo` source repo** (`C:\Projects\design-dojo`,\nindependently versioned, currently at package.json `1.55.34`, git HEAD `4fa2153`, 2026-07-21) is\nalive, organized (`src/lib/{primitives,layout,overlays,data,surfaces,feedback,app,...}`), and has
+**361 source files** vs. the vendor shim's flat 24.
+
+### Actual divergence found (not assumed)
+
+| Vendored component | Exists in standalone repo? | Line-diff vs. standalone counterpart |
+|---|---|---|
+| SettingsPanel | ✅ `src/lib/app/SettingsPanel.svelte` | not diffed (bulk) |
+| Sidebar | ✅ `src/lib/layout/Sidebar.svelte` | **285** differing lines |
+| Input | ✅ `src/lib/primitives/Input.svelte` | **532** differing lines |
+| Select | ✅ `src/lib/primitives/Select.svelte` | not diffed (bulk) |
+| Dialog | ✅ `src/lib/overlays/Dialog.svelte` | **342** differing lines |
+| DashboardGrid | ✅ `src/lib/layout/DashboardGrid.svelte` | **223** differing lines |
+| FirstRunWizard | ✅ `src/lib/app/FirstRunWizard.svelte` | **656** differing lines |
+| Heading | ✅ `src/lib/typography/Heading.svelte` | not diffed (bulk) |
+| TextArea | ✅ `src/lib/primitives/TextArea.svelte` | not diffed (bulk) |
+| Link | ✅ `src/lib/primitives/Link.svelte` | not diffed (bulk) |
+| CodeBlock | ✅ `src/lib/primitives/CodeBlock.svelte` | not diffed (bulk) |
+| Canvas2D | ✅ `src/lib/canvas/Canvas2D.svelte` | not diffed (bulk) |
+| PluginContentArea | ✅ `src/lib/layout/PluginContentArea.svelte` | not diffed (bulk) |
+| GraphView | ✅ `src/lib/app/GraphView.svelte` | **30** differing lines (closest match — recently ported, ADR-0032) |
+| **DataGrid** | ❌ **not present upstream** | genuinely local-only (Phase B, schema-driven, built directly against `types-local.ts`) |
+| **SchemaForm** | ❌ **not present upstream** | genuinely local-only (Phase B, same origin as DataGrid) |
+
+Key findings:
+
+- **13 of 16 "missing" components now exist upstream** — the shim's founding premise ("npm doesn't
+  have these yet") is **stale**. npm registry is at `0.17.1`; the shim comment references
+  "v0.13+" as the removal trigger, which has long since passed, yet the shim was never removed.
+- **Every diffable component has drifted independently and substantially** (200–650+ line diffs),
+  not just by formatting — these are now **effectively forked implementations**, not stale copies
+  of the same code. `git log` on the vendored path shows repeated deliberate restoration commits
+  (`20acb73 fix: restore Sidebar + SettingsPanel to local shim — npm API incompatible`,
+  `0eb0734 fix: stable state — v0.17.0 npm + local Sidebar/SettingsPanel`) — i.e., the team already
+  tried removing the shim components and reverted because the **npm-published API didn't match
+  what pares-radix call sites expected**. This is real API drift, not just laziness.
+- `GraphView` is the newest addition (ADR-0032, 2026-07-11) and has the smallest diff (30 lines) —
+  evidence that when a component is added going *forward*, it can stay close to upstream if the
+  upstream repo gets the change promptly; drift accumulates only when one side changes without the
+  other.
+- `DataGrid`/`SchemaForm` are legitimately pares-radix-native primitives (schema-driven grid/form,
+  Phase B) with no upstream equivalent — these are **not drift**, they are **unpublished
+  contributions** that should flow *into* design-dojo, not be reconciled against it.
+- `types-local.ts` in the vendor package defines local-only types (`DataGridProps`, `SchemaField`,
+  etc.) that duplicate/shadow what should be part of the design-dojo public type surface once
+  DataGrid/SchemaForm are upstreamed.
+
+### Additional risk found: dual resolution path (canvas-runtime)
+
+`packages/canvas-runtime/package.json` depends on `@plures/design-dojo": "*"` **directly**,
+bypassing the vendor shim entirely, while the main app depends on the shim
+(`packages/design-dojo`, `workspace:*`). With both `@plures/design-dojo` (npm, hoisted) and
+`@plures/design-dojo-npm` present in `node_modules`, **canvas-runtime and the main app shell are
+not guaranteed to resolve the same implementation of overlapping components** (e.g. `GraphView`,
+which is confirmed byte/line-diverged between the shim and standalone repo above). This is a
+concrete correctness/consistency risk independent of the drift-cleanup plan below — it should be
+resolved *first* (either point `canvas-runtime` at the shim too, or resolve everything to
+upstream directly) so there is exactly one resolution path while the reconciliation work in §2
+proceeds. No app screen currently imports the shim-only `DataGrid`/`SchemaForm`, so today's
+blast radius for the dual-path risk is centered on the 14 overlapping components, `GraphView`
+most acutely since its divergence is already confirmed.
+
+### Cross-check against ADR-0019 (installer/packaging)
+
+ADR-0019's multiplatform installer/packaging design is entirely Rust/Tauri/CI-side (`src-tauri`,
+`release.yml`) and adds no new design-dojo consumers or requirements. The one relevant forward
+link is ROADMAP Phase 4 ("Svelte GUI parity with Svelte TUI — design-dojo terminal theme"): no
+terminal-theme components exist in either the shim or the standalone repo yet, so that item
+remains a future design-dojo epic, not something this drift cleanup unblocks or blocks.
+
+### Root cause
+There is **no enforcement** preventing a plugin/consumer repo from silently forking UI primitives:
+- No CI check diffing vendored files against the published/standalone package.
+- No ownership boundary — `packages/design-dojo/src/*.svelte` are ordinary files anyone can edit
+  in place during a pares-radix change, with no signal that they are a fork of another repo.
+- No process for promoting local-only primitives (DataGrid, SchemaForm) upstream once proven.
+- The shim's own removal criterion ("npm v0.13+") was met by `0.17.1` and nobody revisited it.
+
+## 2. Decision
+
+Adopt a three-part strategy: **stop the bleeding (ownership), reconcile (migration), then enforce
+(prevent recurrence).** This ADR authorizes DESIGN only; no bulk copy/deletion happens until this
+strategy is reviewed and a follow-up implementation ADR/PR is accepted.
+
+### 2.1 Ownership & release strategy
+- `@plures/design-dojo` (standalone repo) is the **single source of truth** for all shared UI
+  primitives (per ADR-0024 §5). `packages/design-dojo/` in pares-radix is **not** a parallel
+  product — it is a **compatibility shim only**, and must shrink to zero as fast as upstream sync
+  allows.
+- Any component that exists in both places must have **at most one authoritative source**: the
+  standalone repo. Vendored copies are transitional bridges, never permanent forks.
+- `DataGrid` and `SchemaForm` are reclassified as **upstream contributions owed**, not vendor
+  drift — they get a dedicated small PR into `C:\Projects\design-dojo` (own review, own semver\n  bump), not a copy-paste reconciliation.\n- Release cadence: design-dojo standalone repo cuts a release for every component it gains from
+  pares-radix contributions or fixes drift-discovered bugs; pares-radix bumps its
+  `@plures/design-dojo-npm` pin promptly after (target: within one sprint) rather than papering
+  over the gap with a local shim edit.
+
+### 2.2 Migration approach (for follow-up implementation PR — not this ADR)
+1. **Triage per component** (not bulk): for each of the 13 drifted components, determine whether
+   the *pares-radix* variant or the *standalone* variant is closer to "correct" per current
+   requirements — likely mixed, since some diffs are pares-radix bugfixes never upstreamed and
+   some are standalone improvements never pulled down.
+2. **Upstream first** for genuinely-local primitives: PR `DataGrid` + `SchemaForm` (with
+   `types-local.ts` types folded into the public type surface) into the standalone repo before
+   touching anything else.
+3. **Reconcile drifted components one at a time**, smallest-diff first (`GraphView` at 30 lines is
+   the trivial pilot case to prove the reconciliation workflow), each as its own small PR with its
+   own diff review and test pass — never a single mass "sync everything" commit.
+4. **Delete from the vendor shim only after** the reconciled/upstreamed version is published to npm
+   and pares-radix's pin is bumped and verified (`svelte-check`, existing route/story smoke tests)
+   against the npm version, matching the exact pattern already tried in `20acb73`/`0eb0734` but
+   this time backed by enforcement (below) so it doesn't silently re-drift.
+5. Target end state: `packages/design-dojo/` shrinks to nothing (or a thin re-export file kept only
+   if a genuine local override is still required, clearly labeled and covered by the CI check in
+   §2.3), and `pares-radix` package.json depends on `@plures/design-dojo` directly (no shim
+   indirection layer).
+
+### 2.3 Enforcement to prevent renewed drift
+- **CI drift check**: a scheduled/PR-triggered job that, for every file in `packages/design-dojo/`
+  whose basename matches a file in the standalone repo (path resolved via a manifest checked into
+  `packages/design-dojo/UPSTREAM_MAP.json` mapping vendor filename → standalone repo path), fails
+  the build if the vendored copy differs from the pinned npm-published version's corresponding
+  source and the diff isn't accompanied by a `DRIFT.md` entry explaining why (temporary override,
+  upstream PR link, expected removal date).
+- **No silent local edits**: any change to a file under `packages/design-dojo/src/*.svelte` that
+  has an upstream counterpart must be accompanied by either (a) a linked upstream PR/issue in
+  `design-dojo`, or (b) removal of the local override once upstream ships. Enforced via PR
+  template checklist + the CI check above (fails without a `DRIFT.md` entry).
+- **Shim removal criterion becomes a tracked, dated obligation**, not a comment nobody revisits:
+  each entry in `UPSTREAM_MAP.json` carries a `removeAfterNpmVersion` field; CI flags (does not
+  necessarily hard-fail, but surfaces loudly) any entry where the current npm pin already satisfies
+  `removeAfterNpmVersion` — this alone would have caught today's stale shim (target `0.13+` vs.
+  actual pin `0.17.x`).
+- **Ban new local-only primitives in the vendor package** going forward: any *new* shared UI need
+  gets built directly in the standalone `design-dojo` repo (consumed via `workspace:*`/local link
+  during co-development if needed) rather than added to `packages/design-dojo/src/*.svelte` as a
+  "temporary" addition — this is exactly how `DataGrid`/`SchemaForm` ended up stranded.
+
+## 3. Consequences
+
+**Positive** — single source of truth restored; the 200–650-line-diffed components stop silently
+diverging further; `DataGrid`/`SchemaForm` become available to every design-dojo consumer, not just
+pares-radix; CI enforcement makes "shim never gets removed" structurally harder to repeat; smallest
+diff (`GraphView`) provides a low-risk pilot for the reconciliation workflow before tackling the
+large diffs (`FirstRunWizard` at 656 lines will need the most care/dedicated review).
+
+**Costs/risks** — reconciling 13 drifted components is real work spread over multiple PRs/sprints,
+not a single sweep; some pares-radix-side fixes embedded in the drifted diffs may be lost or need
+re-discovery if not carefully triaged before reconciliation; standalone repo maintainers must accept
+and prioritize the `DataGrid`/`SchemaForm` + fix-upstreaming PRs promptly or pares-radix will be
+tempted to re-fork under deadline pressure — this ADR's enforcement mechanism only works if upstream
+turnaround is fast enough to not be a bigger friction than the shim was.
+
+## 4. Explicitly out of scope for this ADR
+- No files are copied, deleted, or modified in either repo by this ADR.
+- No `UPSTREAM_MAP.json`, CI job, or PR template is created yet — those are implementation-stage
+  deliverables of the accepted follow-up PR.
+- No component-by-component reconciliation begins until this design is reviewed and accepted.
+
+## 5. Next steps (pending review/acceptance of this ADR)
+1. Review/accept this ADR.
+2. Open implementation PR #1: `UPSTREAM_MAP.json` + CI drift-check job (enforcement scaffolding,
+   no component changes).
+3. Open upstream PR: `DataGrid` + `SchemaForm` → standalone `design-dojo` repo.
+4. Open reconciliation PR: `GraphView` (pilot, smallest diff) — prove the workflow.
+5. Sequence remaining 12 components by diff size / risk, each its own PR.
+6. Retire `packages/design-dojo/` shim once all entries are reconciled and the npm pin covers them.
+
+## 6. References
+ADR-0024 §5 (design-dojo canonical UI home, subpath consumption pattern), ADR-0032 (GraphView,
+most recent addition — smallest drift, proof that fast upstream sync prevents divergence);
+`C:\Projects\pares-radix\packages\design-dojo\package.json` (shim description, stale removal\ncriterion); `C:\Projects\design-dojo` git HEAD `4fa2153` (2026-07-21); pares-radix git history\n`20acb73`/`0eb0734` (prior attempted-then-reverted shim removal, evidence of real API drift, not
+just process laziness); C-NOSTUB-001.

--- a/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
+++ b/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
@@ -193,5 +193,4 @@ turnaround is fast enough to not be a bigger friction than the shim was.
 ## 6. References
 ADR-0024 §5 (design-dojo canonical UI home, subpath consumption pattern), ADR-0032 (GraphView,
 most recent addition — smallest drift, proof that fast upstream sync prevents divergence);
-`C:\Projects\pares-radix\packages\design-dojo\package.json` (shim description, stale removal\ncriterion); `C:\Projects\design-dojo` git HEAD `4fa2153` (2026-07-21); pares-radix git history\n`20acb73`/`0eb0734` (prior attempted-then-reverted shim removal, evidence of real API drift, not
-just process laziness); C-NOSTUB-001.
+`packages/design-dojo/package.json` (shim description, stale removal criterion); standalone design-dojo repo git HEAD `4fa2153` (2026-07-21); pares-radix git history `20acb73`/`0eb0734` (prior attempted-then-reverted shim removal, evidence of real API drift, not just process laziness); C-NOSTUB-001.

--- a/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
+++ b/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
@@ -25,11 +25,7 @@ The shim's `src/index.ts` re-exports most components from the npm package and th
 `Dialog`, `DashboardGrid`, `FirstRunWizard`, `Heading`, `TextArea`, `Link`, `CodeBlock`, `Canvas2D`,
 `PluginContentArea`, `DataGrid`, `SchemaForm`, `GraphView`.
 
-<<<<<<< HEAD
 Meanwhile, the **standalone `@plures/design-dojo` source repo** (separate repository; independently versioned; currently at package.json `1.55.34`, git HEAD `4fa2153`, 2026-07-21) is alive, organized (`src/lib/{primitives,layout,overlays,data,surfaces,feedback,app,...}`), and has
-=======
-Meanwhile, the **standalone `@plures/design-dojo` source repo** (`C:\Projects\design-dojo`,\nindependently versioned, currently at package.json `1.55.34`, git HEAD `4fa2153`, 2026-07-21) is\nalive, organized (`src/lib/{primitives,layout,overlays,data,surfaces,feedback,app,...}`), and has
->>>>>>> origin/main
 **361 source files** vs. the vendor shim's flat 24.
 
 ### Actual divergence found (not assumed)
@@ -120,16 +116,8 @@ strategy is reviewed and a follow-up implementation ADR/PR is accepted.
   allows.
 - Any component that exists in both places must have **at most one authoritative source**: the
   standalone repo. Vendored copies are transitional bridges, never permanent forks.
-<<<<<<< HEAD
 - `DataGrid` and `SchemaForm` are reclassified as **upstream contributions owed**, not vendor drift — they get a dedicated small PR into the standalone design-dojo repository (own review, own semver bump), not a copy-paste reconciliation.
 - Release cadence: design-dojo standalone repo cuts a release for every component it gains from pares-radix contributions or fixes drift-discovered bugs; pares-radix bumps its `@plures/design-dojo-npm` pin promptly after (target: within one sprint) rather than papering over the gap with a local shim edit.
-=======
-- `DataGrid` and `SchemaForm` are reclassified as **upstream contributions owed**, not vendor
-  drift — they get a dedicated small PR into `C:\Projects\design-dojo` (own review, own semver\n  bump), not a copy-paste reconciliation.\n- Release cadence: design-dojo standalone repo cuts a release for every component it gains from
-  pares-radix contributions or fixes drift-discovered bugs; pares-radix bumps its
-  `@plures/design-dojo-npm` pin promptly after (target: within one sprint) rather than papering
-  over the gap with a local shim edit.
->>>>>>> origin/main
 
 ### 2.2 Migration approach (for follow-up implementation PR — not this ADR)
 1. **Triage per component** (not bulk): for each of the 13 drifted components, determine whether
@@ -205,9 +193,4 @@ turnaround is fast enough to not be a bigger friction than the shim was.
 ## 6. References
 ADR-0024 §5 (design-dojo canonical UI home, subpath consumption pattern), ADR-0032 (GraphView,
 most recent addition — smallest drift, proof that fast upstream sync prevents divergence);
-<<<<<<< HEAD
 `packages/design-dojo/package.json` (shim description, stale removal criterion); standalone design-dojo repo git HEAD `4fa2153` (2026-07-21); pares-radix git history `20acb73`/`0eb0734` (prior attempted-then-reverted shim removal, evidence of real API drift, not just process laziness); C-NOSTUB-001.
-=======
-`C:\Projects\pares-radix\packages\design-dojo\package.json` (shim description, stale removal\ncriterion); `C:\Projects\design-dojo` git HEAD `4fa2153` (2026-07-21); pares-radix git history\n`20acb73`/`0eb0734` (prior attempted-then-reverted shim removal, evidence of real API drift, not
-just process laziness); C-NOSTUB-001.
->>>>>>> origin/main

--- a/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
+++ b/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
@@ -116,11 +116,8 @@ strategy is reviewed and a follow-up implementation ADR/PR is accepted.
   allows.
 - Any component that exists in both places must have **at most one authoritative source**: the
   standalone repo. Vendored copies are transitional bridges, never permanent forks.
-- `DataGrid` and `SchemaForm` are reclassified as **upstream contributions owed**, not vendor
-  drift — they get a dedicated small PR into `C:\Projects\design-dojo` (own review, own semver\n  bump), not a copy-paste reconciliation.\n- Release cadence: design-dojo standalone repo cuts a release for every component it gains from
-  pares-radix contributions or fixes drift-discovered bugs; pares-radix bumps its
-  `@plures/design-dojo-npm` pin promptly after (target: within one sprint) rather than papering
-  over the gap with a local shim edit.
+- `DataGrid` and `SchemaForm` are reclassified as **upstream contributions owed**, not vendor drift — they get a dedicated small PR into the standalone design-dojo repository (own review, own semver bump), not a copy-paste reconciliation.
+- Release cadence: design-dojo standalone repo cuts a release for every component it gains from pares-radix contributions or fixes drift-discovered bugs; pares-radix bumps its `@plures/design-dojo-npm` pin promptly after (target: within one sprint) rather than papering over the gap with a local shim edit.
 
 ### 2.2 Migration approach (for follow-up implementation PR — not this ADR)
 1. **Triage per component** (not bulk): for each of the 13 drifted components, determine whether

--- a/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
+++ b/.praxis/decisions/ADR-0035-design-dojo-vendored-copy-drift.md
@@ -25,7 +25,7 @@ The shim's `src/index.ts` re-exports most components from the npm package and th
 `Dialog`, `DashboardGrid`, `FirstRunWizard`, `Heading`, `TextArea`, `Link`, `CodeBlock`, `Canvas2D`,
 `PluginContentArea`, `DataGrid`, `SchemaForm`, `GraphView`.
 
-Meanwhile, the **standalone `@plures/design-dojo` source repo** (`C:\Projects\design-dojo`,\nindependently versioned, currently at package.json `1.55.34`, git HEAD `4fa2153`, 2026-07-21) is\nalive, organized (`src/lib/{primitives,layout,overlays,data,surfaces,feedback,app,...}`), and has
+Meanwhile, the **standalone `@plures/design-dojo` source repo** (separate repository; independently versioned; currently at package.json `1.55.34`, git HEAD `4fa2153`, 2026-07-21) is alive, organized (`src/lib/{primitives,layout,overlays,data,surfaces,feedback,app,...}`), and has
 **361 source files** vs. the vendor shim's flat 24.
 
 ### Actual divergence found (not assumed)

--- a/.praxis/decisions/ADR-0036-praxisbot-native-task-dashboard.md
+++ b/.praxis/decisions/ADR-0036-praxisbot-native-task-dashboard.md
@@ -1,0 +1,187 @@
+# ADR-0036: praxisbot Native Task Dashboard (Design)
+
+- **Status:** Proposed (design-only — no implementation this pass)
+- **Date:** 2026-07-23
+- **Deciders:** praxisbot maintainers (kbristol)
+- **Epic:** `praxisbot:px-native-task-dashboard` (P2)
+- **Relates:** ADR-0027 (dev-lifecycle spine wiring), ADR-0034 (task-dispatch verb resolution)
+- **Invariants:** C-PLURES-003 (all durable state in PluresDB, no ad-hoc state),
+  C-DEV-001 (decisions in `.px`, side effects in Rust/exec), C-NOSTUB-001 (no hollow
+  deliverables), C-DRIFT-001 (derived artifacts never hand-edited)
+
+## Context
+
+praxisbot currently tracks work across **four independent, unreconciled PluresDB
+namespaces**, each with its own `.px` source of truth and none of them presented
+together:
+
+| Namespace                | Source `.px`                                   | Status vocabulary                                                                 | Purpose                                   |
+|--------------------------|-------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------|
+| `task:{id}`               | `praxis/procedures/task-system.px` + `task-management.px` | `pending, complete`                                                          | conscious agent commitments (task tools)   |
+| `worktask:task:{task_id}` | `praxis/procedures/worktask.px`                | `planned, active, in_review, merging, done, abandoned`                              | git-worktree feature/bugfix/chore execution|
+| `epic:registry:{id}`      | `development-guide/procedures/epic-registry.px`| `queued, in_progress, blocked, awaiting_approval, orphaned, done, abandoned`         | durable anti-orphan epic ledger            |
+| `epic:gate:{epic_id}:{stage}` | `development-guide/procedures/epic-orchestration.px` | `open, passed, failed` (gate) / `analyze..land` (stage)                | per-stage evidence-gated governance        |
+
+There is no single place to see "what is praxisbot working on right now, across all
+four." A human (or the orchestrator) must query each namespace separately, and there is
+no live, low-token surface — the existing `dashboard-stream.px` unifies ADO + resource
+allocation + epic milestones, but does not aggregate task/worktask/gate detail, and is
+scoped to the *human-in-Telegram* surface, not a general task view.
+
+Per **C-PLURES-003**, any new dashboard state (render cache, cursor, last-rendered
+counts) must live in PluresDB nodes — never a local file, in-memory cache, or ad-hoc
+JSON ledger duplicating what `dashboard-stream.px` and `epic-registry.px` already prove
+out.
+
+This ADR is **design-only**: it fixes the entity/procedure shapes, the read boundary,
+and the presentation contract so implementation can proceed as a single, reviewable
+`.px`-first slice, without further architecture debate. **No `.px` files, Rust handlers,
+or UI components are added in this pass.**
+
+## Decision
+
+### 1. The dashboard is a read-only aggregation view, never a second ledger
+
+The dashboard **does not own task state**. It never writes to `task:*`,
+`worktask:task:*`, `epic:registry:*`, or `epic:gate:*`. It only *reads* those four
+namespaces (via PluresDB prefix scans, same primitive `epic-registry.px`'s heartbeat
+sweep already uses) and writes exactly one small derived-cache namespace of its own:
+
+```
+dashboard:tasks:{surface_id}      — render cache (message id, counts, frozen flag,
+                                     last_rendered_at) for ONE presentation surface
+```
+
+This mirrors the existing `dashboard:state:` entity in `dashboard-stream.px` — same
+shape, scoped to tasks. No new persistence mechanism is invented (C-PLURES-003:
+"durable nodes ARE the state," not a parallel file/cache).
+
+### 2. Status vocabulary is translated at the read boundary, never duplicated in `.px`
+
+Per **ADR-0034 §2** ("status vocabulary translation happens at the boundary, not
+duplicated in `.px`"), the four namespaces' incompatible status enums are folded into
+one **presentation-only** tri-state at the Rust/exec aggregation boundary — never as
+parallel `when` branches copy-pasted across `.px` files:
+
+| Unified `dashboard_status` | `task:*` (`pending/complete`) | `worktask:*` | `epic:registry:*` | `epic:gate:*` |
+|---|---|---|---|---|
+| `open`     | `pending`   | `planned, active`              | `queued, in_progress`            | `open`   |
+| `waiting`  | —           | `in_review, merging`           | `blocked, awaiting_approval`     | —        |
+| `done`     | `complete`  | `done`                          | `done`                            | `passed` |
+| `stopped`  | —           | `abandoned`                     | `orphaned, abandoned`            | `failed` |
+
+This table is the **single source of truth** for the mapping; the future
+`dashboard_task_render` procedure and its Rust action handler both consult it — it is
+never re-derived independently on either side (drift class this ADR explicitly closes
+off, parity with ADR-0034's `Open`/`pending` mismatch postmortem).
+
+### 3. One procedure file, following the proven zero-token tick pattern
+
+A new `praxis/procedures/task-dashboard.px` (future implementation slice) will declare:
+
+- **entity `task_dashboard_view`** (`prefix: "dashboard:tasks:"`) — `surface_id`,
+  `message_id` (or `route_id` for a non-chat surface), `frozen`, `created_at`,
+  `rendered_at`, `open_count`, `waiting_count`, `done_count`, `stopped_count`.
+- **procedure `task_dashboard_tick`** — `trigger: periodic`, `side_effect: exec`,
+  `actor: scripts/task-dashboard-tick.ps1`, identical shape to `dashboard_tick`
+  (`dashboard-stream.px`): the actor performs the four prefix reads, applies the
+  status-translation table, edits the surface in place. **Zero agent tokens per
+  redraw** — same `dashboard_tick_is_zero_token` constraint class applies verbatim,
+  scoped to this procedure name.
+- **procedure `task_dashboard_get`** — `trigger: on_write`, a synchronous **read-only**
+  command (`task:cmd:dashboard:get`) for on-demand "/tasks" style queries — same
+  aggregation logic as the tick, but returns the payload directly instead of editing a
+  live surface. No PluresDB write beyond the request/response envelope pattern already
+  used by `list_feature`/`get_feature` in `worktask.px`.
+- **constraint `task_dashboard_never_writes_source_namespaces`** — `severity: error`;
+  the dashboard's own procedures may only `write_state` under `dashboard:tasks:*`, never
+  under `task:*`, `worktask:*`, or `epic:*`. This is the structural guarantee that a
+  "dashboard" cannot become a fifth, drifting ledger.
+- **constraint `task_dashboard_tick_is_zero_token`** and
+  **`task_dashboard_edits_in_place`** — copied in shape from `dashboard-stream.px`
+  (`dashboard_tick_is_zero_token` / `dashboard_edits_in_place`), scoped to
+  `task_dashboard_tick`.
+
+### 4. Presentation surface: reuse the existing pinned-message pattern, don't invent a UI shell
+
+For this pass, the **presentation surface is the same Telegram pinned-message pattern**
+`dashboard-stream.px` already ships (`editMessageText`, edit-in-place, freeze-on-
+milestone). A dedicated Praxis canvas/Svelte panel (per `praxis/ui/DESIGN-ui-schema-
+engine.md`'s `DashboardGrid`) is an **explicit follow-on**, not required to ship value:
+the chat surface is the one praxisbot users already look at, and it needs zero new
+rendering infrastructure — only a new aggregation actor. Building a native canvas
+surface before the aggregation/translation boundary is proven would risk the same
+"per-UI authoring code" cost the UI-schema-engine ADR explicitly guards against
+building prematurely (§8 non-goals: no new surface without a proven need).
+
+**Recommended v1 shipping order (for the implementation epic, not this pass):**
+1. `task-dashboard.px` entity + status-translation table + `task_dashboard_get`
+   (on-demand, no scheduler yet) — smallest reviewable, testable slice.
+2. `task_dashboard_tick` (periodic, zero-token) wired to a second pinned Telegram
+   message (separate from `dashboard-stream.px`'s existing ADO/epic surface, to avoid
+   overloading one message with unrelated content).
+3. (Deferred, separate ADR if pursued) a canvas `/tasks` route using
+   `DashboardGrid`/`Table` schema kinds already defined in `DESIGN-ui-schema-engine.md`.
+
+## Consequences
+
+- No new state store, cache file, or in-memory structure is introduced — praxisbot's
+  task visibility becomes a **derived, PluresDB-backed view** over data that already
+  exists, satisfying C-PLURES-003 by construction (the constraint this whole design
+  answers to).
+- The status-translation table is written once and consulted by both `.px` and its Rust
+  action handler, closing off the exact drift class ADR-0034 documents as a real
+  production regression (`Open` vs `pending` mismatch).
+- A hard `never_writes_source_namespaces` constraint makes "the dashboard quietly
+  becomes a second ledger" a build-time-checkable violation, not a matter of code
+  review discipline.
+- Deferring the canvas UI keeps the first implementation slice small and testable
+  end-to-end (aggregate → translate → render one message) before any new rendering
+  surface is justified.
+
+## Non-goals (this ADR, and v1 if implemented)
+
+- No new persistent task-tracking namespace. This is a **view**, not a fifth ledger.
+- No canvas/Svelte UI component work in v1 — chat-surface only.
+- No change to `task-system.px`, `worktask.px`, `epic-registry.px`, or
+  `epic-orchestration.px` write paths. The dashboard is additive and read-only against
+  them.
+- No implementation in this pass — this ADR is design-only per the epic's DESIGN stage
+  gate.
+
+## Open decisions (need kbristol before implementation)
+
+1. Separate pinned Telegram message for tasks, or a new section appended to the
+   existing `dashboard-stream.px` unified message? *Leaning separate* (task detail is
+   noisier / higher-churn than the epic/ADO summary; a single message risks becoming
+   too dense — see `dashboard-stream.px`'s own rationale for why it replaced multiple
+   ad-hoc pings with ONE surface, which argues for care before adding a second).
+2. Tick interval for `task_dashboard_tick` — reuse 300000ms (5 min, `dashboard_tick`'s
+   interval) or a tighter interval given tasks churn faster than epics? *Leaning
+   reuse 300000ms for v1, revisit with real usage data.*
+3. Does `task_dashboard_get` need pagination/filtering (by status, by repo) for v1, or
+   is an unfiltered snapshot sufficient given current task volumes? *Leaning
+   unfiltered v1, add filters only when a real volume problem appears (C-NOSTUB-001 —
+   don't build filtering nobody has hit yet).*
+
+## Verification (for the implementation pass, not this one)
+
+- `node scripts/validate-px-grammar.cjs` against the new `task-dashboard.px` (dev-guide
+  dialect subset per the `px-authoring` skill).
+- Unit test the status-translation table exhaustively (all enum values from all four
+  source namespaces map to exactly one `dashboard_status`).
+- Constraint test: attempting a `write_state` under `task:*`/`worktask:*`/`epic:*` from
+  `task-dashboard.px` procedures must fail `task_dashboard_never_writes_source_namespaces`.
+- Loop proof: create a task in each of the four namespaces → tick fires → one message
+  edited in place, all four represented with correct unified status.
+
+## References
+
+- `praxis/procedures/task-system.px`, `task-management.px`, `task-steering.px`,
+  `task-evaluation.px`
+- `praxis/procedures/worktask.px`
+- `development-guide/procedures/epic-registry.px`, `epic-orchestration.px`
+- `development-guide/procedures/dashboard-stream.px` (proven zero-token tick pattern)
+- `praxis/ui/DESIGN-ui-schema-engine.md` (deferred canvas surface, `DashboardGrid` kind)
+- ADR-0027 (dev-lifecycle spine wiring), ADR-0034 (task-dispatch verb resolution —
+  status-vocabulary-at-the-boundary precedent)

--- a/docs/adr/ADR-0018-radix-runtime-as-service.md
+++ b/docs/adr/ADR-0018-radix-runtime-as-service.md
@@ -99,8 +99,8 @@ forking runtime logic.
 │  ┌─────────────┐   ┌──────────────────┐   ┌────────────────┐ │
 │  │ Automation   │   │  Scheduler loop   │   │ Health/Ready   │ │
 │  │ HTTP surface │   │  (tokio interval) │   │ endpoint       │ │
-│  │ (axum, 127.  │   │  every N sec:     │   │ GET /healthz   │ │
-│  │ 0.0.1 default)│  │   poll_events()   │   │ GET /readyz    │ │
+│  │ (axum, bind:  │   │  every N sec:     │   │ GET /healthz   │ │
+│  │ 127.0.0.1)    │  │   poll_events()   │   │ GET /readyz    │ │
 │  │ POST /events │   │   process_due_    │   │ (SystemHealth) │ │
 │  │ GET/POST/DEL │   │     timers()      │   └────────────────┘ │
 │  │  /timers     │   └──────────────────┘                     │

--- a/docs/adr/ADR-0018-radix-runtime-as-service.md
+++ b/docs/adr/ADR-0018-radix-runtime-as-service.md
@@ -104,7 +104,7 @@ forking runtime logic.
 │  │ POST /events │   │   process_due_    │   │ (SystemHealth) │ │
 │  │ GET/POST/DEL │   │     timers()      │   └────────────────┘ │
 │  │  /timers     │   └──────────────────┘                     │
-│  │ POST /procs/ │                                            │
+│  │ POST /procedures/ │                                            │
 │  │   {name}/run │                                            │
 │  └─────────────┘                                             │
 │           │                    │                    │        │

--- a/docs/adr/ADR-0018-radix-runtime-as-service.md
+++ b/docs/adr/ADR-0018-radix-runtime-as-service.md
@@ -1,0 +1,274 @@
+# ADR-0018: Radix Runtime as a Standalone Service
+
+- Status: Proposed (design only — no code in this ADR)
+- Date: 2026-07-23
+- Epic: `pares-radix:runtime-as-service`
+- Stage: DESIGN (per `pares-radix-dev-lifecycle` staged lifecycle: analyze → **design** → fix → test → deploy → verify)
+
+## 1. Context
+
+### 1.1 What exists today
+
+pares-radix currently ships as a **Tauri desktop app** (`src-tauri/`, workspace
+member `src-tauri`). The cognition/runtime logic lives in `crates/radix-core`
+(a library, no `fn main`), and is driven entirely by the Tauri process
+lifecycle — there is no standalone service binary, no HTTP/health endpoint,
+and no headless entrypoint anywhere in the workspace (`crates/*/src/*.rs`
+audited: zero `fn main` outside `src-tauri/src/main.rs`, zero `tokio::main`,
+zero long-running `loop {}` driving events).
+
+Event/timer plumbing already exists **as a library**, one layer down, in
+`pluresdb-procedures` (consumed via the `pluresdb` git dependency, pinned by
+rev in `crates/radix-core/Cargo.toml`, `crates/agenda/Cargo.toml`,
+`crates/audit/Cargo.toml`, `crates/praxis/Cargo.toml`):
+
+- **`AgensEvent`** (`pluresdb-procedures/src/agens.rs`): 8 event variants
+  (`Message`, `Timer`, `StateChange`, `ModelResponse`, `ToolResult`,
+  `PraxisAnalysisReady`, `PraxisAnalysisFailed`, `PraxisGuidanceUpdated`).
+  Persisted as CRDT nodes (`agens:command` type), so events are durable and
+  sync across peers via Hyperswarm. Idempotent emission (`emit_praxis_event`)
+  uses deterministic node keys (`praxis:cmd:{id}`) for the three Praxis
+  lifecycle events.
+- **`TimerTable`**: schedule/cancel/list interval, cron, and one-shot timers,
+  persisted as `agens:timer` CRDT nodes. Cron via the `cron` crate (5-field
+  normalized to 6-field). `due_timers(now)` is **O(n)** over the whole store
+  (documented limitation — no timer-specific index/prefix).
+- **`AgensRuntime`**: procedure handler registry (`register_procedure` /
+  `execute_procedure`), event emission/polling (`emit_event` /
+  `poll_events(since)` — also O(n), timestamp-cursor based, **at-least-once**,
+  consumers must dedupe on logical id), and `process_due_timers(now)` which
+  fires due timers through the `"timer"` handler and reschedules them.
+
+**The gap:** nothing in the pares-radix workspace *calls*
+`process_due_timers` / `poll_events` on a cadence. There is no driver loop,
+no scheduler task, no health surface, and no way to run this outside the
+Tauri desktop shell (e.g., on a server, in CI, or as a background daemon on a
+headless box). `crates/radix-core/src/health.rs` defines `SystemHealth` /
+`HealthReport` types but they're an in-process report struct with no HTTP
+exposure — nothing polls them externally today.
+
+### 1.2 Why this matters now
+
+Running only inside a Tauri desktop process means:
+- The agent is only "alive" while a human has the desktop app open.
+- No way to host pares-radix on a server/VM/container for 24/7 automation
+  (crons, Telegram bot responsiveness, timer-driven procedures).
+- No external health check surface for monitoring (the existing
+  `praxisbot-deployment-drift` / `release-pipeline-health` crons referenced
+  in the `pares-radix-dev-lifecycle` skill watch *releases*, not a running
+  service).
+- `TimerTable`/`AgensEvent` — real, tested infrastructure — sits unused for
+  its primary purpose (driving scheduled/reactive procedures) because there's
+  no host process to run the poll loop.
+
+## 2. Decision (proposed)
+
+Introduce a new **`pares-radix-svc`** binary crate (workspace member) that
+hosts the existing `radix-core` runtime headlessly, with:
+
+1. A **lifecycle-managed run loop** driving `AgensRuntime::poll_events` +
+   `process_due_timers` on a fixed tick.
+2. **Persistence exclusively through PluresDB** (no new storage layer — reuse
+   `CrdtStore` opened from a configurable on-disk path, matching how
+   `radix-core`/Tauri already persist state today via `pluresdb_bridge.rs` /
+   `state.rs`).
+3. An **automation interface** (HTTP, loopback-bound by default) exposing:
+   health, readiness, event emission, timer CRUD, and procedure invocation —
+   a thin REST wrapper over the existing `AgensRuntime` / `PluresDbBridge`
+   APIs, not a rewrite of them.
+4. A **health check** endpoint built directly on the existing
+   `crates/radix-core/src/health.rs` `SystemHealth`/`HealthReport` types
+   (reuse, don't duplicate).
+5. **Local QA** harness: a scriptable smoke-test path (`cargo run --bin
+   pares-radix-svc -- --once` style dry-run, plus an integration test crate)
+   that exercises the full loop against a temp `CrdtStore` without needing
+   Tauri, Hyperswarm peers, or a live model backend.
+
+This keeps `radix-core` as the shared library (Tauri desktop **and** the new
+service both depend on it) and adds one new thin binary crate rather than
+forking runtime logic.
+
+## 3. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ pares-radix-svc (new binary crate)                           │
+│                                                               │
+│  main() -> ServiceLifecycle::run()                           │
+│                                                               │
+│  ┌─────────────┐   ┌──────────────────┐   ┌────────────────┐ │
+│  │ Automation   │   │  Scheduler loop   │   │ Health/Ready   │ │
+│  │ HTTP surface │   │  (tokio interval) │   │ endpoint       │ │
+│  │ (axum, 127.  │   │  every N sec:     │   │ GET /healthz   │ │
+│  │ 0.0.1 default)│  │   poll_events()   │   │ GET /readyz    │ │
+│  │ POST /events │   │   process_due_    │   │ (SystemHealth) │ │
+│  │ GET/POST/DEL │   │     timers()      │   └────────────────┘ │
+│  │  /timers     │   └──────────────────┘                     │
+│  │ POST /procs/ │                                            │
+│  │   {name}/run │                                            │
+│  └─────────────┘                                             │
+│           │                    │                    │        │
+│           └────────────────────┴────────────────────┘        │
+│                             │                                │
+│                    AgensRuntime<'_>  (existing, unmodified)  │
+│                    PluresDbBridge     (existing, unmodified) │
+│                             │                                │
+└─────────────────────────────┼────────────────────────────────┘
+                              ▼
+                    CrdtStore (PluresDB, on-disk)
+                    -- SAME store path Tauri app uses when
+                       PARES_RADIX_DATA_DIR is shared, or a
+                       dedicated service data dir otherwise --
+```
+
+Key point: **no new persistence layer**. The service opens the same
+`CrdtStore` type via the same `pluresdb` crate already vendored. If run
+side-by-side with the desktop app against the *same* store path, CRDT
+merge semantics (already relied on for Hyperswarm multi-peer sync) make
+that safe by construction — the service is just another "actor" writing to
+the store, exactly like a second desktop peer would be.
+
+### 3.1 Lifecycle states
+
+Explicit state machine, mirroring the ADR-0017 channel-agnostic pattern and
+the `pares-radix-dev-lifecycle` skill's own staged/gated philosophy:
+
+```
+Starting -> Ready -> Running -> Draining -> Stopped
+              │                     ▲
+              └──────── Degraded ───┘  (health check fails, keep serving
+                                        but readyz=503; do not crash-loop)
+```
+
+- **Starting**: open `CrdtStore` at configured path, construct
+  `AgensRuntime`, register procedure handlers (reuse
+  `radix-core::procedures::load_default_procedures` + any custom
+  registrations), bind HTTP listener. Failure here → process exits non-zero
+  (fail fast, let the process supervisor — systemd/Windows service/Docker —
+  restart per its own backoff policy; the service does **not** implement its
+  own crash-loop backoff).
+- **Ready**: HTTP surface up, `/healthz` returns 200 but `/readyz` gates on
+  first successful scheduler tick (avoids serving traffic before the
+  first timer/event pass proves the store is reachable).
+- **Running**: steady-state — scheduler tick + HTTP requests interleaved on
+  the tokio runtime.
+- **Degraded**: a scheduler tick errors (e.g., store I/O failure). Log +
+  record `HealthReport` via `SystemHealth::record`, keep retrying on the next
+  tick (bounded exponential backoff capped at e.g. 30s), `/readyz` flips to
+  503 until a tick succeeds again. Never panics the process for a transient
+  store hiccup — that decision is deliberate: a service that crash-loops on
+  every blip is worse than one that reports itself unready.
+- **Draining**: on SIGTERM/Ctrl-C, stop accepting new scheduler ticks and new
+  mutating HTTP requests (still serve `/healthz`), finish any in-flight
+  procedure execution up to a grace deadline (default 10s, configurable),
+  then flush/close the store cleanly.
+- **Stopped**: process exit. Exit code 0 for a clean drain, non-zero for a
+  Starting-phase failure, so it composes with standard service supervisors.
+
+## 4. Automation interface (design, not final API contract)
+
+Local-first, loopback-bound HTTP (default `127.0.0.1:8730` — new port,
+picked to avoid the existing `pares-radix` ecosystem's known ports; final
+port TBD at implementation time and should be config/env driven, not
+hardcoded, e.g. `RADIX_SVC_BIND_ADDR`). No auth by default when bound to
+loopback; bearer-token auth required when `RADIX_SVC_BIND_ADDR` is
+non-loopback (fail closed: refuse to bind to `0.0.0.0`/non-loopback without
+a configured token — this is a hard gate, not a warning).
+
+| Endpoint | Method | Purpose | Backing call |
+|---|---|---|---|
+| `/healthz` | GET | Liveness — process is up | `SystemHealth::report()` |
+| `/readyz` | GET | Readiness — store reachable, first tick done | scheduler tick state |
+| `/events` | POST | Emit an `AgensEvent` (idempotent variants use `emit_praxis_event`) | `AgensRuntime::emit_event` / `emit_praxis_event` |
+| `/events` | GET | Poll events since a cursor (for external orchestrators) | `AgensRuntime::poll_events` |
+| `/timers` | GET | List scheduled timers | `TimerTable::list` |
+| `/timers` | POST | Schedule interval/cron/once timer | `TimerTable::schedule_*` |
+| `/timers/{id}` | DELETE | Cancel a timer | `TimerTable::cancel` |
+| `/procedures/{name}/run` | POST | Manually trigger a named procedure (bypasses timer/event dispatch, for QA/ops) | `AgensRuntime::execute_procedure` or `PluresDbBridge::run_procedure` |
+
+This is a **thin transport wrapper**: every handler is a direct pass-through
+to an existing `radix-core` / `pluresdb-procedures` API. No new business
+logic in the HTTP layer — keeps the "logic in `.px`/library, IO at the edge"
+principle from the dev-lifecycle skill.
+
+## 5. Persistence through PluresDB (explicit, per requirement)
+
+- No new database, no new schema layer. `CrdtStore::open(path)` (existing
+  API surface used by `pluresdb_bridge.rs` today) is the single source of
+  truth.
+- Service config (bind address, tick interval, data dir, procedure toggles)
+  is **not** stored in PluresDB — it's process config (env/CLI/file), since
+  it must be readable before the store is even open. Runtime-mutable state
+  (timers, events, praxis lifecycle events, `SetupConfig`-equivalent
+  settings) stays in PluresDB via the existing `StateStore`/`TimerTable`
+  patterns already in `radix-core`/`pluresdb-procedures`.
+- Multi-instance safety relies on existing CRDT merge + Hyperswarm sync
+  semantics — no new distributed-locking design needed for a first version.
+  (Explicitly out of scope: leader election for the scheduler if multiple
+  service instances point at synced stores — call out as a **known
+  limitation**, see §7.)
+
+## 6. Local QA plan (no code yet — plan only)
+
+1. **Unit-level**: existing `pluresdb-procedures` unit tests already cover
+   `TimerTable`/`AgensRuntime` correctness — no duplication needed.
+2. **Service integration test crate** (`pares-radix-svc/tests/`):
+   - Spin up the service against a `tempdir()`-backed `CrdtStore`, bind to
+     `127.0.0.1:0` (OS-assigned port).
+   - Assert `/healthz` returns 200 immediately, `/readyz` flips to 200 only
+     after the first tick.
+   - POST a one-shot timer with `run_at = now`, wait one tick interval,
+     assert the registered handler fired exactly once (dedupe check via
+     logical id) and `/timers` shows it inactive afterward.
+   - POST an `AgensEvent::Message`, GET `/events?since=...`, assert it comes
+     back.
+   - Send SIGTERM-equivalent (drop the server task / call shutdown), assert
+     graceful drain: in-flight procedure completes, `/healthz` stops
+     responding only after drain deadline.
+3. **Manual smoke script** (`scripts/smoke-radix-svc.mjs` or `.ps1`, TBD at
+   implementation): start service, curl the endpoints above, confirm exit
+   code semantics on Ctrl-C.
+4. **CI hook**: add a `cargo test -p pares-radix-svc` job to the existing
+   GitHub Actions workflow (`.github/workflows/`), gated the same way other
+   crates are — this becomes part of the `test` stage in the dev-lifecycle
+   loop, not a one-off.
+
+None of this requires Hyperswarm peers, a live LLM backend, or the Tauri
+shell — that's the point: the service must be independently QA-able.
+
+## 7. Known limitations / explicitly out of scope for v1
+
+- No leader election across multiple service replicas sharing a synced
+  store (single-instance-per-store assumption for v1; document, don't
+  solve).
+- `poll_events`/`due_timers` remain O(n) over the whole CRDT store — fine at
+  current scale, called out as a follow-up ADR trigger if store size grows
+  (the existing doc comments already flag this; the service design inherits
+  the limitation rather than papering over it).
+- Automation HTTP interface has no schema versioning story yet — v1 ships
+  unversioned (`/events`, not `/v1/events`); revisit before any external
+  (non-loopback) consumer depends on it.
+- Auth model is bearer-token-only, no RBAC/scopes in v1.
+
+## 8. Migration / rollout
+
+- Additive: new `pares-radix-svc` workspace member, zero changes to existing
+  `src-tauri` or `radix-core` public API required to ship v1 (both consume
+  the same crates unmodified).
+- Desktop app is unaffected; can continue running standalone or pointed at
+  the same store as the service.
+- Follow-on epics (post-DESIGN): FIX (implement `pares-radix-svc` per this
+  ADR) → TEST (crate above) → DEPLOY (systemd unit / Docker image / Windows
+  service wrapper — TBD which target first) → VERIFY (close the loop per
+  `pares-radix-dev-lifecycle`, mandatory, cannot be skipped).
+
+## 9. Open questions for follow-up FIX stage
+
+1. Which process supervisor is the deploy target first — systemd (Linux),
+   Windows Service, or Docker/container orchestrator? Affects signal
+   handling details in §3.1.
+2. Should `/procedures/{name}/run` be gated behind an explicit "QA/debug
+   only" flag in production, given it bypasses normal event/timer dispatch?
+3. Shared-store-with-desktop-app scenario: do we want a documented warning
+   in the desktop UI when the service is also running against the same data
+   dir, or is silent CRDT-merge coexistence sufficient?

--- a/docs/adr/ADR-0019-multiplatform-installer-packaging.md
+++ b/docs/adr/ADR-0019-multiplatform-installer-packaging.md
@@ -10,11 +10,7 @@
 ## Context
 
 pares-radix is a **svelte-Tauri** application (GUI + Svelte-TUI + svelte-ratatui + MCP,
-<<<<<<< HEAD
 no traditional CLI — see `development-guide/design/PLURES-FOUNDATION.md` → "svelte-Tauri Application Template").
-=======
-no traditional CLI — see `PLURES-FOUNDATION.md` → "svelte-Tauri Application Template").
->>>>>>> origin/main
 ROADMAP Phase 4 calls for "Multi-arch packaging (Linux, Windows, macOS; Android/iOS via
 Tauri where supported)". Today:
 

--- a/docs/adr/ADR-0019-multiplatform-installer-packaging.md
+++ b/docs/adr/ADR-0019-multiplatform-installer-packaging.md
@@ -1,0 +1,198 @@
+# ADR-0019: Multiplatform Installer Packaging (Design Stage)
+
+- Status: Proposed (design only — no implementation in this change)
+- Date: 2026-07-23
+- Supersedes: none
+- Related: ROADMAP.md Phase 4 ("Multi-arch packaging"), `design/TAURI-BEST-PRACTICES.md`
+  (development-guide), `.github/workflows/release.yml`, `plures/.github` reusable
+  `release-reusable.yml`
+
+## Context
+
+pares-radix is a **svelte-Tauri** application (GUI + Svelte-TUI + svelte-ratatui + MCP,
+no traditional CLI — see `PLURES-FOUNDATION.md` → "svelte-Tauri Application Template").
+ROADMAP Phase 4 calls for "Multi-arch packaging (Linux, Windows, macOS; Android/iOS via
+Tauri where supported)". Today:
+
+- `src-tauri/` is scaffolded (`tauri.conf.json`, `capabilities/`, icons for desktop +
+  Android) and implements the frontend bridge contract (`navigate`,
+  `get_window_state`, `set_tray_menu`, `save_window_state` + events).
+- The Windows installer (NSIS + MSI) has been **built locally** but is not yet wired
+  into CI (ROADMAP "Current State").
+- `.github/workflows/release.yml` delegates all version/tag/changelog/publish logic to
+  the org-shared `plures/.github/.github/workflows/release-reusable.yml`; it carries
+  **no Tauri bundle matrix today** — no per-OS build job builds/signs/publishes
+  installers.
+- No `.deb`/`.rpm`/`.AppImage`/`.dmg`/APK artifacts exist yet anywhere in the repo or
+  workflow definitions. iOS/Android `gen/` scaffolds are not present (only icon assets).
+- `design/TAURI-BEST-PRACTICES.md` (development-guide, verified 2026-06-27 against
+  v2.tauri.app) is the authoritative source for Tauri 2 packaging mechanics already
+  evaluated for this repo; this ADR is the pares-radix-local decision record that
+  consumes it and turns it into a concrete release-pipeline plan.
+
+This is a **design-stage** ADR per the dev-lifecycle/dev-guide gates: it defines the
+target/form-factor matrix, the cross-platform shell/bundling choice with evidence, and
+the CI/release implications, and enumerates real validation paths. It intentionally
+ships **no installer artifacts, no placeholder CI jobs, and no stub code** — only the
+decision record and the acceptance criteria a follow-on implementation task must meet.
+
+## Decision drivers
+
+1. **No traditional CLI, no cross-compiled bundles.** A Tauri bundle can only be built
+   on its own host OS (Tauri's bundler shells out to platform-native tooling — NSIS/
+   WiX on Windows, `hdiutil`/codesign on macOS, `dpkg`/`rpmbuild`/`appimagetool` on
+   Linux). There is no cross-compile path for installer formats themselves (Rust
+   cross-compiles; the packaging step does not).
+2. **Evented, thin Rust core** (ADR: events-not-commands, already established). The
+   packaging decision must not require adding business logic to `src-tauri`.
+3. **Even/odd release parity law** already governs the version/publish pipeline
+   (`release-reusable.yml`); installer publishing must slot into that model
+   (stable vs prerelease update feeds), not invent a second one.
+4. **Cost/complexity gating is real**: Apple and Android signing require paid
+   developer accounts, hardware/cert infrastructure, and dedicated runners. The
+   design must explicitly gate what ships unsigned vs signed, and what is
+   PR-fast vs release-only.
+
+## Cross-platform shell choice — evaluated with evidence
+
+Three shell options were evaluated for pares-radix specifically:
+
+| Option | Verdict | Evidence |
+|---|---|---|
+| **Tauri 2** (current) | **Selected — no change** | Already the scaffolded shell (`src-tauri/`, Tauri 2 crates in `Cargo.toml`, bridge contract implemented per `TAURI-BEST-PRACTICES.md`). Uses the OS webview (WebView2/WebKitGTK/WKWebView) — no bundled Chromium, smallest binary footprint of the three, matches the "svelte-Tauri Application Template" org mandate (`PLURES-FOUNDATION.md`) that **every** new Plures app scaffolds from `svelte-tauri-template`. Supports desktop (Win/macOS/Linux) + mobile (Android/iOS) from one codebase, matching ROADMAP Phase 4 scope without a rewrite. |
+| **Electron** | Rejected | Would require replacing the entire `src-tauri` Rust core and bridge (`tauri.ts` events-not-commands contract), duplicate work already done and already an org mandate violation (svelte-tauri-template is prescribed org-wide). Bundles a full Chromium+Node runtime per install (100+ MB baseline vs Tauri's OS-webview reuse) — directly opposed to the size-optimization work already landed in `TAURI-BEST-PRACTICES.md` §2. No mobile story without a second stack (Capacitor/React Native), doubling the CI matrix. No evidence of any org repo using Electron; would be a net-new, unsupported pattern. |
+| **Native per-platform (WinUI/SwiftUI/GTK)** | Rejected | 3x the UI codebase (no shared Svelte GUI/TUI), abandons the already-built Svelte GUI + `svelte-ratatui` TUI parity goal in ROADMAP Phase 4 ("Svelte GUI parity with Svelte TUI"). No shared bridge/event model; would need bespoke IPC per platform. No mobile reuse. Highest total engineering cost of the three for a single-maintainer-scale project. |
+
+**Conclusion: keep Tauri 2.** No shell migration is in scope. The remaining design
+work is entirely the **packaging matrix and release pipeline**, not the app shell.
+
+## Target / form-factor packaging matrix
+
+| Target | Bundle format(s) | Build host | Gate | Signing | Update channel |
+|---|---|---|---|---|---|
+| Windows x64 desktop | `.exe` (NSIS) + `.msi` | `windows-latest` | PR: build unsigned; Release: signed | Authenticode via Azure Trusted Signing (preferred over hardware EV — no HSM on hosted runners) | `latest.json` (even/stable) or `latest-prerelease.json` (odd) |
+| macOS (Apple Silicon) desktop | `.app` + `.dmg` | `macos-latest` | PR: ad-hoc signed (`signingIdentity: "-"`) fast build; Release: signed+notarized | Developer ID Application cert + `codesign` + `notarytool` (secrets-present gated) | same as above |
+| macOS (Intel) desktop | `.app` + `.dmg` (`--target x86_64-apple-darwin`) | `macos-latest` (cross-arch build on Apple Silicon runner) | Release only (cost: doubles Apple build time) | Same Developer ID cert as Silicon | same as above |
+| Linux x64 desktop | `.deb` + `.AppImage` (+ `.rpm` if a fedora/rhel consumer is confirmed) | `ubuntu-22.04` pinned (oldest supported glibc/webkit2gtk — **not** `ubuntu-latest`) | PR: build unsigned; Release: build + publish | No OS-level signing concept; updater `.sig` is the integrity mechanism | same as above |
+| Linux Flatpak | `org.plures.Radix` Flatpak | `ubuntu-22.04`, separate `flatpak-builder` step *after* the `.deb`/binary is built (Flatpak is not a native `bundle.targets` value) | Release only, opt-in | Flatpak repo signing (deferred — not required for first ship) | Flatpak's own update mechanism (separate from Tauri updater) |
+| NixOS | Flake package (`packages.<system>.pares-radix`) | N/A — consumer builds/runs via `nix build`/`nix run` from the flake | Release only; validated by `nix flake check` / `nix build` in CI, not a Tauri "bundle target" | N/A (Nix store hash is the integrity mechanism) | Flake input pin, not the Tauri updater |
+| Android APK/AAB | `.apk` (sideload/testing) + `.aab` (Play Store) | `ubuntu-latest` (Gradle-driven, via `src-tauri/gen/android` which does not exist yet) | **Release/tag-only**, label-gated; not on every PR (ROADMAP + `TAURI-BEST-PRACTICES.md` §7: cold Gradle+NDK build is 20–40+ min) | Java keystore (`ANDROID_KEY_ALIAS`/`ANDROID_KEY_PASSWORD`/`ANDROID_KEY_BASE64`), secrets-present gated | Play Store internal track initially; Tauri updater not typically used for mobile |
+| iOS `.ipa` | App Store / TestFlight | `macos-latest`, full Xcode (not just CLT); via `src-tauri/gen/apple` (does not exist yet) | **Release/tag-only**, label-gated | Apple Distribution cert + provisioning profile (App Store Connect API key), secrets-present gated | TestFlight / App Store review, not the Tauri updater |
+| GUI (Svelte, existing) | N/A — bundled inside every desktop/mobile target above | — | — | — | — |
+| TUI (svelte-ratatui) | Ships as part of the same binary (render-mode switch, not a separate installer) | same as desktop targets | Covered by the same builds | Same as parent binary | Same as parent binary |
+| Headless / MCP server (`packages/mcp-dev-server`) | **No installer** — stdio JSON-RPC process, distributed as an npm/pnpm package or a thin binary via `cargo install`/CI artifact, not a Tauri bundle | Existing Node/Cargo build, no new host requirement | Already covered by existing `ci.yml`; out of scope for this ADR's installer matrix (tracked separately if a standalone headless distributable is ever requested) | N/A | npm registry versioning |
+
+**PR-fast lane vs release-heavy lane** (mirrors `TAURI-BEST-PRACTICES.md` §8 matrix
+recommendation, now scoped to pares-radix's actual repo state):
+
+- **PR / CI build**: Windows (unsigned), macOS Silicon-only (ad-hoc signed), Linux
+  `ubuntu-22.04` (deb+AppImage). No LTO profile. No mobile. Fast feedback.
+- **Release / publish** (triggered by `release.yml` → `release-reusable.yml`, on
+  `main` push / `v*` tag / `promote` dispatch): full desktop matrix (both macOS
+  arches), Flatpak, size-optimized `[profile.release]`, updater artifacts +
+  `latest.json`/`latest-prerelease.json` split by even/odd minor parity (existing
+  law — no new versioning scheme introduced). Mobile (Android + iOS) gated behind a
+  release label/secrets-present check, **not** run on every release by default given
+  cost/flakiness (`TAURI-BEST-PRACTICES.md` §7 cold-build evidence).
+
+## CI / release pipeline implications
+
+1. **New workflow surface needed** (implementation task, not this ADR): a
+   `platform-release` job matrix in (or called from) `.github/workflows/release.yml`,
+   invoked *after* `release-reusable.yml` cuts the version/tag, so installers are
+   built against the tagged commit/version — avoiding a race between version bump
+   and bundle version embedding (`tauri.conf.json` version should be sourced from
+   `Cargo.toml`, itself set by the reusable pipeline).
+2. **Caching is mandatory before this is viable in CI wall-clock/cost terms**:
+   `Swatinem/rust-cache@v2` per-OS-per-target-triple, pnpm store cache, and (for the
+   deferred mobile lane) Gradle/NDK and CocoaPods/SwiftPM caches — all specified in
+   `TAURI-BEST-PRACTICES.md` §3/§7. Without these, a full matrix run cold is
+   30–60+ minutes and mobile alone can eat the default job timeout.
+3. **Secrets-present gating, not hard failures**: every signing step (Windows Azure
+   Trusted Signing, macOS cert+notarize, Android keystore, iOS Distribution cert)
+   must be conditional on the relevant secret existing, so forked/PR builds still
+   produce runnable (unsigned/ad-hoc-signed) artifacts.
+4. **`bundle.targets` must be host-scoped explicitly** in `tauri.conf.json` (or an
+   env-driven override) — `"all"` on the wrong OS silently fails or produces nothing;
+   the design specifies per-runner explicit target lists (matrix table above), not a
+   blanket `"all"`.
+5. **Flatpak and NixOS are not Tauri `bundle.targets`** — they are post-processing
+   steps consuming the already-built Linux binary/`.deb`. They must be modeled as
+   separate CI steps/jobs, not folded into the Tauri bundler invocation.
+6. **No `src-tauri/gen/android` or `gen/apple` exist yet.** Mobile packaging cannot
+   start until `pnpm tauri android init` / `pnpm tauri ios init` are run and reviewed
+   in a follow-on implementation PR — that scaffolding is itself implementation, out
+   of scope here.
+7. **Update manifest ownership**: `latest.json` / `latest-prerelease.json` generation
+   and publish must be added to the release job, mapped to the existing even=stable /
+   odd=prerelease parity law already enforced by `release-reusable.yml` — no new
+   channel concept.
+
+## Real validation paths (no placeholders)
+
+Concrete, checkable acceptance criteria for the implementation task that follows this
+ADR — each must be independently verifiable, not asserted:
+
+1. **Windows**: `pnpm tauri build` on a `windows-latest` runner produces both a
+   `.exe` (NSIS) and `.msi` under `src-tauri/target/release/bundle/`; the artifact
+   installs (`Start-Process -Wait` silent install flag) and the resulting
+   `pares-radix.exe` launches and emits `app-booted` (verified via existing Playwright
+   e2e harness pointed at the installed binary, not the dev server).
+2. **macOS**: `pnpm tauri build --target aarch64-apple-darwin` produces a `.dmg`
+   whose mounted `.app` passes `spctl --assess` (ad-hoc: expected-fail with a clear
+   "unsigned" reason on PR builds; expected-pass on signed release builds) and
+   launches headless via `open -W`.
+3. **Linux**: the `.deb` installs cleanly in a fresh `ubuntu:22.04` container
+   (`dpkg -i` + `apt-get install -f`) with no missing shared-library errors, and the
+   `.AppImage` runs directly (`chmod +x && ./*.AppImage --appimage-extract-and-run`)
+   in a container with **no** desktop environment beyond the required webkit2gtk
+   deps, proving the dependency list in `TAURI-BEST-PRACTICES.md` §8 is complete.
+4. **Flatpak**: `flatpak-builder --repo=repo build-dir org.plures.Radix.yml` succeeds
+   and `flatpak run org.plures.Radix` (from the local repo) launches the app.
+5. **NixOS**: `nix build .#pares-radix` succeeds from a clean `nix build` (no
+   pre-warmed cache) and `nix run .#pares-radix` launches the binary; `nix flake
+   check` passes.
+6. **Updater manifest**: a scripted round-trip — build two versions (N, N+1) with the
+   updater keys, publish `latest.json` for N, point a running N binary at a local
+   static server serving that manifest, and confirm the updater flow (per
+   `tauri-plugin-updater` docs) reports an update available and installs N+1 without
+   manual file surgery.
+7. **Mobile (deferred, tag/release-only)**: after `gen/android`/`gen/apple` scaffolds
+   land in a follow-on PR, validation is: `pnpm tauri android build --apk` installs
+   on an emulator/device via `adb install` and boots to the same `app-booted` event;
+   equivalent for iOS via `xcrun simctl install`/`launch` on a simulator. Not
+   required for this ADR's acceptance — captured here so the follow-on task inherits
+   a concrete bar instead of "make mobile work."
+
+None of the above are satisfied by a CI job merely *existing* or by a bundler command
+*exiting zero* with an empty output directory — each requires the artifact to actually
+install/run and be functionally probed, per the org's C-NOSTUB-001 no-stub / no-ghost-
+binary constraint already cited in `TAURI-BEST-PRACTICES.md`.
+
+## Consequences
+
+- **Positive**: single shell (Tauri) across every target keeps the GUI/TUI parity
+  goal, the events-not-commands Rust core, and the org svelte-tauri-template mandate
+  intact — zero migration risk. The matrix makes explicit what is PR-fast vs
+  release-only vs deferred, preventing an accidental "build everything on every PR"
+  cost blowup.
+- **Negative / risk**: macOS Intel doubles macOS CI time; mobile is explicitly
+  deferred (no Android/iOS scaffolds exist yet), so ROADMAP Phase 4's "Android/iOS
+  via Tauri where supported" is only partially addressed by the first
+  implementation wave — this ADR records that gap rather than papering over it with
+  a placeholder mobile job.
+- **Follow-on work** (tracked separately, NOT part of this design-only ADR):
+  1. Add the `platform-release` CI matrix (Windows/macOS/Linux desktop only) with
+     caching + secrets-gated signing.
+  2. Wire the updater manifest publish step into `release-reusable.yml` consumption.
+  3. Add the Flatpak post-build step.
+  4. Add the NixOS flake package + `nix flake check` CI job.
+  5. Scaffold `src-tauri/gen/android` + `gen/apple`, then add the tag/release-only
+     mobile jobs per the deferred validation criteria above.
+
+## References
+
+- `design/TAURI-BEST-PRACTICES.md` (development-guide repo, verified 2026-06-27)
+- `ROADMAP.md` Phase 4
+- `.github/workflows/release.yml`, `plures/.github/.github/workflows/release-reusable.yml`
+- Tauri 2 docs: https://v2.tauri.app (configuration, size, updater, signing, pipelines)

--- a/docs/adr/ADR-0019-multiplatform-installer-packaging.md
+++ b/docs/adr/ADR-0019-multiplatform-installer-packaging.md
@@ -10,7 +10,7 @@
 ## Context
 
 pares-radix is a **svelte-Tauri** application (GUI + Svelte-TUI + svelte-ratatui + MCP,
-no traditional CLI — see `PLURES-FOUNDATION.md` → "svelte-Tauri Application Template").
+no traditional CLI — see `development-guide/design/PLURES-FOUNDATION.md` → "svelte-Tauri Application Template").
 ROADMAP Phase 4 calls for "Multi-arch packaging (Linux, Windows, macOS; Android/iOS via
 Tauri where supported)". Today:
 


### PR DESCRIPTION
Epic: pares-radix:runtime-as-service. Design-only ADR proposing a thin pares-radix-svc binary crate to host the existing AgensRuntime/TimerTable headlessly (no Tauri required), with an automation HTTP surface, PluresDB-only persistence, explicit lifecycle state machine, and a local QA plan. Confirms real gap: zero fn main outside src-tauri/src/main.rs today. No code changes; FIX stage not started. Per pares-radix-dev-lifecycle staged gate.