### PR TITLE
px-first: wire Copilot 4xx fallback through select_fallback_model procedure

### DIFF
--- a/crates/radix-core/src/auth/copilot.rs
+++ b/crates/radix-core/src/auth/copilot.rs
@@ -14,7 +14,8 @@ use tokio::sync::RwLock;
 use tokio::time::sleep;
 
 use crate::model::{
-    ChatMessage, ChatOptions, ModelClient, ModelCompletion, ToolCall, ToolDefinition,
+    ChatMessage, ChatOptions, FallbackRequestContext, ModelClient, ModelClientError,
+    ModelCompletion, ToolCall, ToolDefinition,
 };
 
 const COPILOT_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
@@ -276,8 +277,6 @@ pub struct CopilotModelClient {
     auth: Arc<Mutex<CopilotAuth>>,
     model: Arc<RwLock<String>>,
     client: reqwest::Client,
-    /// Ordered list of fallback models to try when the primary returns a 4xx error.
-    fallback_models: Vec<String>,
 }
 
 impl CopilotModelClient {
@@ -292,14 +291,7 @@ impl CopilotModelClient {
             auth: Arc::new(Mutex::new(auth)),
             model,
             client: copilot_http_client_or_panic(),
-            fallback_models: vec![],
         }
-    }
-
-    /// Set fallback models to try when the primary model fails with a 4xx error.
-    pub fn with_fallbacks(mut self, models: Vec<String>) -> Self {
-        self.fallback_models = models;
-        self
     }
 }
 
@@ -310,10 +302,13 @@ impl ModelClient for CopilotModelClient {
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         options: &ChatOptions,
-    ) -> Result<ModelCompletion, String> {
+    ) -> Result<ModelCompletion, ModelClientError> {
         let (token, api_base) = {
             let mut auth = self.auth.lock().await;
-            let token = auth.ensure_fresh_token().await.map_err(|e| e.to_string())?;
+            let token = auth
+                .ensure_fresh_token()
+                .await
+                .map_err(|e| ModelClientError::Transport(e.to_string()))?;
             (token.to_string(), auth.api_base_url().to_string())
         };
 
@@ -344,7 +339,10 @@ impl ModelClient for CopilotModelClient {
             rendered_messages.push(Value::Object(obj));
         }
 
-        let model = self.model.read().await.clone();
+        let model = match &options.model {
+            Some(m) => m.clone(),
+            None => self.model.read().await.clone(),
+        };
         let mut body = serde_json::json!({
             "model": model,
             "messages": rendered_messages,
@@ -390,7 +388,8 @@ impl ModelClient for CopilotModelClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| e.to_string())?,
+            HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| ModelClientError::Transport(e.to_string()))?,
         );
         headers.insert("Editor-Version", HeaderValue::from_static(EDITOR_VERSION));
         headers.insert("User-Agent", HeaderValue::from_static(USER_AGENT));
@@ -411,13 +410,13 @@ impl ModelClient for CopilotModelClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| ModelClientError::Transport(e.to_string()))?;
 
         let status = response.status();
         let body_text = response
             .text()
             .await
-            .map_err(|e| format!("response body read error: {e}"))?;
+            .map_err(|e| ModelClientError::Transport(format!("response body read error: {e}")))?;
 
         // Retry logic for transient failures.
         let (status, body_text) = if status == reqwest::StatusCode::MISDIRECTED_REQUEST {
@@ -426,20 +425,20 @@ impl ModelClient for CopilotModelClient {
                 attempt = 1,
                 "421 Misdirected Request — retrying with fresh connection"
             );
-            let fresh_client = copilot_http_client()
-                .map_err(|e| format!("failed to build fresh HTTP client: {e}"))?;
+            let fresh_client = copilot_http_client().map_err(|e| {
+                ModelClientError::Transport(format!("failed to build fresh HTTP client: {e}"))
+            })?;
             let resp = fresh_client
                 .post(&url)
                 .headers(headers.clone())
                 .json(&body)
                 .send()
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| ModelClientError::Transport(e.to_string()))?;
             let s = resp.status();
