### PR TITLE
ADR-0025 revision: procedure-graph-canonical model

### DIFF
--- a/.praxis/decisions/ADR-0025-hyperswarm-git-forge.md
+++ b/.praxis/decisions/ADR-0025-hyperswarm-git-forge.md
@@ -1,278 +1,178 @@
-# ADR-0025: Hyperswarm-Backed Git Forge (`hyperswarm-git` plugin)
+# ADR-0025: Procedure-Graph Forge with Hyperswarm Collaboration and Git Compatibility
 
-## Status: Proposed
+## Status: Proposed (Revised)
 
-## Date: 2026-06-26
+## Date: 2026-07-24
 
-> Driver: kbristol directive (Radix Plugin Program, Task 2.A —
-> `workspace/memory/plan-radix-plugins-2026-06-26.md` §2.A). Design-only (Pillar 1).
-> Authors the forge architecture + the `git-repo@1.x` CID + a capability-gap list that
-> feeds Task 3. **No implementation code in this ADR.** It composes existing foundation
-> primitives (PluresDB + its built-in Hyperswarm sync, `plures-object`, `pares-arca`,
-> `secrets@1.x` from vault) rather than reinventing storage or transport, per
-> C-PLURES-002/004.
+> Driver: corrected Phase 2 architecture direction (kbristol, 2026-07-24) captured in
+> `workspace/memory/phase2-git-forge-corrected-architecture.md`.
+> This revision replaces ADR-0025's prior canonical-storage premise.
+> Design-only (Pillar 1). No implementation in this ADR.
 
 ## Context
 
-There is **no git forge in the plures org** (verified: GitHub `plures` org + local
-`C:\Projects` scan, 2026-06-26). A Hyperswarm-backed forge is genuinely net-new, but it\nis **not greenfield-from-zero**: a git repository *is* a content-addressed object database
-with a thin pointer (refs) layer, and the org already ships every substrate it needs:
+ADR-0025 previously treated conventional Git objects/packs as the canonical repository
+content and PluresDB as pointer/metadata state around that content. That model is now
+incorrect.
 
-- **PluresDB** — CRDT store with **built-in Hyperswarm sync (a foundation pillar)**,
-  reactive procedures, event triggers, graph ops. The forge's HA/DR rides this sync; it is
-  **not** a new transport.
-- **`plures-object`** — S3-compatible, content-addressed chunk store with Hyperswarm P2P
-  replication. A git object store is content-addressed by construction (SHA-1/SHA-256 of
-  the object) → this is the natural home for git blobs/trees/commits/packs.
-- **`pares-arca`** — distributed content cache (PluresDB + Hyperswarm) → edge/CDN for
-  read-heavy `fetch`/`clone` traffic.
-- **`secrets@1.x`** (vault provider, per ADR-0024 §3) — deploy keys, push tokens, SSH host
-  keys. The forge **depends on** this; it does not build credential storage.
-- **`agens`** (PRIVATE) — optional LLM for PR summarization/review. Optional capability;
-  absent ⇒ degrade.
+Per Phase 1 architecture decisions, the canonical repository is the **PluresDB procedure
+graph**. Conventional Git objects are a **compatibility projection** for existing Git clients,
+not the source of truth.
 
-This ADR builds on ADR-0024 (canonical plugin format: `plugin.toml` + `.px` procedures +
-adapter IO + `ui/` on design-dojo + capability deps) and ADR-0022 (capability/CID model,
-TOML CIDs, mediated events/nodes). The forge is authored as **one canonical plugin** that
-**provides** `git-repo@1.x` and **consumes** `storage`, `network`, `secrets@^1.0`, and
-optionally `llm`.
+The corrected repository model is:
 
-**The four problems this design must resolve (named in the program plan as open):**
+1. **Canonical repository:** PluresDB native graph + procedure history.
+2. **Portable canonical snapshot:** deterministic `.px` procedure bundle.
+3. **Bulk immutable content:** `plures-object`.
+4. **Distribution/cache:** `pares-arca`.
+5. **Conventional Git objects/refs:** generated compatibility artifacts only.
 
-1. **Object model** — map git loose/packed objects onto `plures-object` content-addressed
-   chunks vs. native PluresDB blob nodes.
-2. **Wire protocol surface** — which git transports for v1, and the fact that they are
-   **long-lived/streaming**, which the current radix IO-actor model (request/response) does
-   not serve.
-3. **The hard problem** — git refs are single-writer-ish pointers, but PluresDB is
-   CRDT/multi-writer. A ref-update conflict policy must be **decided**, not hand-waved.
-4. **Feature scope** — what ships in v1 vs. later, mapped to `.px` procedures + mediated
-   events.
+This ADR must preserve valid parts of the prior design (forge lifecycle, capability model,
+Arca integration, Bastion/secrets integration, and explicit streaming transport gap), while
+reframing data authority around the native procedure graph.
 
 ## Decision
 
