### PR TITLE
fix(mcp-dev-server): task-handoff records use dbPut so they persist to disk

### DIFF
--- a/packages/mcp-dev-server/src/index.ts
+++ b/packages/mcp-dev-server/src/index.ts
@@ -570,7 +570,7 @@ const tools: ToolDef[] = [
         timestamp: new Date().toISOString(),
       };
       timeline.push(entry);
-      db.set('chronos:timeline', timeline);
+      dbPut('chronos:timeline', timeline);
       return { ok: true, id: entry.id };
     },
   },
@@ -606,7 +606,7 @@ const tools: ToolDef[] = [
       required: ['level'],
     },
     handler: ({ level }) => {
-      db.set('chronos:config:level', level);
+      dbPut('chronos:config:level', level);
       return { ok: true, level };
     },
   },
@@ -650,7 +650,7 @@ const tools: ToolDef[] = [
       if (!record) return { error: `Plugin '${name}' not found` };
       record.active = true;
       record.activatedAt = new Date().toISOString();
-      db.set(`plugin:${name}`, record);
+      dbPut(`plugin:${name}`, record);
       return { ok: true, plugin: record };
     },
   },
@@ -663,7 +663,7 @@ const tools: ToolDef[] = [
       if (!record) return { error: `Plugin '${name}' not found` };
       record.active = false;
       record.deactivatedAt = new Date().toISOString();
-      db.set(`plugin:${name}`, record);
+      dbPut(`plugin:${name}`, record);
       return { ok: true, plugin: record };
     },
   },
@@ -707,7 +707,7 @@ const tools: ToolDef[] = [
       if (inlineTask) {
         const existing = db.get(recKey) as any;
         if (!existing) {
-          db.set(recKey, {
+          dbPut(recKey, {
             task: inlineTask,
             custody_state: 'owned',
             owner_agent: source_agent as string,
@@ -730,7 +730,7 @@ const tools: ToolDef[] = [
       }
 
       record.custody_state = 'transfer_pending';
-      db.set(recKey, record);
+      dbPut(recKey, record);
 
       // Build envelope (SHA-256 not available in this JS runtime without crypto;
       // we use a deterministic content string as the digest stand-in).
@@ -814,7 +814,7 @@ const tools: ToolDef[] = [
       record.generation = (record.generation as number) + 1;
       record.locked_by = null;
       record.lock_token = null;
-      db.set(recKey, record);
+      dbPut(recKey, record);
 
       return { task_id: tid, new_owner: target_agent, generation: record.generation, handoff_id };
     },
@@ -856,7 +856,7 @@ const tools: ToolDef[] = [
       const token = Math.random().toString(36).slice(2) + Date.now().toString(36);
       record.locked_by = worker_id as string;
       record.lock_token = token;
-      db.set(recKey, record);
+      dbPut(recKey, record);
 
       return { task_id: tid, worker_id, token };
     },


### PR DESCRIPTION
## Bug

The 4 task.handoff.* MCP handlers (prepare/verify/accept/claim) in packages/mcp-dev-server/src/index.ts called db.set() directly on the raw in-memory Map, bypassing the dbPut() wrapper. Only dbPut() calls schedulePersist() (debounced 500ms write to ~/.radix/pluresdb.json). Every real handoff done through this MCP surface was memory-only and silently lost on process restart -- found and reproduced by pares-radix:mvd-dogfood-proof.

## Fix

Changed all 8 direct db.set() call sites (outside dbPut() itself) to dbPut():
- task.handoff.prepare (seed + transfer_pending transition), lines ~710, ~733
- task.handoff.accept (custody transfer), line ~817
- task.handoff.claim (lock/token write), line ~859
- Blast-radius sweep found 4 more instances of the same anti-pattern in unrelated handlers: chronos.record, chronos.setLevel, plugin.activate, plugin.deactivate -- fixed those too.

## Verification (real, not fixture-based)

Reproduced the original bug, then verified the fix by:
1. Spawning the real MCP server process (\
ode .../tsx/dist/cli.mjs src/index.ts\ with RADIX_DEV=1, RADIX_DB_PATH pointed at a scratch file)
2. Driving real stdio JSON-RPC: initialize -> tools/call prepare -> accept -> claim for a genuine task payload
3. Waiting 2s past the 500ms persist debounce
4. Killing the process
5. Grepping the persisted JSON file for the handoff record

Result: **PERSISTED: YES** -- the handoff record is present in the on-disk file after process kill, confirming durability across process restart.

## Known gap (not fixed, flagged for follow-up)

packages/mcp-dev-server/src/task-handoff.test.ts inlines a copy of the handler logic rather than calling the real index.ts dispatcher (test-hygiene gap noted by the discovery subagent). Left as-is in this PR: index.ts starts stdin listeners at module load and isn't trivially importable for white-box testing without a larger refactor. Recommend a small follow-up to extract the tool-dispatch table into an importable module so this test can call the real handlers.

## Relates to
pares-radix:mvd-dogfood-proof (epic-registry.json)