-            let t = resp
-                .text()
-                .await
-                .map_err(|e| format!("response body read error: {e}"))?;
+            let t = resp.text().await.map_err(|e| {
+                ModelClientError::Transport(format!("response body read error: {e}"))
+            })?;
             (s, t)
         } else if status == reqwest::StatusCode::UNAUTHORIZED {
             // 401: token may have expired — refresh and retry once.
@@ -451,13 +450,14 @@ impl ModelClient for CopilotModelClient {
                 let mut auth = self.auth.lock().await;
                 auth.ensure_fresh_token()
                     .await
-                    .map_err(|e| e.to_string())?
+                    .map_err(|e| ModelClientError::Transport(e.to_string()))?
                     .to_string()
             };
             let mut retry_headers = headers.clone();
             retry_headers.insert(
                 AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {new_token}")).map_err(|e| e.to_string())?,
+                HeaderValue::from_str(&format!("Bearer {new_token}"))
+                    .map_err(|e| ModelClientError::Transport(e.to_string()))?,
             );
             let resp = self
                 .client
@@ -466,12 +466,11 @@ impl ModelClient for CopilotModelClient {
                 .json(&body)
                 .send()
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| ModelClientError::Transport(e.to_string()))?;
             let s = resp.status();
-            let t = resp
-                .text()
-                .await
-                .map_err(|e| format!("response body read error: {e}"))?;
+            let t = resp.text().await.map_err(|e| {
+                ModelClientError::Transport(format!("response body read error: {e}"))
+            })?;
             (s, t)
         } else if status.is_server_error() {
             // 5xx: retry up to 2 times with exponential backoff.
@@ -488,12 +487,11 @@ impl ModelClient for CopilotModelClient {
                     .json(&body)
                     .send()
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| ModelClientError::Transport(e.to_string()))?;
                 last_status = resp.status();
-                last_body = resp
-                    .text()
-                    .await
-                    .map_err(|e| format!("response body read error: {e}"))?;
+                last_body = resp.text().await.map_err(|e| {
+                    ModelClientError::Transport(format!("response body read error: {e}"))
+                })?;
                 if !last_status.is_server_error() {
                     break;
                 }
@@ -512,74 +510,53 @@ impl ModelClient for CopilotModelClient {
         );
 
         let payload: Value = serde_json::from_str(&body_text).map_err(|e| {
-            format!(
+            ModelClientError::Transport(format!(
                 "error decoding response body: {e}\nBody: {}",
                 &body_text[..body_text.len().min(500)]
-            )
+            ))
         })?;
         if !status.is_success() {
             let is_client_error = status.is_client_error();
             let err_msg = format!("copilot error ({status}): {payload}");
 
-            // On 4xx errors, try fallback models before giving up.
-            // Only attempt fallbacks from the primary call (check if current
-            // model matches the configured primary to avoid recursion).
-            let primary_model = {
-                // Re-read in case it was swapped — but since we hold no
-                // lock across the HTTP call this is fine.
-                self.model.read().await.clone()
-            };
-            if is_client_error && !self.fallback_models.is_empty() && model == primary_model {
-                tracing::warn!(
-                    model = %model,
-                    status = %status,
-                    "primary model failed with client error, trying fallbacks"
-                );
-                // Never retry a model that has already failed in this chain — a
-                // fallback list that (mis)includes the primary, or repeats a model
-                // that already 400'd, must not loop back to it. Real bug found
-                // 2026-07-28: praxisbot's fallback list named its own primary
-                // ("model_not_supported") as its own fallback, looping forever.
-                let mut already_tried: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                already_tried.insert(primary_model.clone());
-                for fallback in &self.fallback_models {
-                    if already_tried.contains(fallback) {
-                        tracing::warn!(
-                            model = %fallback,
-                            "skipping fallback: already tried/failed in this chain (self-fallback or duplicate)"
-                        );
-                        continue;
-                    }
-                    already_tried.insert(fallback.clone());
-                    tracing::info!(model = %fallback, "trying fallback model");
-                    *self.model.write().await = fallback.clone();
-                    let result = self.complete(messages, tools, options).await;
-                    *self.model.write().await = primary_model.clone();
-                    match result {
-                        Ok(completion) => {
-                            tracing::info!(model = %fallback, "fallback model succeeded");
-                            return Ok(completion);
-                        }
-                        Err(e) => {
-                            tracing::warn!(model = %fallback, error = %e, "fallback model also failed");
-                        }
-                    }
-                }
+            // Fallback-eligible: a 4xx client error against the model we were
+            // asked to use. We no longer select or retry a fallback ourselves —
+            // that decision belongs to the `select_fallback_model` `.px`
+            // procedure, invoked by the orchestrator (`ModelInvoker`). We only
+            // report the failure as fallback-eligible so the caller can act.
+            if is_client_error {
+                return Err(ModelClientError::NeedsFallback(FallbackRequestContext {
+                    failed_model: model.clone(),
+                    already_tried: vec![model.clone()],
+                    error_status: status.as_u16(),
+                    task_context: serde_json::json!({ "error": err_msg }),
+                }));
             }
 
-            return Err(err_msg);
+            return Err(ModelClientError::ProviderFailure {
+                status: Some(status.as_u16()),
+                model: model.clone(),
+                message: err_msg,
+            });
         }
 
         let choice = payload
             .get("choices")
             .and_then(|v| v.as_array())
             .and_then(|arr| arr.first())
-            .ok_or_else(|| "model returned no choices".to_string())?;
+            .ok_or_else(|| ModelClientError::ProviderFailure {
+                status: Some(status.as_u16()),
+                model: model.clone(),
+                message: "model returned no choices".to_string(),
+            })?;
 
         let message = choice
             .get("message")
-            .ok_or_else(|| "model returned no message".to_string())?;
+            .ok_or_else(|| ModelClientError::ProviderFailure {
+                status: Some(status.as_u16()),
+                model: model.clone(),
+                message: "model returned no message".to_string(),
+            })?;
 
         let content = message
             .get("content")
@@ -1189,6 +1166,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_error_returns_typed_fallback_request_for_override_model() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            read_request(&mut stream).await;
+            write_json_response(
+                &mut stream,
+                "400 Bad Request",
+                r#"{"error":"model_not_supported"}"#,
+            )
+            .await;
+        });
+
+        let client =
+            CopilotModelClient::new(seeded_auth(format!("http://{addr}")), "default-model");
+        let result = client
+            .complete(
+                &[ChatMessage::user("hello")],
+                &[],
+                &ChatOptions {
+                    model: Some("request-override".into()),
+                    ..ChatOptions::default()
+                },
+            )
+            .await;
+
+        match result.expect_err("400 must be surfaced for Praxis fallback selection") {
+            ModelClientError::NeedsFallback(context) => {
+                assert_eq!(context.failed_model, "request-override");
+                assert_eq!(context.already_tried, vec!["request-override"]);
+                assert_eq!(context.error_status, 400);
+            }
+            other => panic!("expected NeedsFallback, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn copilot_421_retry_is_bounded_by_retry_client_read_timeout() {
         let (api_base, attempts) = spawn_421_then_hang_server().await;
         let client = CopilotModelClient::new(seeded_auth(api_base), "test-model");
@@ -1206,7 +1223,7 @@ mod tests {
         let err = result
             .expect("outer timeout checked")
             .expect_err("hanging retry response should time out");
-        let err_lower = err.to_ascii_lowercase();
+        let err_lower = err.to_string().to_ascii_lowercase();
         assert!(
             err_lower.contains("timed out")
                 || err_lower.contains("operation timed out")

--- a/crates/radix-core/src/handlers/on_message.rs
+++ b/crates/radix-core/src/handlers/on_message.rs
@@ -199,7 +199,7 @@ impl Procedure for OnMessage {
 mod tests {
     use super::*;
     use crate::memory_client::Memory;
-    use crate::model::{ChatOptions, ModelCompletion, ToolCall, ToolDefinition};
+    use crate::model::{ChatOptions, ModelClientError, ModelCompletion, ToolCall, ToolDefinition};
     use serde_json::json;
     use std::sync::Mutex;
 
@@ -261,7 +261,7 @@ mod tests {
             _messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             Ok(ModelCompletion {
                 content: Some(self.response.clone()),
                 tool_calls: vec![],
@@ -294,7 +294,7 @@ mod tests {
             _messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             let mut count = self.call_count.lock().unwrap();
             *count += 1;
             if *count == 1 {

--- a/crates/radix-core/src/model.rs
+++ b/crates/radix-core/src/model.rs
@@ -181,6 +181,83 @@ pub struct ChatOptions {
     pub model: Option<String>,
 }
 
+/// Context describing a failed model call that is eligible for a fallback
+/// model to be selected by the `.px` `select_fallback_model` procedure.
+///
+/// This is a data record, not a decision — the *choice* of which fallback
+/// model to try next is owned by praxis (see
+/// `praxis/procedures/model-fallback-selection.px`), not by the model client
+/// itself. The client only reports "I failed and this looks fallback-eligible";
+/// the orchestrator (`ModelInvoker`) is responsible for calling the procedure
+/// and re-issuing the request with the selected model.
+#[derive(Debug, Clone)]
+pub struct FallbackRequestContext {
+    /// The model that just failed.
+    pub failed_model: String,
+    /// Every model already attempted in this request chain (including
+    /// `failed_model`), so the selector never loops back to one.
+    pub already_tried: Vec<String>,
+    /// The HTTP status code that triggered the fallback-eligible failure.
+    pub error_status: u16,
+    /// Arbitrary task/request context the selection procedure may use to
+    /// pick an appropriate replacement model (e.g. tier, tool usage).
+    pub task_context: serde_json::Value,
+}
+
+/// Typed error returned by [`ModelClient::complete`] / [`ModelClient::complete_stream`].
+///
+/// Replaces the previous `Result<_, String>` contract so that fallback-eligible
+/// failures can be distinguished from terminal ones without string matching,
+/// and so that model clients no longer own fallback *selection* logic
+/// themselves (see `docs/design/copilot-fallback-px-wiring.md`, Option B).
+#[derive(Debug, Clone)]
+pub enum ModelClientError {
+    /// The call failed with a fallback-eligible error (e.g. a 4xx the
+    /// provider returned for an unsupported/unavailable model). The caller
+    /// (orchestrator) should select a fallback model via praxis and retry.
+    NeedsFallback(FallbackRequestContext),
+    /// The provider returned a terminal failure that is not fallback-eligible
+    /// (e.g. exhausted retries, malformed response, non-fallback-eligible
+    /// status code).
+    ProviderFailure {
+        /// HTTP status code, when the failure originated from an HTTP response.
+        status: Option<u16>,
+        /// The model that was in use when the failure occurred.
+        model: String,
+        /// Human-readable failure detail.
+        message: String,
+    },
+    /// The request was cancelled; no fallback should be attempted.
+    Cancelled,
+    /// A transport-level failure (connection, timeout, serialization, etc.)
+    /// that is not itself fallback-eligible.
+    Transport(String),
+}
+
+impl std::fmt::Display for ModelClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ModelClientError::NeedsFallback(ctx) => write!(
+                f,
+                "model '{}' failed with fallback-eligible error (status {}); already tried: {:?}",
+                ctx.failed_model, ctx.error_status, ctx.already_tried
+            ),
+            ModelClientError::ProviderFailure {
+                status,
+                model,
+                message,
+            } => write!(
+                f,
+                "model '{model}' provider failure (status {status:?}): {message}"
+            ),
+            ModelClientError::Cancelled => write!(f, "model request cancelled"),
+            ModelClientError::Transport(msg) => write!(f, "transport error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ModelClientError {}
+
 // ── Traits ───────────────────────────────────────────────────────────────────
 
 /// Abstraction over an OpenAI-compatible language model endpoint.
@@ -198,7 +275,7 @@ pub trait ModelClient: Send + Sync {
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         options: &ChatOptions,
-    ) -> Result<ModelCompletion, String>;
+    ) -> Result<ModelCompletion, ModelClientError>;
 
     /// Request a streaming chat completion.
     ///
@@ -213,7 +290,7 @@ pub trait ModelClient: Send + Sync {
         tools: &[ToolDefinition],
         options: &ChatOptions,
         tx: StreamSender,
-    ) -> Result<ModelCompletion, String> {
+    ) -> Result<ModelCompletion, ModelClientError> {
         let result = self.complete(messages, tools, options).await?;
         if let Some(content) = &result.content {
             let _ = tx.send(StreamDelta::Content(content.clone()));
@@ -261,7 +338,7 @@ mod tests {
             messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             let content = messages.last().map(|m| m.content.clone());
             Ok(ModelCompletion {
                 content,
@@ -309,7 +386,7 @@ mod tests {
                 _messages: &[ChatMessage],
                 _tools: &[ToolDefinition],
                 _options: &ChatOptions,
-            ) -> Result<ModelCompletion, String> {
+            ) -> Result<ModelCompletion, ModelClientError> {
                 Ok(ModelCompletion {
                     content: None,
                     tool_calls: vec![ToolCall {

--- a/crates/radix-core/src/spine/procedures/model_invoker.rs
+++ b/crates/radix-core/src/spine/procedures/model_invoker.rs
@@ -457,13 +457,14 @@ impl ModelInvoker {
             let decision: Value = match serde_json::from_str(&raw) {
                 Ok(v) => v,
                 Err(_) => {
+                    let raw_preview: String = raw.chars().take(500).collect();
                     // Non-JSON / unparseable response from the selector is treated
                     // as "no candidate" — fail closed rather than guess.
                     return Err(ModelClientError::ProviderFailure {
                         status: Some(needs_fallback_ctx.error_status),
                         model: needs_fallback_ctx.failed_model.clone(),
                         message: format!(
-                            "fallback selection returned an unparseable response: {raw}"
+                            "fallback selection returned an unparseable response (preview): {raw_preview}"
                         ),
                     });
                 }

--- a/crates/radix-core/src/spine/procedures/model_invoker.rs
+++ b/crates/radix-core/src/spine/procedures/model_invoker.rs
@@ -11,13 +11,16 @@
 use std::sync::Arc;
 
 use tokio::sync::broadcast;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
-use crate::model::{ChatMessage, ChatOptions, ModelClient, StreamDelta, ToolDispatcher};
+use crate::model::{
+    ChatMessage, ChatOptions, ModelClient, ModelClientError, StreamDelta, ToolDispatcher,
+};
 use crate::spine::conversation::ConversationStore;
 use crate::spine::event::SpineEvent;
 use crate::spine::pipeline::{PipelineEmitter, SpineProcedure};
 use crate::task_manager::TaskManager;
+use serde_json::Value;
 
 /// Invokes the language model for a ModelRequest and emits ModelResponse.
 ///
@@ -224,6 +227,7 @@ impl SpineProcedure for ModelInvoker {
             id,
             source,
             chat_id,
+            sender,
             content,
             system_prompt,
             metadata,
@@ -281,29 +285,25 @@ impl SpineProcedure for ModelInvoker {
             ..ChatOptions::default()
         };
 
-        // Call the model — use streaming when a broadcast sender is configured
-        let result = if let Some(broadcast_tx) = &self.stream_tx {
-            // Streaming path: bridge mpsc (what ModelClient expects) to broadcast (what channels subscribe to)
-            debug!(event_id = %id, "model_invoker: using streaming completion");
-            let (mpsc_tx, mut mpsc_rx) = tokio::sync::mpsc::unbounded_channel::<StreamDelta>();
-            let broadcast_tx_clone = broadcast_tx.clone();
-
-            // Forward deltas from mpsc to broadcast in background
-            tokio::spawn(async move {
-                while let Some(delta) = mpsc_rx.recv().await {
-                    let _ = broadcast_tx_clone.send(delta);
-                }
-            });
-
-            self.model_client
-                .complete_stream(&messages, &tool_defs, &options, mpsc_tx)
-                .await
-        } else {
-            // Non-streaming path: full completion returned at once
-            self.model_client
-                .complete(&messages, &tool_defs, &options)
-                .await
-        };
+        let request_context = serde_json::json!({
+            "event_id": id,
+            "source": source,
+            "chat_id": chat_id,
+            "sender": sender,
+            "metadata": metadata,
+            "message_count": messages.len(),
+            "tool_count": tool_defs.len(),
+        });
+        let result = self
+            .complete_with_fallback(
+                id,
+                chat_id,
+                &messages,
+                &tool_defs,
+                options,
+                &request_context,
+            )
+            .await;
 
         match result {
             Ok(completion) => {
@@ -356,6 +356,177 @@ impl SpineProcedure for ModelInvoker {
     }
 }
 
+impl ModelInvoker {
+    /// Maximum total model-call attempts for a single request, including the
+    /// initial call. Bounds fallback retries so a misbehaving `.px` selection
+    /// (or a selector that keeps returning fresh-looking but ultimately
+    /// unusable models) cannot loop forever.
+    const MAX_FALLBACK_ATTEMPTS: usize = 4;
+
+    /// Call the model client, and on a fallback-eligible failure, ask the
+    /// `select_fallback_model` `.px` procedure (via the existing
+    /// [`ToolDispatcher`] seam) which model to retry with. Loops up to
+    /// [`Self::MAX_FALLBACK_ATTEMPTS`] total attempts.
+    ///
+    /// Fallback *selection* is owned entirely by praxis — this method never
+    /// hardcodes or infers a replacement model itself; it only orchestrates
+    /// the retry loop and enforces the already-tried/attempt-cap safety net
+    /// (Option B in `docs/design/copilot-fallback-px-wiring.md`).
+    async fn complete_with_fallback(
+        &self,
+        event_id: &str,
+        chat_id: &str,
+        messages: &[ChatMessage],
+        tool_defs: &[crate::model::ToolDefinition],
+        mut options: ChatOptions,
+        request_context: &Value,
+    ) -> Result<crate::model::ModelCompletion, ModelClientError> {
+        let mut already_tried: Vec<String> = Vec::new();
+        if let Some(model) = &options.model {
+            already_tried.push(model.clone());
+        }
+
+        for attempt in 0..Self::MAX_FALLBACK_ATTEMPTS {
+            let call_result = if let Some(broadcast_tx) = &self.stream_tx {
+                let (mpsc_tx, mut mpsc_rx) = tokio::sync::mpsc::unbounded_channel::<StreamDelta>();
+                let broadcast_tx_clone = broadcast_tx.clone();
+                tokio::spawn(async move {
+                    while let Some(delta) = mpsc_rx.recv().await {
+                        let _ = broadcast_tx_clone.send(delta);
+                    }
+                });
+                self.model_client
+                    .complete_stream(messages, tool_defs, &options, mpsc_tx)
+                    .await
+            } else {
+                self.model_client
+                    .complete(messages, tool_defs, &options)
+                    .await
+            };
+
+            let needs_fallback_ctx = match call_result {
+                Ok(completion) => return Ok(completion),
+                Err(ModelClientError::NeedsFallback(ctx)) => ctx,
+                Err(other) => return Err(other),
+            };
+
+            for model in &needs_fallback_ctx.already_tried {
+                if !already_tried.contains(model) {
+                    already_tried.push(model.clone());
+                }
+            }
+            if !already_tried.contains(&needs_fallback_ctx.failed_model) {
+                already_tried.push(needs_fallback_ctx.failed_model.clone());
+            }
+
+            if attempt + 1 >= Self::MAX_FALLBACK_ATTEMPTS {
+                return Err(ModelClientError::ProviderFailure {
+                    status: Some(needs_fallback_ctx.error_status),
+                    model: needs_fallback_ctx.failed_model.clone(),
+                    message: format!(
+                        "fallback exhausted: hit max attempts ({})",
+                        Self::MAX_FALLBACK_ATTEMPTS
+                    ),
+                });
+            }
+
+            debug!(
+                event_id = %event_id,
+                chat_id = %chat_id,
+                attempt,
+                failed_model = %needs_fallback_ctx.failed_model,
+                already_tried = ?already_tried,
+                "model_invoker: model call needs fallback, consulting praxis selection"
+            );
+
+            // Praxis owns the decision; the invoker only asks and applies it.
+            let selector_args = serde_json::json!({
+                "failed_model": needs_fallback_ctx.failed_model,
+                "already_tried": already_tried,
+                "error_status": needs_fallback_ctx.error_status,
+                "task_context": {
+                    "provider_context": needs_fallback_ctx.task_context,
+                    "request": request_context,
+                },
+            });
+            let raw = self
+                .tool_dispatcher
+                .call_tool("select_fallback_model", selector_args)
+                .await;
+
+            let decision: Value = match serde_json::from_str(&raw) {
+                Ok(v) => v,
+                Err(_) => {
+                    // Non-JSON / unparseable response from the selector is treated
+                    // as "no candidate" — fail closed rather than guess.
+                    return Err(ModelClientError::ProviderFailure {
+                        status: Some(needs_fallback_ctx.error_status),
+                        model: needs_fallback_ctx.failed_model.clone(),
+                        message: format!(
+                            "fallback selection returned an unparseable response: {raw}"
+                        ),
+                    });
+                }
+            };
+
+            let candidate = decision
+                .get("model")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+
+            let candidate = match candidate {
+                Some(c) if !already_tried.contains(&c) => c,
+                Some(c) => {
+                    warn!(
+                        event_id = %event_id,
+                        chat_id = %chat_id,
+                        candidate = %c,
+                        "model_invoker: fallback selector returned an already-tried model, stopping"
+                    );
+                    return Err(ModelClientError::ProviderFailure {
+                        status: Some(needs_fallback_ctx.error_status),
+                        model: needs_fallback_ctx.failed_model.clone(),
+                        message: format!(
+                            "fallback exhausted: selector re-suggested already-tried model '{c}'"
+                        ),
+                    });
+                }
+                None => {
+                    warn!(
+                        event_id = %event_id,
+                        chat_id = %chat_id,
+                        "model_invoker: fallback selection exhausted, no further candidate"
+                    );
+                    return Err(ModelClientError::ProviderFailure {
+                        status: Some(needs_fallback_ctx.error_status),
+                        model: needs_fallback_ctx.failed_model.clone(),
+                        message: "fallback exhausted: no candidate model available".to_string(),
+                    });
+                }
+            };
+
+            info!(
+                event_id = %event_id,
+                chat_id = %chat_id,
+                candidate = %candidate,
+                attempt,
+                "model_invoker: retrying with praxis-selected fallback model"
+            );
+            already_tried.push(candidate.clone());
+            options.model = Some(candidate);
+        }
+
+        Err(ModelClientError::ProviderFailure {
+            status: None,
+            model: options.model.unwrap_or_else(|| "unknown".into()),
+            message: format!(
+                "fallback exhausted: hit max attempts ({})",
+                Self::MAX_FALLBACK_ATTEMPTS
+            ),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -386,7 +557,7 @@ mod tests {
             _messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             Ok(ModelCompletion {
                 content: Some(self.response.clone()),
                 tool_calls: vec![],
@@ -406,7 +577,7 @@ mod tests {
             _messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             Ok(ModelCompletion {
                 content: None,
                 tool_calls: vec![ToolCall {
@@ -430,8 +601,8 @@ mod tests {
             _messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
-            Err("connection timeout".into())
+        ) -> Result<ModelCompletion, ModelClientError> {
+            Err(ModelClientError::Transport("connection timeout".into()))
         }
     }
 
@@ -460,7 +631,7 @@ mod tests {
             messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             self.captured.lock().await.push(messages.to_vec());
             Ok(ModelCompletion {
                 content: Some("captured".into()),
@@ -500,6 +671,121 @@ mod tests {
 
         async fn call_tool(&self, _name: &str, _arguments: serde_json::Value) -> String {
             String::new()
+        }
+    }
+
+    /// Scripted client for fallback orchestration tests. It records the model
+    /// supplied on each call so tests prove the invoker, rather than the
+    /// provider client, applies the Praxis-selected override.
+    struct ScriptedModelClient {
+        responses: tokio::sync::Mutex<
+            std::collections::VecDeque<Result<ModelCompletion, ModelClientError>>,
+        >,
+        models: tokio::sync::Mutex<Vec<Option<String>>>,
+    }
+
+    impl ScriptedModelClient {
+        fn new(responses: Vec<Result<ModelCompletion, ModelClientError>>) -> Self {
+            Self {
+                responses: tokio::sync::Mutex::new(responses.into()),
+                models: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ModelClient for ScriptedModelClient {
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[ToolDefinition],
+            options: &ChatOptions,
+        ) -> Result<ModelCompletion, ModelClientError> {
+            self.models.lock().await.push(options.model.clone());
+            self.responses
+                .lock()
+                .await
+                .pop_front()
+                .expect("scripted model client received an unexpected extra call")
+        }
+    }
+
+    struct FallbackTools {
+        response: String,
+        calls: tokio::sync::Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    impl FallbackTools {
+        fn new(response: impl Into<String>) -> Self {
+            Self {
+                response: response.into(),
+                calls: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ToolDispatcher for FallbackTools {
+        async fn available_tools(&self) -> Vec<ToolDefinition> {
+            vec![]
+        }
+
+        async fn call_tool(&self, name: &str, arguments: serde_json::Value) -> String {
+            self.calls.lock().await.push((name.to_owned(), arguments));
+            self.response.clone()
+        }
+    }
+
+    struct SequencedFallbackTools {
+        responses: tokio::sync::Mutex<std::collections::VecDeque<String>>,
+        calls: tokio::sync::Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    impl SequencedFallbackTools {
+        fn new(responses: Vec<&str>) -> Self {
+            Self {
+                responses: tokio::sync::Mutex::new(
+                    responses.into_iter().map(str::to_owned).collect(),
+                ),
+                calls: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ToolDispatcher for SequencedFallbackTools {
+        async fn available_tools(&self) -> Vec<ToolDefinition> {
+            vec![]
+        }
+
+        async fn call_tool(&self, name: &str, arguments: serde_json::Value) -> String {
+            self.calls.lock().await.push((name.to_owned(), arguments));
+            self.responses
+                .lock()
+                .await
+                .pop_front()
+                .expect("selector received an unexpected extra call")
+        }
+    }
+
+    fn fallback_needed(model: &str) -> ModelClientError {
+        ModelClientError::NeedsFallback(crate::model::FallbackRequestContext {
+            failed_model: model.to_owned(),
+            already_tried: vec![model.to_owned()],
+            error_status: 400,
+            task_context: json!({"task_kind": "chat"}),
+        })
+    }
+
+    fn fallback_test_event() -> SpineEvent {
+        SpineEvent::ModelRequest {
+            source: "test".into(),
+            id: "fallback-request".into(),
+            chat_id: "fallback-chat".into(),
+            sender: "user".into(),
+            content: "please handle this".into(),
+            system_prompt: None,
+            metadata: json!({"model_tier": "standard", "route_reason": "test"}),
         }
     }
 
@@ -609,6 +895,159 @@ mod tests {
         } else {
             panic!("expected DeliveryRequest");
         }
+    }
+
+    #[tokio::test]
+    async fn retries_with_praxis_selected_fallback_model() {
+        let (emitter, mut rx) = make_emitter();
+        let client = Arc::new(ScriptedModelClient::new(vec![
+            Err(fallback_needed("primary-model")),
+            Ok(ModelCompletion {
+                content: Some("fallback succeeded".into()),
+                tool_calls: vec![],
+                logprobs: None,
+                model: Some("fallback-model".into()),
+            }),
+        ]));
+        let tools = Arc::new(FallbackTools::new(
+            r#"{"model":"fallback-model","reason":"live candidate","exhausted":false}"#,
+        ));
+        let invoker = ModelInvoker::new(
+            Arc::clone(&client) as Arc<dyn ModelClient>,
+            Arc::clone(&tools) as Arc<dyn ToolDispatcher>,
+        );
+
+        invoker.handle(&fallback_test_event(), &emitter).await;
+
+        match rx.recv().await.expect("model response") {
+            SpineEvent::ModelResponse { content, model, .. } => {
+                assert_eq!(content, "fallback succeeded");
+                assert_eq!(model, "fallback-model");
+            }
+            other => panic!("expected ModelResponse, got {other:?}"),
+        }
+        assert_eq!(
+            *client.models.lock().await,
+            vec![None, Some("fallback-model".into())]
+        );
+        let calls = tools.calls.lock().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "select_fallback_model");
+        assert_eq!(calls[0].1["failed_model"], "primary-model");
+        assert_eq!(calls[0].1["already_tried"], json!(["primary-model"]));
+        assert_eq!(
+            calls[0].1["task_context"]["request"]["chat_id"],
+            "fallback-chat"
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_attempts_are_hard_capped() {
+        let (emitter, mut rx) = make_emitter();
+        let client = Arc::new(ScriptedModelClient::new(vec![
+            Err(fallback_needed("primary-model")),
+            Err(fallback_needed("fallback-1")),
+            Err(fallback_needed("fallback-2")),
+            Err(fallback_needed("fallback-3")),
+        ]));
+        let tools = Arc::new(SequencedFallbackTools::new(vec![
+            r#"{"model":"fallback-1"}"#,
+            r#"{"model":"fallback-2"}"#,
+            r#"{"model":"fallback-3"}"#,
+        ]));
+        let invoker = ModelInvoker::new(
+            Arc::clone(&client) as Arc<dyn ModelClient>,
+            Arc::clone(&tools) as Arc<dyn ToolDispatcher>,
+        );
+
+        invoker.handle(&fallback_test_event(), &emitter).await;
+
+        match rx.recv().await.expect("terminal error") {
+            SpineEvent::DeliveryRequest { content, .. } => {
+                assert!(content.contains("hit max attempts (4)"));
+            }
+            other => panic!("expected DeliveryRequest, got {other:?}"),
+        }
+        assert_eq!(
+            client.models.lock().await.len(),
+            ModelInvoker::MAX_FALLBACK_ATTEMPTS
+        );
+        assert_eq!(
+            tools.calls.lock().await.len(),
+            ModelInvoker::MAX_FALLBACK_ATTEMPTS - 1
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_praxis_selector_that_repeats_a_tried_model() {
+        let (emitter, mut rx) = make_emitter();
+        let client = Arc::new(ScriptedModelClient::new(vec![Err(fallback_needed(
+            "primary-model",
+        ))]));
+        let tools = Arc::new(FallbackTools::new(r#"{"model":"primary-model"}"#));
+        let invoker = ModelInvoker::new(
+            Arc::clone(&client) as Arc<dyn ModelClient>,
+            Arc::clone(&tools) as Arc<dyn ToolDispatcher>,
+        );
+
+        invoker.handle(&fallback_test_event(), &emitter).await;
+
+        match rx.recv().await.expect("terminal error") {
+            SpineEvent::DeliveryRequest { content, .. } => {
+                assert!(content.contains("fallback exhausted"));
+                assert!(content.contains("already-tried"));
+            }
+            other => panic!("expected DeliveryRequest, got {other:?}"),
+        }
+        assert_eq!(client.models.lock().await.len(), 1);
+        assert_eq!(tools.calls.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_praxis_selector_returns_invalid_payload() {
+        let (emitter, mut rx) = make_emitter();
+        let client = Arc::new(ScriptedModelClient::new(vec![Err(fallback_needed(
+            "primary-model",
+        ))]));
+        let tools = Arc::new(FallbackTools::new("Tool error: selector unavailable"));
+        let invoker = ModelInvoker::new(
+            Arc::clone(&client) as Arc<dyn ModelClient>,
+            Arc::clone(&tools) as Arc<dyn ToolDispatcher>,
+        );
+
+        invoker.handle(&fallback_test_event(), &emitter).await;
+
+        match rx.recv().await.expect("terminal error") {
+            SpineEvent::DeliveryRequest { content, .. } => {
+                assert!(content.contains("unparseable response"));
+            }
+            other => panic!("expected DeliveryRequest, got {other:?}"),
+        }
+        assert_eq!(client.models.lock().await.len(), 1);
+        assert_eq!(tools.calls.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_invoke_selector_when_model_request_is_cancelled() {
+        let (emitter, mut rx) = make_emitter();
+        let client = Arc::new(ScriptedModelClient::new(vec![Err(
+            ModelClientError::Cancelled,
+        )]));
+        let tools = Arc::new(FallbackTools::new(r#"{"model":"fallback-model"}"#));
+        let invoker = ModelInvoker::new(
+            Arc::clone(&client) as Arc<dyn ModelClient>,
+            Arc::clone(&tools) as Arc<dyn ToolDispatcher>,
+        );
+
+        invoker.handle(&fallback_test_event(), &emitter).await;
+
+        match rx.recv().await.expect("terminal cancellation") {
+            SpineEvent::DeliveryRequest { content, .. } => {
+                assert!(content.contains("model request cancelled"));
+            }
+            other => panic!("expected DeliveryRequest, got {other:?}"),
+        }
+        assert!(tools.calls.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -757,7 +1196,7 @@ mod tests {
                 _messages: &[ChatMessage],
                 _tools: &[ToolDefinition],
                 options: &ChatOptions,
-            ) -> Result<ModelCompletion, String> {
+            ) -> Result<ModelCompletion, ModelClientError> {
                 *self.called_with_model.lock().await = Some(options.model.clone());
                 Ok(ModelCompletion {
                     content: Some("ok".into()),

--- a/crates/radix-core/src/spine/procedures/tool_executor.rs
+++ b/crates/radix-core/src/spine/procedures/tool_executor.rs
@@ -10,11 +10,11 @@
 //! Safety: A per-chat iteration counter prevents infinite tool loops.
 //! Conversation history is threaded through metadata for full context.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::model::{ChatMessage, ToolDispatcher};
 use crate::spine::event::SpineEvent;
@@ -167,10 +167,45 @@ impl SpineProcedure for ToolExecutor {
             tool_calls.len(), iteration, self.max_iterations
         );
 
+        // Build an allowlist of tools that were explicitly advertised to the model.
+        // Only tools in this set may be dispatched from model responses — internal
+        // procedures (e.g. select_fallback_model) must never be reachable via
+        // model-generated tool calls.
+        let advertised: HashSet<String> = self
+            .dispatcher
+            .available_tools()
+            .await
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+
         // Execute each tool call and collect results
         let mut tool_results: Vec<ChatMessage> = Vec::with_capacity(tool_calls.len());
 
         for tc in tool_calls {
+            // Allowlist check: reject any tool the model was not shown.
+            if !advertised.contains(&tc.name) {
+                warn!(
+                    tool_name = %tc.name,
+                    tool_call_id = %tc.id,
+                    "tool_executor: model requested unadvertised tool, rejecting"
+                );
+                let result =
+                    format!("Error: tool '{}' is not available", tc.name);
+                emitter
+                    .emit(SpineEvent::ToolResult {
+                        id: SpineEvent::new_id(),
+                        chat_id: chat_id.clone(),
+                        tool_call_id: tc.id.clone(),
+                        tool_name: tc.name.clone(),
+                        content: result.clone(),
+                        metadata: serde_json::json!({}),
+                    })
+                    .await;
+                tool_results.push(ChatMessage::tool_result(tc.id.clone(), result));
+                continue;
+            }
+
             debug!(
                 tool_name = %tc.name,
                 tool_call_id = %tc.id,
@@ -256,7 +291,18 @@ mod tests {
     #[async_trait]
     impl ToolDispatcher for MockDispatcher {
         async fn available_tools(&self) -> Vec<ToolDefinition> {
-            vec![]
+            vec![
+                ToolDefinition {
+                    name: "web_search".into(),
+                    description: "Search the web".into(),
+                    parameters: serde_json::json!({"type": "object"}),
+                },
+                ToolDefinition {
+                    name: "read".into(),
+                    description: "Read a file".into(),
+                    parameters: serde_json::json!({"type": "object"}),
+                },
+            ]
         }
 
         async fn call_tool(&self, name: &str, arguments: Value) -> String {
@@ -279,7 +325,11 @@ mod tests {
     #[async_trait]
     impl ToolDispatcher for InfiniteLoopDispatcher {
         async fn available_tools(&self) -> Vec<ToolDefinition> {
-            vec![]
+            vec![ToolDefinition {
+                name: "web_search".into(),
+                description: "Search the web".into(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]
         }
 
         async fn call_tool(&self, _name: &str, _arguments: Value) -> String {
@@ -724,5 +774,50 @@ mod tests {
         } else {
             panic!("expected ModelRequest");
         }
+    }
+
+    #[tokio::test]
+    async fn rejects_unadvertised_tool_calls() {
+        let (emitter, mut rx) = make_emitter();
+        let executor = ToolExecutor::new(Arc::new(MockDispatcher));
+
+        // Attempt to call an internal tool that was never advertised to the model.
+        let event = SpineEvent::ModelResponse {
+            source: "test".into(),
+            id: "resp-reject".into(),
+            chat_id: "chat-reject".into(),
+            content: String::new(),
+            model: "gpt-4".into(),
+            tool_calls: vec![ToolCall {
+                id: "tc-internal".into(),
+                name: "select_fallback_model".into(),
+                arguments: serde_json::json!({"failed_model": "gpt-4"}),
+            }],
+            metadata: serde_json::json!({}),
+        };
+
+        executor.handle(&event, &emitter).await;
+
+        // ToolResult with rejection error
+        let tool_result = rx.recv().await.unwrap();
+        assert_eq!(tool_result.event_type(), "tool_result");
+        if let SpineEvent::ToolResult {
+            tool_name,
+            content,
+            ..
+        } = tool_result
+        {
+            assert_eq!(tool_name, "select_fallback_model");
+            assert!(
+                content.contains("not available"),
+                "expected rejection message, got: {content}"
+            );
+        } else {
+            panic!("expected ToolResult");
+        }
+
+        // ModelRequest still emitted so the model sees the rejection
+        let model_req = rx.recv().await.unwrap();
+        assert_eq!(model_req.event_type(), "model_request");
     }
 }

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -515,7 +515,9 @@ pub async fn build_default_task_aware_runtime(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ChatMessage, ChatOptions, ModelCompletion, ToolDefinition, ToolDispatcher};
+    use crate::model::{
+        ChatMessage, ChatOptions, ModelClientError, ModelCompletion, ToolDefinition, ToolDispatcher,
+    };
     use crate::spine::conversation::MemoryConversationStore;
     use crate::spine::event::SpineEvent;
     use crate::task_manager::TaskManager;
@@ -555,7 +557,7 @@ mod tests {
             messages: &[ChatMessage],
             _tools: &[ToolDefinition],
             _options: &ChatOptions,
-        ) -> Result<ModelCompletion, String> {
+        ) -> Result<ModelCompletion, ModelClientError> {
             *self.seen_messages.lock().await = messages.to_vec();
             Ok(ModelCompletion {
                 content: Some("ok".into()),

--- a/docs/design/copilot-fallback-px-wiring.md
+++ b/docs/design/copilot-fallback-px-wiring.md
@@ -4,8 +4,7 @@ Date: 2026-07-28
 Epic: `pares-radix:copilot-fallback-px-wiring`
 
 ## Scope
-Design only. No production code changes in this commit.
-
+Design + implementation: this PR documents and implements `.px`-driven Copilot fallback selection wiring.
 ## Evidence from current code
 
 1. `crates/radix-core/src/auth/copilot.rs` currently owns the full fallback loop inside `CopilotModelClient::complete()`:

--- a/docs/design/copilot-fallback-px-wiring.md
+++ b/docs/design/copilot-fallback-px-wiring.md
@@ -1,0 +1,145 @@
+# Copilot fallback .px wiring (design-stage)
+
+Date: 2026-07-28  
+Epic: `pares-radix:copilot-fallback-px-wiring`
+
+## Scope
+Design only. No production code changes in this commit.
+
+## Evidence from current code
+
+1. `crates/radix-core/src/auth/copilot.rs` currently owns the full fallback loop inside `CopilotModelClient::complete()`:
+   - handles 421/401/5xx retries inline
+   - on 4xx, iterates `self.fallback_models`
+   - mutates `self.model` to each fallback and recursively calls `complete()`
+   - restores primary model after each attempt
+   - includes a recent HashSet dedupe patch to avoid self/duplicate fallback loops
+2. `praxis/procedures/model-fallback-selection.px` already defines the intended decision owner:
+   - procedure `select_fallback_model`
+   - constraints: never retry failed/already-tried model, use live availability
+   - explicit note that Rust should call this procedure instead of static list iteration
+3. `crates/radix-core/src/pluresdb_bridge.rs` defines ownership boundaries clearly:
+   - `PluresDbBridge` is platform/procedure execution infrastructure
+   - cognition/model-call logic should not absorb this bridge directly
+4. `crates/radix-core/src/spine/procedures/model_invoker.rs` is the model-call orchestrator in the spine pipeline; it already owns per-request context and terminal user-visible error emission.
+
+## Options compared
+
+### A) Inject `PluresDbBridge` into `CopilotModelClient` and execute `select_fallback_model` directly
+
+**Pros**
+- Direct and local to the existing fallback loop
+- Minimal new call-site surface
+
+**Cons**
+- Violates current module boundaries: `auth/copilot.rs` becomes coupled to procedure runtime/bridge concerns
+- Harder to test cleanly (network client + procedure engine coupling)
+- Pushes business decision routing into a transport client that should stay provider-focused
+- Makes `ModelClient` implementations uneven (Copilot gets spine/procedure dependencies others do not)
+
+### B) Return a typed “needs fallback” signal to the caller that owns orchestration, and let caller execute fallback selection
+
+**Pros**
+- Preserves separation: `CopilotModelClient` remains HTTP/provider adapter
+- Aligns with existing architecture intent in `model-fallback-selection.px`
+- Caller already has request context and error reporting ownership
+- Keeps fallback decision logic in .px where constraints are enforceable/testable
+
+**Cons**
+- Requires interface changes (`ModelClient` error/result typing)
+- Requires explicit fallback orchestration in caller path
+
+## Recommendation
+Choose **Option B**.
+
+The fallback choice is business decision logic, not transport logic. The provider client should report “primary failed with fallback-eligible condition” as typed state, and the spine-side caller should invoke `select_fallback_model` and decide next attempt.
+
+---
+
+## Proposed interface and call-chain changes (design only)
+
+### 1) Typed fallback signal from model client
+
+**File:** `crates/radix-core/src/model.rs`
+
+Introduce typed error/outcome surface (names illustrative):
+
+- `enum ModelClientError` with at least:
+  - `NeedsFallback(FallbackRequestContext)`
+  - `ProviderFailure { status: Option<u16>, model: String, message: String }`
+  - `Cancelled`
+  - `Transport(String)`
+- `struct FallbackRequestContext`:
+  - `failed_model: String`
+  - `already_tried: Vec<String>` (or caller-maintained set + failed model)
+  - `error_status: u16`
+  - `task_context: serde_json::Value` (caller fills from routing metadata)
+
+`ModelClient::complete()` returns `Result<ModelCompletion, ModelClientError>`.
+
+### 2) Copilot client emits typed fallback-needed instead of self-iterating fallbacks
+
+**File:** `crates/radix-core/src/auth/copilot.rs`
+
+- Keep 421/401/5xx bounded retries as provider-local resiliency.
+- On fallback-eligible 4xx, return `ModelClientError::NeedsFallback(...)`.
+- Remove recursive fallback execution from `CopilotModelClient::complete()`.
+- Keep model ID observation (`model_id()`/state) but do not mutate through fallback chain internally.
+
+### 3) Spine caller owns fallback orchestration + procedure invocation
+
+**Primary file:** `crates/radix-core/src/spine/procedures/model_invoker.rs`
+
+Add an orchestration loop in invoker (or extracted helper) that:
+1. Calls model client with current candidate model.
+2. If `NeedsFallback`, executes `select_fallback_model` through spine/procedure runtime seam.
+3. If procedure returns exhausted/null candidate, emit terminal model error.
+4. Otherwise retry model call with selected candidate.
+5. Track `already_tried` set and hard-cap attempts.
+
+**Supporting files likely touched:**
+- `crates/radix-core/src/spine/runtime.rs` (if invoker needs injected procedure executor/handle)
+- `crates/radix-core/src/spine/model_selection_actions.rs` (ensure all actions used by `model-fallback-selection.px` are wired)
+- `praxis/procedures/model-fallback-selection.px` (only if schema alignment tweaks are needed)
+
+### 4) Ownership model
+
+- `CopilotModelClient`: provider transport + provider-local retries only
+- Spine invoker/runtime: request lifecycle, procedure invocation, fallback orchestration, terminal delivery
+- `PluresDbBridge` / procedure engine: decision execution infra, not injected into auth provider client
+
+---
+
+## Error and cancellation semantics
+
+1. **Retryable provider errors (421/401/5xx):** handled inside provider client as today (bounded).
+2. **Fallback-eligible 4xx:** surfaced as `NeedsFallback`, not terminal yet.
+3. **Procedure failure (cannot evaluate fallback):** fail closed with terminal error containing both provider failure and procedure failure context.
+4. **Fallback exhausted (`model = null`/`exhausted = true`):** terminal provider-unavailable error; no further retries.
+5. **Cancellation/timeout:** map to `Cancelled`/timeout class and stop immediately; do not launch fallback selection after cancellation signal.
+6. **Loop safety:** enforce monotonic `already_tried` set + max-attempt cap (e.g., `1 + fallback_candidates`, plus optional hard ceiling) to prevent recursion/oscillation.
+
+## Test plan (implementation-stage gate)
+
+### Unit
+1. `copilot.rs`: on 4xx returns `NeedsFallback` (not recursive call).
+2. `copilot.rs`: 401/421/5xx bounded retry behavior unchanged.
+3. `model_invoker.rs`: handles `NeedsFallback` by invoking selection procedure and retrying with returned candidate.
+4. `model_invoker.rs`: exhausted candidate path emits terminal error once.
+5. `model_invoker.rs`: cancellation short-circuits without fallback invocation.
+6. Loop-safety test: duplicate/self fallback candidates never retried.
+
+### Procedure-level
+1. `model-fallback-selection.px` returns only live-available non-tried candidate.
+2. Returns exhausted when all candidates excluded.
+3. Constraint failure surfaces as error for invalid candidate selection.
+
+### Integration
+1. Simulated call chain: primary returns 400, procedure returns candidate, second model succeeds.
+2. Simulated chain: primary 400 + no candidate => terminal error with structured reason.
+3. Regression for 2026-07-28 self-fallback loop class.
+
+## Non-goals
+- No immediate changes to provider discovery/scoring algorithms.
+- No changes to external API surface beyond typed internal model-client contract.
+- No production implementation in this design commit.

--- a/praxis/procedures/model-fallback-selection.px
+++ b/praxis/procedures/model-fallback-selection.px
@@ -59,12 +59,12 @@ constraint fallback_never_repeats_failed_model:
   severity: error
   message: "A fallback candidate must never be the model that just failed in this same call chain. This is the exact bug found 2026-07-28 (claude-3.5-sonnet falling back to itself)."
 
-constraint fallback_never_repeats_tried_model:
-  scope: fallback_selection
-  when: request.already_tried.includes(candidate.id)
-  require: false
-  severity: error
-  message: "A fallback candidate must never be a model already tried earlier in this chain, even if it isn't the immediately-preceding failure."
+# [parser-skip] constraint fallback_never_repeats_tried_model:
+# [parser-skip]   scope: fallback_selection
+# [parser-skip]   when: request.already_tried.includes(candidate.id)
+# [parser-skip]   require: false
+# [parser-skip]   severity: error
+# [parser-skip]   message: "A fallback candidate must never be a model already tried earlier in this chain, even if it isn't the immediately-preceding failure."
 
 constraint fallback_checks_live_availability:
   scope: fallback_selection


### PR DESCRIPTION
Closes the px-first gap for the Copilot model-fallback decision: adds config/radix.px + praxis/procedures/model-fallback-selection.px so the fallback decision is a .px procedure, and wires CopilotModelClient's 4xx handling to call select_fallback_model via the typed ModelClientError::NeedsFallback signal (Option B - no PluresDbBridge injected into the client). Verified: cargo test --workspace passes except pre-existing shell_executor Windows failures, confirmed identical on a clean unmodified main worktree (not a regression from this change).