-Author `hyperswarm-git` as a canonical ADR-0024 plugin providing `git-repo@1.x`. The
-decisions below resolve the four problems and pin the layering: **git *semantics* (packfile
-negotiation, ref advertisement, the transports) live in `adapter/` TypeScript (or a Rust
-actor) at the IO boundary; forge *logic* (PR / issue / review / release / webhook
-lifecycle, ref-update policy) lives in `.px` procedures over PluresDB; UI lives in `ui/` on
-design-dojo.**
+Author `hyperswarm-git` as a canonical plugin that provides `git-repo@1.x`, but redefine
+its architecture as **procedure-graph-first**:
 
-### 1. Object model — `plures-object` for content, PluresDB nodes for refs/metadata
+- Native authoring, review, and merge semantics operate on PluresDB graph revisions.
+- Git protocol endpoints expose a compatibility projection generated from canonical graph
+  state.
+- Replication/causal-state sync remains owned by PluresDB native Hyperswarm; radix sync
+  does not reimplement replication.
 
-**RECOMMENDED:** store git **objects and packs in `plures-object`** (content-addressed
-chunks); store **refs and all forge metadata as PluresDB nodes**. Justification:
+### 1) Canonical data and projection layers
 
-- A git object is *immutable and content-addressed by its hash* — identical to
-  `plures-object`'s model. Reusing it gives us de-dup, chunked transfer, and **Hyperswarm
-  P2P replication of objects for free**, which is exactly the HA/DR story. Re-encoding git
-  objects as PluresDB blob nodes would duplicate a content-addressed store we already own
-  (C-PLURES-002 violation) and lose `plures-object`'s replication.
-- Refs, PRs, issues, reviews, releases, webhooks are **mutable, queryable, reactive,
-  multi-writer** records → exactly PluresDB nodes (so `.px` procedures react to them and
-  CRDT sync replicates them). They are small pointers/metadata, not bulk content.
-- `git_object` and `pack` therefore appear in the CID as **node *descriptors* that
-  reference `plures-object` content by hash** (the node holds `oid` + `kind` + a
-  content-address handle; the bytes live in `plures-object`). The node is the index entry;
-  `plures-object` is the bytes. `pares-arca` caches hot objects/packs at the edge for
-  `fetch`.
+The forge uses explicit layers with non-overlapping authority:
 
-Loose vs. packed: incoming loose objects (from `receive-pack`) are written to
-`plures-object`; periodic repacking (a `.px`-triggered maintenance op invoking a `git`
-actor at the IO boundary) coalesces them into packs, also stored in `plures-object`. Pack
-**integrity** (object count + checksum trailer) is a CID invariant the provider must verify
-on ingest.
+- **Canonical layer (authoritative):**
+  - PluresDB collaboration graph (repos, branches, proposals, reviews, policy decisions).
+  - Append-only multi-writer graph revisions; divergence is preserved explicitly as graph
+    structure, not flattened by last-writer-wins.
+- **Portable canonical snapshot:**
+  - Deterministic `.px` bundle export/import for reproducible transfer and recovery.
+- **Bulk content layer:**
+  - `plures-object` stores immutable payloads (blob-like content, bundles, pack artifacts,
+    release/build artifacts).
+- **Distribution layer:**
+  - `pares-arca` handles cache/distribution segments (public, org, repo, release-channel,
+    build-cache, private-workspace).
+- **Git compatibility layer (non-authoritative):**
+  - Conventional Git commits/trees/blobs/refs generated as a projection from canonical graph
+    state for interoperability with unmodified Git clients.
 
-### 2. Wire protocol surface — smart-HTTP first; `git://` + SSH next. Streaming is a real gap.
+### 2) Concurrency model: native graph vs Git-compatible refs
 
-**v1 transport: smart-HTTP** (`git-upload-pack` for fetch/clone, `git-receive-pack` for
-push) — it works through firewalls/proxies, is the most widely supported, and any `git`
-client speaks it unmodified. **v2 transports: `git://` daemon, then SSH.**
+The system keeps two distinct mutation contracts:
 
-The **git semantics layer** — ref advertisement, packfile negotiation
-(`want`/`have`/`ACK`/`NAK`), pack generation and ingest — lives in **`adapter/` (TS, or a
-Rust actor)** at the declared IO boundary (ADR-0024 three-way split). It is pure git
-protocol mechanics; it calls into `plures-object` for object bytes and writes/reads ref
-nodes via the host. The **forge logic** (who may push, ref-update policy, PR/issue/review
-lifecycle) is `.px`.
+- **Native graph revisions:** append-only, multi-writer, divergence-preserving.
+  - Competing updates coexist as explicit graph branches/lineage.
+  - Canonical branch selection is a policy-governed graph operation.
+- **Git-compat refs:** strict compare-and-swap (CAS).
+  - Ref updates require `expected-head`.
+  - Mismatch is rejected (non-fast-forward behavior for Git clients).
 
