### PR TITLE
test(radix-core): dogfood harness for ADR-0038 git_projection round-trip

### DIFF
--- a/crates/radix-core/examples/git_projection_dogfood.rs
+++ b/crates/radix-core/examples/git_projection_dogfood.rs
@@ -46,27 +46,49 @@ fn git_blob_content(repo: &str, oid: &str) -> Vec<u8> {
     git_stdout(repo, &["cat-file", "-p", oid])
 }
 
-fn parse_tree_entries(raw: &str) -> Vec<(String, String, String, String)> {
-    // Each line: "<mode> <type> <oid>\t<name>"
+/// Map a raw git tree-entry mode string to a known `'static` str.
+///
+/// Git tree entry modes are a small fixed set. Mapping to known literals
+/// avoids leaking memory for every entry and fails fast on unexpected modes.
+fn mode_to_static(mode: &str) -> &'static str {
+    match mode {
+        "100644" => "100644",
+        "100755" => "100755",
+        "100664" => "100664",
+        "120000" => "120000",
+        "160000" => "160000",
+        "40000" => "40000",
+        other => panic!("unexpected git tree entry mode: {other}"),
+    }
+}
+
+fn parse_tree_entries(raw: &[u8]) -> Vec<(String, String, String, String)> {
+    // `git ls-tree -z` separates entries with NUL, which is safe for
+    // filenames that contain newlines.  Each entry: "<mode> <type> <oid>\t<name>"
     let mut out = Vec::new();
-    for line in raw.lines() {
-        if line.is_empty() {
+    for entry in raw.split(|&b| b == 0) {
+        if entry.is_empty() {
             continue;
         }
-        let (meta, name) = line.split_once('\t').expect("malformed tree line");
+        let tab_pos = match entry.iter().position(|&b| b == b'\t') {
+            Some(pos) => pos,
+            None => continue,
+        };
+        let meta = String::from_utf8_lossy(&entry[..tab_pos]);
+        let name = String::from_utf8_lossy(&entry[tab_pos + 1..]).into_owned();
         let mut parts = meta.splitn(3, ' ');
-        let mut mode = parts.next().unwrap().to_string();
-        let kind = parts.next().unwrap().to_string();
-        let oid = parts.next().unwrap().to_string();
-        // `git cat-file -p`/`ls-tree` DISPLAYS directory mode as 6-digit
-        // "040000", but the real git tree OBJECT BYTES store it as 5-digit
-        // "40000" (no leading zero) -- this is a documented git display
-        // quirk, not a git_projection.rs bug. Normalize here so the harness
-        // feeds project_tree() the exact on-disk mode string it expects.
+        let mut mode = parts.next().unwrap_or("").to_string();
+        let kind = parts.next().unwrap_or("").to_string();
+        let oid = parts.next().unwrap_or("").to_string();
+        // `git ls-tree` DISPLAYS directory mode as 6-digit "040000", but the
+        // real git tree OBJECT BYTES store it as 5-digit "40000" (no leading
+        // zero) -- this is a documented git display quirk, not a
+        // git_projection.rs bug. Normalize so project_tree() gets the exact
+        // on-disk mode string it expects.
         if mode == "040000" {
             mode = "40000".to_string();
         }
-        out.push((mode, kind, oid, name.to_string()));
+        out.push((mode, kind, oid, name));
     }
     out
 }
@@ -84,13 +106,16 @@ struct Stats {
 /// Recursively verify every blob/tree under `git_tree_oid` re-derives to the
 /// same object id via the pure projection functions.
 fn verify_tree(repo: &str, git_tree_oid: &str, path: &str, stats: &mut Stats) -> [u8; 20] {
-    let raw = String::from_utf8(git_stdout(repo, &["cat-file", "-p", git_tree_oid]))
-        .expect("tree listing not utf8");
+    let raw = git_stdout(repo, &["ls-tree", "-z", git_tree_oid]);
     let entries = parse_tree_entries(&raw);
 
     let mut projected_entries = Vec::new();
     for (mode, kind, oid, name) in &entries {
-        let child_path = format!("{path}/{name}");
+        let child_path = if path.is_empty() {
+            name.clone()
+        } else {
+            format!("{path}/{name}")
+        };
         let projected_oid: [u8; 20] = match kind.as_str() {
             "blob" => {
                 let content = git_blob_content(repo, oid);
@@ -118,9 +143,8 @@ fn verify_tree(repo: &str, git_tree_oid: &str, path: &str, stats: &mut Stats) ->
                 continue;
             }
         };
-        let leaked_mode: &'static str = Box::leak(mode.clone().into_boxed_str());
         projected_entries.push(TreeEntry {
-            mode: leaked_mode,
+            mode: mode_to_static(mode),
             name: name.clone(),
             oid: projected_oid,
         });
@@ -145,7 +169,13 @@ fn verify_tree(repo: &str, git_tree_oid: &str, path: &str, stats: &mut Stats) ->
 /// This proves the projected bytes are not just oid-compatible in theory but
 /// are literally ingestible as real git objects.
 fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
-    std::fs::create_dir_all(target_repo).unwrap();
+    // Ensure a truly fresh bare repo — remove any pre-existing directory so
+    // stale objects cannot invalidate the freshness assumption.
+    let target_path = std::path::Path::new(target_repo);
+    if target_path.exists() {
+        std::fs::remove_dir_all(target_path).unwrap();
+    }
+    std::fs::create_dir_all(target_path).unwrap();
     let init = Command::new("git")
         .args(["init", "--bare", target_repo])
         .output()
@@ -158,8 +188,7 @@ fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
         .to_string();
 
     fn rebuild_into(target_repo: &str, source_repo: &str, git_tree_oid: &str) -> String {
-        let raw = String::from_utf8(git_stdout(source_repo, &["cat-file", "-p", git_tree_oid]))
-            .unwrap();
+        let raw = git_stdout(source_repo, &["ls-tree", "-z", git_tree_oid]);
         let entries = parse_tree_entries(&raw);
         let mut mktree_input = String::new();
         for (mode, kind, oid, name) in &entries {
@@ -178,6 +207,7 @@ fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
                         .args(["hash-object", "-w", "--stdin"])
                         .stdin(Stdio::piped())
                         .stdout(Stdio::piped())
+                        .stderr(Stdio::piped())
                         .spawn()
                         .unwrap();
                     child
@@ -187,6 +217,12 @@ fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
                         .write_all(&content)
                         .unwrap();
                     let out = child.wait_with_output().unwrap();
+                    if !out.status.success() {
+                        panic!(
+                            "git hash-object failed for blob {name}: {}",
+                            String::from_utf8_lossy(&out.stderr)
+                        );
+                    }
                     let written_oid = String::from_utf8(out.stdout).unwrap().trim().to_string();
                     assert_eq!(
                         written_oid, projected_hex,
@@ -207,6 +243,7 @@ fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
             .arg("mktree")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()
             .unwrap();
         child
@@ -216,6 +253,12 @@ fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
             .write_all(mktree_input.as_bytes())
             .unwrap();
         let out = child.wait_with_output().unwrap();
+        if !out.status.success() {
+            panic!(
+                "git mktree failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
         String::from_utf8(out.stdout).unwrap().trim().to_string()
     }
 

--- a/crates/radix-core/examples/git_projection_dogfood.rs
+++ b/crates/radix-core/examples/git_projection_dogfood.rs
@@ -1,0 +1,273 @@
+//! Dogfood harness for ADR-0038 slice-1 (`git_projection.rs`).
+//!
+//! Reads a real git tree (from a real repo, at a given commit) via `git`
+//! subprocess calls, re-derives blob/tree objects using the pure
+//! `project_blob`/`project_tree` functions in `pares_radix_core::git_projection`,
+//! and verifies the resulting object ids match git's own object ids
+//! byte-for-byte. This is a verification harness only — it does not modify
+//! `git_projection.rs` itself, since that module intentionally does not
+//! (yet) implement commit or ref projection (see module docs).
+//!
+//! Usage: `cargo run --example git_projection_dogfood -- <repo_path> <rev>`
+//!
+//! Exit code 0 + prints `PASS` per verified object if every blob/tree under
+//! the given rev round-trips through the pure projection functions with an
+//! identical object id to git's own. Any mismatch prints `MISMATCH` and the
+//! process exits non-zero. Honest reporting only: this harness does not
+//! attempt to verify commits or refs, because no projection primitive for
+//! those exists yet.
+
+use pares_radix_core::git_projection::{project_blob, project_tree, TreeEntry};
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn git_stdout(repo: &str, args: &[&str]) -> Vec<u8> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("failed to run git");
+    if !out.status.success() {
+        eprintln!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        std::process::exit(1);
+    }
+    out.stdout
+}
+
+/// Fetch raw object bytes for a blob (exact bytes, no text mangling) using
+/// `git cat-file -p <oid>` — safe here because we only ever call it on
+/// objects git itself already reports as type `blob`.
+fn git_blob_content(repo: &str, oid: &str) -> Vec<u8> {
+    git_stdout(repo, &["cat-file", "-p", oid])
+}
+
+fn parse_tree_entries(raw: &str) -> Vec<(String, String, String, String)> {
+    // Each line: "<mode> <type> <oid>\t<name>"
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let (meta, name) = line.split_once('\t').expect("malformed tree line");
+        let mut parts = meta.splitn(3, ' ');
+        let mut mode = parts.next().unwrap().to_string();
+        let kind = parts.next().unwrap().to_string();
+        let oid = parts.next().unwrap().to_string();
+        // `git cat-file -p`/`ls-tree` DISPLAYS directory mode as 6-digit
+        // "040000", but the real git tree OBJECT BYTES store it as 5-digit
+        // "40000" (no leading zero) -- this is a documented git display
+        // quirk, not a git_projection.rs bug. Normalize here so the harness
+        // feeds project_tree() the exact on-disk mode string it expects.
+        if mode == "040000" {
+            mode = "40000".to_string();
+        }
+        out.push((mode, kind, oid, name.to_string()));
+    }
+    out
+}
+
+fn hex(bytes: &[u8; 20]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+struct Stats {
+    blobs_checked: usize,
+    trees_checked: usize,
+    mismatches: usize,
+}
+
+/// Recursively verify every blob/tree under `git_tree_oid` re-derives to the
+/// same object id via the pure projection functions.
+fn verify_tree(repo: &str, git_tree_oid: &str, path: &str, stats: &mut Stats) -> [u8; 20] {
+    let raw = String::from_utf8(git_stdout(repo, &["cat-file", "-p", git_tree_oid]))
+        .expect("tree listing not utf8");
+    let entries = parse_tree_entries(&raw);
+
+    let mut projected_entries = Vec::new();
+    for (mode, kind, oid, name) in &entries {
+        let child_path = format!("{path}/{name}");
+        let projected_oid: [u8; 20] = match kind.as_str() {
+            "blob" => {
+                let content = git_blob_content(repo, oid);
+                let projected = project_blob(&content);
+                stats.blobs_checked += 1;
+                if hex(&projected.oid) != *oid {
+                    stats.mismatches += 1;
+                    println!(
+                        "MISMATCH blob {child_path}: git_oid={oid} projected_oid={}",
+                        hex(&projected.oid)
+                    );
+                } else {
+                    println!("PASS blob {child_path} oid={oid}");
+                }
+                projected.oid
+            }
+            "tree" => verify_tree(repo, oid, &child_path, stats),
+            "commit" => {
+                // Submodule (gitlink) — out of scope for this slice, note honestly.
+                println!("SKIP (submodule/gitlink, not blob/tree) {child_path} oid={oid}");
+                continue;
+            }
+            other => {
+                println!("SKIP (unknown git object kind {other}) {child_path}");
+                continue;
+            }
+        };
+        let leaked_mode: &'static str = Box::leak(mode.clone().into_boxed_str());
+        projected_entries.push(TreeEntry {
+            mode: leaked_mode,
+            name: name.clone(),
+            oid: projected_oid,
+        });
+    }
+
+    let projected_tree =
+        project_tree(&projected_entries).expect("project_tree failed on real repo data");
+    stats.trees_checked += 1;
+    let projected_hex = hex(&projected_tree.oid);
+    if projected_hex != git_tree_oid {
+        stats.mismatches += 1;
+        println!("MISMATCH tree {path}: git_oid={git_tree_oid} projected_oid={projected_hex}");
+    } else {
+        println!("PASS tree {path} oid={git_tree_oid}");
+    }
+    projected_tree.oid
+}
+
+/// Project-back step: write the harness's own projected blob/tree bytes into
+/// a FRESH throwaway bare repo using `git hash-object -w`/`git mktree`, and
+/// confirm the objects git produces from OUR bytes match the same oids.
+/// This proves the projected bytes are not just oid-compatible in theory but
+/// are literally ingestible as real git objects.
+fn project_back_smoke_test(source_repo: &str, rev: &str, target_repo: &str) {
+    std::fs::create_dir_all(target_repo).unwrap();
+    let init = Command::new("git")
+        .args(["init", "--bare", target_repo])
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+
+    let tree_oid = String::from_utf8(git_stdout(source_repo, &["rev-parse", &format!("{rev}^{{tree}}")]))
+        .unwrap()
+        .trim()
+        .to_string();
+
+    fn rebuild_into(target_repo: &str, source_repo: &str, git_tree_oid: &str) -> String {
+        let raw = String::from_utf8(git_stdout(source_repo, &["cat-file", "-p", git_tree_oid]))
+            .unwrap();
+        let entries = parse_tree_entries(&raw);
+        let mut mktree_input = String::new();
+        for (mode, kind, oid, name) in &entries {
+            match kind.as_str() {
+                "blob" => {
+                    let content = git_blob_content(source_repo, oid);
+                    let projected = project_blob(&content);
+                    let projected_hex = hex(&projected.oid);
+                    // Write OUR projected bytes' content into the target repo via
+                    // hash-object -w (git recomputes its own oid over the same
+                    // content+header format — this is the real "project back to
+                    // git objects" step, not a simulation).
+                    let mut child = Command::new("git")
+                        .arg("-C")
+                        .arg(target_repo)
+                        .args(["hash-object", "-w", "--stdin"])
+                        .stdin(Stdio::piped())
+                        .stdout(Stdio::piped())
+                        .spawn()
+                        .unwrap();
+                    child
+                        .stdin
+                        .as_mut()
+                        .unwrap()
+                        .write_all(&content)
+                        .unwrap();
+                    let out = child.wait_with_output().unwrap();
+                    let written_oid = String::from_utf8(out.stdout).unwrap().trim().to_string();
+                    assert_eq!(
+                        written_oid, projected_hex,
+                        "git's own hash-object oid must match our pure projection oid for blob {name}"
+                    );
+                    mktree_input.push_str(&format!("{mode} blob {written_oid}\t{name}\n"));
+                }
+                "tree" => {
+                    let sub_oid = rebuild_into(target_repo, source_repo, oid);
+                    mktree_input.push_str(&format!("{mode} tree {sub_oid}\t{name}\n"));
+                }
+                _ => continue,
+            }
+        }
+        let mut child = Command::new("git")
+            .arg("-C")
+            .arg(target_repo)
+            .arg("mktree")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(mktree_input.as_bytes())
+            .unwrap();
+        let out = child.wait_with_output().unwrap();
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    let rebuilt_tree_oid = rebuild_into(target_repo, source_repo, &tree_oid);
+    println!("project-back: original_tree={tree_oid} rebuilt_tree={rebuilt_tree_oid}");
+    assert_eq!(
+        rebuilt_tree_oid, tree_oid,
+        "rebuilt tree oid (from projected bytes fed through real git) must equal original tree oid"
+    );
+    println!("PASS project-back tree oid identical: {tree_oid}");
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: git_projection_dogfood <repo_path> <rev> [target_bare_repo]");
+        std::process::exit(2);
+    }
+    let repo = &args[1];
+    let rev = &args[2];
+    let target = args
+        .get(3)
+        .cloned()
+        .unwrap_or_else(|| format!("{repo}-projected-back.git"));
+
+    let tree_oid = String::from_utf8(git_stdout(repo, &["rev-parse", &format!("{rev}^{{tree}}")]))
+        .unwrap()
+        .trim()
+        .to_string();
+
+    println!("== ADR-0038 git_projection dogfood: repo={repo} rev={rev} tree={tree_oid} ==");
+
+    let mut stats = Stats {
+        blobs_checked: 0,
+        trees_checked: 0,
+        mismatches: 0,
+    };
+    verify_tree(repo, &tree_oid, "", &mut stats);
+
+    println!(
+        "-- forward projection summary: blobs_checked={} trees_checked={} mismatches={} --",
+        stats.blobs_checked, stats.trees_checked, stats.mismatches
+    );
+
+    project_back_smoke_test(repo, rev, &target);
+
+    println!("-- NOTE: commit objects, refs, and pack assembly are NOT covered --");
+    println!("-- (no project_commit / pack function exists in git_projection.rs as of this slice) --");
+
+    if stats.mismatches != 0 {
+        eprintln!("FAIL: {} mismatches found", stats.mismatches);
+        std::process::exit(1);
+    }
+    println!("== ALL BLOB/TREE PROJECTIONS MATCHED REAL GIT OIDS ==");
+}


### PR DESCRIPTION
Adds an example harness (crates/radix-core/examples/git_projection_dogfood.rs) that dogfoods the ADR-0038 git_projection blob/tree primitive against a real git repo, end-to-end, in a Docker container isolated from praxisbot/surface.

## What this proves
- Forward projection: for every blob/tree under a given rev, project_blob/project_tree produce object ids identical to git's own, verified recursively.
- Project-back: the harness feeds the projected object bytes into a fresh bare repo via real git hash-object -w + git mktree, and the rebuilt tree oid matches the original.

## Verification (Docker, arca-e2e-node1, no praxisbot/surface touched)
Ran against a disposable throwaway repo (2 commits on master + a feature/x branch, real files/dirs, no production repo touched):
- master: 3 blobs, 3 trees checked, 0 mismatches; project-back tree oid identical.
- feature/x: 4 blobs, 3 trees checked, 0 mismatches; project-back tree oid identical.

## Honest scope
This does NOT exercise commit objects, refs, or pack assembly - no project_commit/pack function exists yet in git_projection.rs (documented as a follow-up in the original PR #591). This harness only verifies what exists today: blob + tree projection genuinely round-trips real repo data.

No changes to git_projection.rs itself - test/verification glue only.

Note: could not run radix__praxis-evaluate from this session (MCP radix tools not in this session's tool surface). Flagging for reviewer/CI to confirm the pre_push gate if required.