-**🔴 CAPABILITY GAP (feeds Task 3 §3.B):** git smart-HTTP, `git://`, and SSH are
-**long-lived, duplex, streaming** protocols (a single fetch can stream a multi-megabyte
-packfile; `receive-pack` streams the client's pack in). **Radix's current IO-actor model is
-request/response** (mediated events carry a request, a result comes back). It has **no
-streaming/duplex transport host capability today.** This is a *real* gap, not a forge-only
-hack: the correct fix per the program's governing rule is a **general streaming-transport
-host capability** (a `network`-class long-lived/duplex actor surface) usable by any plugin
-needing streaming IO, not a git-specific bolt-on. v1 of the forge can begin with a
-buffered/chunked request/response approximation for small repos, but the production
-transport requires this host capability to land. **This ADR's primary Task-3 output is that
-gap.**
+This avoids imposing Git's single-head pointer semantics onto native graph collaboration while
+still providing familiar Git behavior in the compatibility surface.
 
-### 3. The hard problem — ref-update conflict policy under CRDT (per-repo authoritative writer + CAS)
+### 3) Hyperswarm ownership boundaries
 
-Git refs are single-writer-ish pointers (`refs/heads/main` is one SHA at a time, advanced
-by a push that asserts its expected old value). PluresDB is CRDT/multi-writer — a naive
-last-writer-wins on a ref node would silently lose pushes and break git's fundamental
-fast-forward guarantee. **Decision (the riskiest design point, made explicit):**
+- **PluresDB native Hyperswarm owns:** replication transport, causal state propagation,
+  and graph sync semantics.
+- **Radix sync/host layer owns:** pairing UX, subscriptions, partition policy,
+  approval/control plane, and observability.
+- **Radix forge does not own:** reimplementation of replication/CRDT conflict mechanics.
 
-- **Compare-and-swap (CAS) semantics on every ref update.** A ref node carries
-  `(repo_id, name, target_oid, generation)`. A push's `receive-pack` supplies the
-  **expected old `oid`** (git already sends this in the ref-update command). The provider's
-  `.px` ref-update procedure accepts the update **iff** the stored `target_oid` equals the
-  expected old oid (or the ref is being created and is absent), then atomically advances
-  `target_oid` and bumps `generation`. Mismatch ⇒ **reject with non-fast-forward** (the
-  exact error git already understands), surfaced to the client. This makes ref updates
-  *linearizable per ref* and maps native git semantics onto the store. **This is a CID
-  invariant (`ref_update_cas`).**
-- **Per-repo authoritative writer to serialize concurrent CAS.** Because CAS across a
-  CRDT needs a serialization point, each repo binds to a **Hyperswarm topic = repo_id**, and
-  ref-mutating writes are funneled through an **authoritative writer for that repo** (a
-  per-repo single-writer election over the Hyperswarm topic). Reads/clones/fetches are
-  served by **any** replica (that is the HA/DR win — full P2P read scale-out); only the
-  small, rare ref-*mutation* path is serialized through the elected writer. Writer
-  unavailability ⇒ re-election; until a writer is present, the repo is **read-only**
-  (fetch/clone keep working from replicas), which is a safe, explicit degradation rather
-  than divergent refs.
-- **Why this and not pure-CRDT refs:** a pure-CRDT ref would have to *merge* two divergent
-  branch tips, which has no correct git meaning (it would fabricate history). CAS + a
-  per-repo writer preserves git's "a push either fast-forwards or is rejected" contract
-  exactly, while still getting CRDT replication for everything that legitimately *is*
-  multi-writer (issues, PR comments, reviews — those merge fine). **Objects are immutable and
-  content-addressed**, so object replication needs no conflict policy at all; only the
-  pointer (ref) layer does.
+### 4) Capability and portfolio mapping (preserved and clarified)
 
-This split — **immutable content (P2P, no conflict) + serialized pointers (CAS via per-repo
-writer) + freely-merging social metadata (CRDT)** — is the core architectural insight of the
-forge.
+This ADR aligns responsibilities without re-litigating ownership:
 
-### 4. Forge feature set — v1 vs. later, mapped to `.px` + mediated events
+- **pares-radix:** capability host + forge procedures/orchestration in this repo.
+- **pares-scribe:** graph/projected editor path
+  (`editor -> projection doc -> semantic ranges -> owning .px procedures -> PluresDB tx`).
+- **pares-bastion + `secrets@1.x`:** secrets, identity, signing, key material.
+- **pares-arca:** artifact distribution/cache only.
+- **pares-modulus:** forge/app packaging and governance; issues/PRs/projects/CI/releases as
+  governed Modulus plugins.
+- **pluresdb (native Hyperswarm):** canonical repository + collaboration graph + replication.
 
-| Feature | v1? | `.px` procedure(s) | Mediated op / event |
-|---|---|---|---|
-| Repos (create/list/delete/archive) | ✅ v1 | `repo-lifecycle` | (host/admin ops; nodes) |
-| Refs (advertise, CAS-update) | ✅ v1 | `ref-update` (CAS, §3) | `push_received` → `ref.updated` |
-| Push (`receive-pack`) | ✅ v1 | `ingest-pack` + `ref-update` | `push_received` |
-| Fetch/clone (`upload-pack`) | ✅ v1 | `serve-pack` (negotiation in adapter) | `fetch` |
-| Pull requests (open/merge/close) | ✅ v1 | `pr-lifecycle` | `open_pr`, `merge_pr` |
-| Issues (open/comment/close) | ✅ v1 | `issue-lifecycle` | `open_issue` |
-| Reviews (approve/request-changes) | ✅ v1 | `review-lifecycle` | `create_review` |
-| Releases (tag → release) | ⏳ later | `release-lifecycle` | `create_release` |
-| Webhooks (register/deliver) | ⏳ later | `webhook-dispatch` | `register_webhook` |
-| CI hooks (on push/PR) | ⏳ later | rides `webhook` + ADR-0023 events | (consumes proc events) |
-| PR auto-summary/review (LLM) | ⏳ later (optional cap) | `pr-summarize` (via agens) | optional `llm` |
+### 5) Transport surface and streaming gap (preserved)
 
-The CRDT-merge nature of PluresDB is a **feature** for the social layer: issue/PR comments
-and reviews from multiple participants merge without conflict. Only refs need CAS (§3).
-Release and webhook lifecycle are **deferred, not stubbed** (C-NOSTUB-001) — present in the
-CID marked `deferred`, with no fake implementation.
+Transport sequence remains:
 
-### 5. Capabilities — requires / provides
+- v1: smart-HTTP (`upload-pack`/`receive-pack` compatibility projection).
+- later: `git://` and SSH compatibility endpoints.
 
-**Requires** (ADR-0024 `[capabilities.required]` / `[dependencies].capabilities`):
-- `storage = "^1.0"` (platform, ADR-0011) — PluresDB nodes for refs/metadata; the
-  `plures-object` content store is reached through the storage/object substrate.
-- `network = "^1.0"` (platform, ADR-0011, `user-approve`) — git transports. **NB: needs the
-  streaming-transport extension from §2/Task-3 for production.**
-- `secrets = "^1.0"` (provider, via vault per ADR-0024 §3) — deploy keys, push tokens, SSH
-  host keys. **Declared dependency**, not a homegrown store.
+The prior capability gap remains valid and is now more explicit:
 
-**Optional:**
-- `llm = "^1.0"` (provider, via agens) — PR summarization/review. Feature-detected; absent ⇒
-  the summary feature is simply absent (not faked).
+- Git transport is long-lived, duplex, and streaming.
+- Current request/response IO actor shape is insufficient for production-scale push/fetch.
+- A **general streaming transport host capability** is required at radix host level.
 
-**Provides:**
-- `git-repo = "1.0.0"` — CID `capabilities/git-repo.cid.toml` (this ADR's File 2).
+This is foundation work; do not hide it behind buffered approximations presented as complete.
 
-### 6. UI — forge screens in `ui/` on design-dojo
+### 6) Forge lifecycle scope in this ADR
 
-Per ADR-0024 §5, **product-specific** forge screens live in the plugin's `ui/` (built on
-`@plures/design-dojo` primitives), not in design-dojo itself (kit, not catalog):
-- **Repo browser** — repo list, file tree, blob view, commit log (reads ref/object nodes).
-- **PR view** — PR list, conversation/timeline, **diff** view, review controls, merge button.
-- **Issue tracker** — issue list, issue detail + comments.
-- **Releases** (when v-later lands).
+v1 procedures remain design targets (no implementation here):
 
-Long-lived transport operations (a big clone/push in progress) surface through the
-**design-dojo side-effect-handler UI** (progress/connection-status), which ADR-0024 §5 places
-in design-dojo for exactly these long-lived IO actors.
+- Repo lifecycle (create/archive/delete policy-gated)
+- Graph branch/proposal lifecycle
+- Git-compat projection generation and ref CAS updates
+- PR/issue/review lifecycle as governed procedures/plugins
+- Artifact publication hooks to Arca
+
+Deferred (explicitly absent until built):
+
+- Full release automation surfaces
+- Webhook ecosystem breadth
+- Advanced Git features dependent on streaming maturity (e.g., very large transfer
+  optimizations)
 
 ## Consequences
 
-**Positive**
-- A real GitHub alternative whose **HA/DR is inherent** (Hyperswarm P2P object replication +
-  read scale-out from any replica), not bolted on. Any `git` client works unmodified
-  (smart-HTTP).
-- Maximal foundation reuse: objects→`plures-object`, cache→`pares-arca`, sync→PluresDB
-  Hyperswarm, secrets→vault. Net-new code is the **git semantics layer + forge `.px`** — the
-  irreducible new part — honoring C-PLURES-002/004.
-- The social layer (issues/PR comments/reviews) gets **conflict-free multi-writer merge for
-  free** from PluresDB CRDT — a genuine advantage over a centralized forge.
-- Forge primitives (refs/PR/issue/review/release as reusable `.px`) generalize to other
-  project-management plugins (sprint-log, agent-console overlap), per the program's
-  reuse mandate.
+### Positive
 
-**Negative / costs**
-- The **streaming-transport host capability does not exist yet** — v1 production push/fetch
-  is blocked on that Task-3 foundation work (buffered approximation only until then).
-- A **per-repo authoritative-writer election** is real distributed-systems machinery (leader
-  election over a Hyperswarm topic, failover, read-only degradation window). It must be
-  built and tested carefully; it is the highest-risk component.
-- Git protocol mechanics (pack negotiation v0/v1/v2, shallow/partial clone, multi-ack) are
-  intricate; the adapter is non-trivial even though it composes existing object storage.
+- Restores architectural truth: canonical source is the procedure graph, not Git object
+  storage.
+- Clean separation between collaboration semantics (native graph) and interoperability
+  semantics (Git projection).
+- Preserves multi-writer collaboration richness without sacrificing strict Git client
+  expectations at projection refs.
+- Reuses existing foundations appropriately:
+  PluresDB for state/replication, `plures-object` for immutable payloads,
+  `pares-arca` for distribution/cache, Bastion/`secrets@1.x` for security/signing.
 
-**Risks**
-- **Ref divergence if CAS/writer-election is wrong** — the single most dangerous failure
-  (silent lost pushes / fabricated history). Mitigation: CAS is a CID invariant validated at
-  the provider surface; per-repo single-writer serialization; read-only (never divergent)
-  degradation when no writer. This is why §3 is decided explicitly and tested first.
-- **Pack integrity / object corruption** across P2P replication. Mitigation: content-address
-  verification on ingest + a `pack_integrity` CID invariant (object count + checksum
-  trailer); `plures-object` already content-addresses, so corruption is detectable by hash.
-- **Streaming approximation masking the gap** — shipping the buffered v1 and calling the
-  transport "done." Mitigation: the gap is recorded as Task-3 foundation work and the CID
-  marks production transport dependencies honestly (C-NOSTUB-001); the buffered path is
-  labeled a known limitation, not a finished transport.
-- **Auth surface** — deploy keys/tokens are security-critical. Mitigation: depend on
-  `secrets@^1.0` (vault); never store credentials in plugin state (no localStorage,
-  C-PLURES-003).
+### Negative / costs
 
-## Implementation outline (lifecycle work, gated; design = Pillar 1 only here)
+- Projection pipeline becomes a critical subsystem and must be deterministic and auditable.
+- Canonical-branch policy on divergent graph histories requires strong governance defaults.
+- Streaming host capability remains a prerequisite for production-grade transport behavior.
 
-The dev lifecycle (analyze → build → test → deploy → verify) drives each stage as gated
-subagents. This ADR is the design (Pillar 1) only.
+### Risks and mitigations
 
-1. **`git-repo@1.x` CID** (`capabilities/git-repo.cid.toml`, File 2 of this ADR) — the
-   contract: node types, mediated ops, events, invariants. Provider validated against it at
-   install (ADR-0022 §7).
-2. **Object/ref mapping** — `git_object`/`pack` node descriptors referencing `plures-object`
-   content; `ref` nodes with `(target_oid, generation)`. Repack maintenance op (`.px`-triggered,
-   `git` actor at IO boundary).
-3. **Ref-update CAS + per-repo writer election** (§3) — the riskiest piece; **build and test
-   FIRST**, in isolation, against the non-fast-forward contract. Hyperswarm topic = repo_id.
-4. **Smart-HTTP adapter** — `upload-pack`/`receive-pack` semantics in `adapter/` (TS or Rust
-   actor); pack negotiation + integrity verify on ingest.
-5. **Streaming-transport host capability (Task 3, foundation/radix)** — general
-   long-lived/duplex actor surface; unblocks production push/fetch and `git://`/SSH later.
-   Routed to pares-radix (the legitimate side-effect boundary).
-6. **Forge `.px` procedures** — repo/ref/PR/issue/review lifecycle over PluresDB nodes;
-   release/webhook deferred.
-7. **UI** (`ui/` on design-dojo) — repo browser, PR+diff view, issues; side-effect-handler UI
-   for long transports.
-8. **Tests BLOCK** (provider, ADR-0024 §6 / C-TEST-002): channel-independent — load the plugin
-   in a real radix instance, drive `push_received`/`fetch`/`open_pr` via the host, assert
-   PluresDB ref/PR state; **build the binary, run a real `git push`/`git clone` against it**
-   (C-TEST-001), assert ref CAS rejects a non-fast-forward.
+- **Risk:** accidental authority inversion (treating projection as source of truth).
+  - **Mitigation:** explicit contract: projection artifacts are generated, never canonical.
+- **Risk:** CAS bugs in Git-compat ref updates causing client-visible inconsistency.
+  - **Mitigation:** strict expected-head validation with deterministic rejection semantics.
+- **Risk:** overlap/confusion between radix sync and PluresDB replication responsibilities.
+  - **Mitigation:** boundary codified in this ADR; replication work routes to PluresDB.
+
+## Implementation outline (design-stage guidance only)
+
+1. Update `git-repo@1.x` CID language to encode canonical-vs-projection authority.
+2. Define deterministic projection procedures from graph revisions to Git-compat artifacts.
+3. Preserve strict CAS contract for Git-compat refs (`expected-head`).
+4. Route replication features to PluresDB; restrict radix sync scope to control-plane duties.
+5. Keep Arca/Bastion/Modulus integration points explicit in procedure lifecycle definitions.
+6. Validate with design-time invariants before dev stage: no projection write path may bypass
+   canonical graph policy.
 
 ## References
-- ADR-0010 — Agens-first plugin model
-- ADR-0011 — Plugin security (platform capabilities, mediated IO, trust tiers)
-- ADR-0022 — Capability host contract (provider capabilities, CIDs, resolver, binding policy)
-- ADR-0023 — Procedure observability event contract (CI hooks consume `plures.proc.event.v1`)
-- ADR-0024 — Canonical plugin format (`plugin.toml` + `.px` + adapter + `ui/`; capability deps; `secrets@1.x` via vault)
-- `capabilities/commerce.cid.toml` — the reference CID format this CID mirrors
-- `capabilities/git-repo.cid.toml` — the `git-repo@1.x` CID authored alongside this ADR
-- C-PLURES-002 / C-PLURES-003 / C-PLURES-004 — extend don't reinvent; state in PluresDB; pure logic in PluresDB, IO at the boundary
-- C-NOSTUB-001 — no stubs; deferred features marked absent (release/webhook/streaming), never faked
-- C-TEST-001 / C-TEST-002 — channel-independent QA; build the binary, run a real `git` client against it
-- Foundation primitives: PluresDB (built-in Hyperswarm sync), `plures-object` (content-addressed P2P chunks), `pares-arca` (distributed cache), `plures-vault`→`secrets@1.x`, `agens` (private LLM)
-- Program plan: `workspace/memory/plan-radix-plugins-2026-06-26.md` §2.A (thesis + open questions) and §3.B (streaming-transport gap)
+
+- `workspace/memory/phase2-git-forge-corrected-architecture.md`
+- ADR-0022 — capability/CID model
+- ADR-0024 — canonical plugin format + capability dependencies
+- Prior ADR-0025 revision (2026-06-26) — retained valid transport/capability/lifecycle framing
+- Foundation components: PluresDB (native Hyperswarm), `plures-object`, `pares-arca`,
+  `pares-bastion`, `secrets@1.x`, `pares-modulus`, `pares-scribe`

--- a/.praxis/decisions/ADR-0038-deterministic-git-projection.md
+++ b/.praxis/decisions/ADR-0038-deterministic-git-projection.md
@@ -1,0 +1,172 @@
+# ADR-0038: Deterministic Procedure-Graph-to-Git Projection
+
+## Status: Proposed
+
+## Date: 2026-07-30
+
+> Companion to ADR-0025 (revised, "Procedure-Graph Forge with Hyperswarm Collaboration and
+> Git Compatibility"). Design-only (Pillar 1). **No implementation code in this ADR.**
+> This ADR exists because ADR-0025's corrected model treats git objects/packs as a
+> **generated compatibility projection** of the canonical PluresDB procedure graph, and that
+> projection is only correct if it is byte-reproducible across independent replicas — a
+> requirement substantial enough to need its own explicit invariants, not a hand-wave
+> inside ADR-0025 itself.
+
+## Context
+
+ADR-0025 (revised) establishes that the PluresDB procedure graph is the canonical
+repository, and that conventional git objects/refs served to `git` clients are generated
+compatibility artifacts — not the source of truth. This is only safe if:
+
+1. **Any replica**, computing the projection independently from the same graph revision,
+   produces **byte-identical** git objects (same SHA, same pack bytes) — otherwise two
+   peers could silently disagree about what `git clone` returns for the same ref, which is
+   a correctness failure invisible at the graph layer (the graph itself has no conflict;
+   only its git-facing shadow diverges).
+2. The projection is **reproducible over time** — recomputing the projection for the same
+   historical graph revision, on any node, at any later time, yields the same bytes it
+   would have at the time the ref was first advertised. Projected packs are a regenerable
+   cache; if regeneration ever produced different bytes than what a client previously
+   fetched and pinned locally, that client's repository would desync from the forge's
+   notion of history.
+3. The projection has a **precise entity mapping** back to graph nodes/`.px` procedures,
+   not just "produces valid git bytes" — needed by any graph-native editor consuming the
+   projection (e.g. pares-scribe) to map a byte range in the projected view back to the
+   owning graph entity.
+
+None of these are automatic. Naive "serialize the graph to git objects" code has many
+silent non-determinism sources (hash-map iteration order, floating timestamp precision,
+locale-dependent formatting, unstable sort comparators, differing compression producing
+different pack bytes for the same logical content, etc.). This ADR pins the invariants
+that close those gaps.
+
+## Decision
+
+### 1. Ordering invariants
+
+- **Tree entries** (graph child-edges representing directory contents) MUST be projected
+  in **strict byte-wise ordering of entry name**, exactly matching git's own tree-object
+  ordering rule (sorted by name, treating a trailing `/` as part of the comparison for
+  directories). This ordering MUST be computed at projection time from the graph edge set
+  — it MUST NOT depend on any incidental storage/iteration order of the underlying
+  PluresDB query.
+- **Commit parents**: for a graph revision with multiple causal parents, parent order in
+  the projected commit object MUST be a **deterministic function of the graph's recorded
+  causal order** (e.g., first parent = the graph's designated primary predecessor,
+  following parents = other predecessors in the order the merge procedure recorded them)
+  — never re-sorted by hash, timestamp, or iteration order at projection time.
+- **Pack object ordering**: when multiple objects are bundled into a pack, object order
+  MUST follow a stated deterministic rule (e.g., topological order by graph causal history,
+  then tree/blob objects in the order first referenced by that walk) — pinned as a CID/
+  procedure invariant, not left to incidental collection iteration.
+
+### 2. Timestamp / encoding invariants
+
+- All projected timestamps (commit author/committer time) MUST be serialized in git's
+  canonical `<unix-seconds> <±HHMM>` format, sourced from a single canonical timestamp
+  field on the graph revision (not derived from wall-clock at projection time, not
+  reformatted through a locale-aware date library whose output can vary by environment).
+- Author/committer name and email MUST be projected verbatim from a single canonical
+  string field on the graph node (no environment-dependent normalization).
+- String encoding is UTF-8, no BOM, matching git's convention; content stored with a
+  different declared encoding is transcoded at projection time via a single pinned
+  transcoding path.
+
+### 3. Hashing invariants
+
+- Git object hashing (SHA-1 for compatibility with existing git tooling; SHA-256 is
+  out of scope for v1, tracked as a later variant) MUST be computed over the exact git
+  object byte format (`"<type> <length>\0<content>"`) using a single shared hashing
+  routine — not reimplemented ad hoc at each call site.
+- The projection function MUST be **pure**: `project(graph_revision_id) -> git_object_bytes`
+  with no hidden inputs (no current wall-clock, no random IDs, no host-specific state). Any
+  non-graph input the projection needs (e.g., a compression level) MUST be a **pinned
+  constant** recorded in this ADR or the CID, not a runtime-configurable default that could
+  differ across replica deployments.
+- **Pack compression**: because delta selection can legitimately produce different but
+  equally valid packs, the determinism requirement is scoped to **per-object hashes**
+  (every loose object's SHA MUST be reproducible), while pack byte-layout MUST be
+  reproducible only insofar as v1 uses a fixed, versioned delta/ordering algorithm — an
+  implementation MAY skip delta-compression entirely for v1 (store all objects undeltified
+  in the pack) to eliminate this axis of non-determinism until a later revision adds a
+  pinned delta algorithm. This tradeoff MUST be an explicit implementation-stage decision
+  recorded against this ADR, not silently assumed.
+
+### 4. Reproducibility test requirement (blocks "done")
+
+Before the projection is considered implementation-complete:
+
+- **Cross-replica determinism test**: two independent processes (ideally two different
+  machines/OSes, or at minimum two independent process invocations with no shared runtime
+  state) project the **same graph revision** and assert **byte-identical** output for every
+  object and the resulting pack (or byte-identical loose objects if v1 skips
+  delta-packing per §3). This is the acceptance gate for this ADR's invariants.
+- **Time-travel reproducibility test**: project the same historical graph revision twice,
+  separated by wall-clock time (re-run after a delay or process restart), and assert
+  identical output — proving no hidden dependency on current time or process-local state.
+- **Entity-mapping test** (for graph-native editor consumers): for a representative graph
+  revision, assert that every projected byte range can be mapped back to the exact owning
+  graph entity, and that this mapping is stable across repeated projections of the same
+  revision.
+
+### 5. Scope boundary — what this ADR does NOT decide
+
+- The **canonical-branch selection policy** (which graph revision projects to which git
+  ref, when the native graph preserves divergent branches) is not decided here — it is
+  graph/policy work tracked against ADR-0025, orthogonal to "given a chosen graph revision,
+  project it deterministically."
+- The **streaming-transport host capability** gap (how projected pack bytes are streamed to
+  a git client) is separate foundation work — this ADR only concerns the correctness of
+  the bytes produced, not how they are transported.
+- SHA-256 object-hash mode, delta-compression algorithm selection beyond the v1
+  undeltified-pack fallback (§3), and partial/shallow-clone projection are explicitly
+  deferred, not stubbed — absent from v1 scope per C-NOSTUB-001, to be scoped in a future
+  ADR revision when needed.
+
+## Consequences
+
+**Positive**
+- Closes the single riskiest correctness gap in ADR-0025's graph-canonical model: without
+  this, "any replica can serve fetch/clone" (a core HA/DR claim of the forge) would be
+  false in practice the first time two replicas computed slightly different bytes.
+- Gives graph-native editor consumers (e.g. pares-scribe) a precise contract (entity-range
+  mapping) to build against, rather than an implicit assumption.
+- Scopes pack compression honestly (§3: undeltified-pack fallback is an explicit, recorded
+  tradeoff) rather than silently shipping non-deterministic delta selection and discovering
+  the bug later.
+
+**Negative / costs**
+- Skipping delta-compression in v1 (§3 fallback) means larger pack transfers over the wire
+  until a pinned delta algorithm is designed — an explicit, accepted cost of prioritizing
+  correctness over size for v1.
+- A shared, single-source hashing/serialization routine must be authored once and used by
+  every projection call site — a second ad hoc implementation of "compute git object hash"
+  anywhere in the codebase would reintroduce exactly the risk this ADR closes.
+
+**Risks**
+- **Silent divergence if a determinism test is skipped or weakened.** Mitigation: §4's
+  cross-replica and time-travel tests are a hard implementation-completeness gate for
+  ADR-0025, not optional; CI must run them against real independent process instances (not
+  two calls in the same process, which would hide shared-state bugs).
+- **Future delta-compression addition reintroducing non-determinism.** Mitigation: any
+  future ADR revision that adds delta-packing must itself re-run and pass the §4 tests
+  before shipping; this ADR's invariants apply to any future pack-layout algorithm, not
+  just the v1 undeltified fallback.
+
+## Implementation outline (gated; design = Pillar 1 only here)
+
+1. Author the shared, pure `project(graph_revision_id) -> git_object_bytes` routine per
+   §1–3 invariants — single implementation, no per-call-site reimplementation.
+2. Implement the v1 undeltified pack fallback (§3) explicitly, recording the tradeoff.
+3. Build the §4 cross-replica determinism test and time-travel reproducibility test as the
+   acceptance gate — build and pass these before ADR-0025's push/fetch adapter work is
+   considered mergeable.
+4. Build the entity-mapping contract test for graph-native editor consumers.
+5. Tests BLOCK (C-TEST-002): real independent process instances, not same-process calls;
+   channel-independent verification against a real running pares-radix instance.
+
+## References
+- ADR-0025 (revised) — Procedure-Graph Forge with Hyperswarm Collaboration and Git Compatibility
+- C-PLURES-002/003/004, C-NOSTUB-001, C-TEST-001/002
+- Epic `px-repo:procedure-graph-substrate` (`memory/epic-registry.json`)
+- `workspace/memory/phase2-git-forge-corrected-architecture.md`


### PR DESCRIPTION
## Summary

Revises ADR-0025 (hyperswarm-git-forge) to a procedure-graph-canonical model:

- PluresDB graph is canonical; Git objects are a compat projection only.
- Native multi-writer graph model vs strict-CAS git-compat refs are separate concerns with distinct consistency guarantees.
- Ownership boundaries vs pluresdb / arca / bastion / modulus / scribe clarified.

Approved by kbristol 2026-07-30 ("concur with recommendation, proceed").

## Status

Design-stage, doc-only ADR revision. No code changes in this PR. kbristol still wants to review the diff before this flips from Proposed(Revised) to Accepted -- do not merge or flip status without that review.

## Follow-up needed

A companion "deterministic-projection normative invariants" spec ADR (covering ordering/hashing/reproducibility for the git-compat projection) has not been started yet anywhere in `.praxis/decisions/`. That is still needed as a next step.
