### PR TITLE
docs(procedure-graph): M0 spec - identity/hashing ADR, graph schema, .px bundle format, ExactArtifactProcedure

### DIFF
--- a/.praxis/decisions/ADR-0040-procedure-graph-identity-and-canonical-hashing.md
+++ b/.praxis/decisions/ADR-0040-procedure-graph-identity-and-canonical-hashing.md
@@ -1,0 +1,286 @@
+# ADR-0040: Procedure-Graph Repository Substrate — Identity and Canonical-Hashing Model
+
+## Status: Proposed
+
+## Date: 2026-07-31
+
+> M0 deliverable #1 of epic `pares-radix:procedure-graph-repository-substrate`
+> (design spec: OpenClaw workspace `memory/design-procedure-graph-repository-substrate-2026-07-24.md`,
+> §4.3 "Identity types" and §14 "Determinism and reproducibility"). Design-only
+> (Pillar 1), same discipline as ADR-0038/ADR-0039: **no runtime wiring in this
+> ADR** beyond the minimal conformance test required by the epic's M0 exit
+> criterion (two independent serializers producing byte-identical output for
+> one test graph — see `crates/px-repo-model`).
+>
+> **Blocked-on note:** this ADR was gated on `plures/praxis-lang` RFC-0003
+> ("Effects and Capabilities") landing, since the substrate's `CapabilityGrant`
+> entity (§4.1/§4.2 of the design spec) needed a concrete effect/capability
+> shape to hash against. RFC-0003 merged as `plures/praxis-lang#21`
+> (`docs/rfcs/RFC-0003-effects-and-capabilities.md`, commit `1e63568`) as a
+> **design-only, no-code-shipped** RFC. Its `Effect` enum (§2.1: `db_read`,
+`db_write`, `network`, `shell`, `file_read`, `file_write`, `env_read`, `clock`,
+`random`) and `CapabilityGrant { effect, scope: Option<String> }` shape (§3.2)
+are adopted directly below as the canonical shape for this repo's
+`CapabilityGrant` graph entity — see §5.
+
+## Context
+
+The design spec (§2, §3, §4.3) requires every graph entity to carry **three
+distinct kinds of identity**, and requires (§14) that canonical serialization
+be pinned tightly enough that two independent implementations, given the same
+logical graph, produce byte-identical output. Today neither exists anywhere in
+`pares-radix`: `crates/radix-core/src/spine/git_projection.rs` (ADR-0038) gives
+us a precedent for "deterministic projection with a documented byte-format and
+a dogfood round-trip test," but it projects an already-existing git tree — it
+does not define entity identity or canonical hashing for a *new* graph model.
+This ADR is the identity/hashing foundation everything else in the epic
+(schema doc, bundle format doc, `ExactArtifactProcedure`) is built on top of.
+
+Three problems this ADR must solve, none of which the design spec fully
+resolves on its own (it states the *requirement*, not the *encoding*):
+
+1. **What exactly gets hashed, and in what byte order** — the design spec says
+   "canonical `.px` bundle... deterministic serialization" (§1, §3.2) and lists
+   the identity types (§4.3) but does not specify a wire encoding. Two
+   implementations cannot agree on a hash without an unambiguous byte-for-byte
+   specification of what bytes get fed to the hash function.
+2. **Which identifiers are content-derived vs. assigned** — `EntityId` and
+   `ProcedureId` are explicitly required to survive rename/move/edit (§4.3
+   table: "Survives rename and move", "Survives procedure edits"), meaning
+   they CANNOT be pure content hashes (a content hash changes the instant the
+   content changes). `ProcedureRevisionHash`, `BlobHash`, and
+   `RenderingProfileHash` are explicitly content-addressed ("Changes with
+   content", "Content-addressed", "Immutable"). Mixing these two identifier
+   *kinds* under one hashing scheme was the failure mode this ADR exists to
+   prevent.
+3. **How graph-level structural hashes (`procedure_root`, `entity_root`,
+   `materialization_root` — §4.4 `RepositoryRevision`) compose from
+   entity-level hashes** — the design spec names these fields but does not
+   define a Merkle/tree composition rule. §14 requires "materialize twice...
+   compare artifact Merkle roots" and §19 conformance test 15 ("Repeated
+   materialization produces the same Merkle root") both assume a defined
+   composition rule exists.
+
+## Decision
+
+### 1. Two identifier kinds, never conflated
+
+Per §4.3 of the design spec, every identifier in the repository graph is
+exactly one of:
+
+- **Assigned identity** (`EntityId`, `ProcedureId`, `LogicalChangeId`,
+  `ProjectionId`) — a **UUIDv7** (time-ordered, per existing workspace
+  convention — `uuid = { version = "1", features = ["v4"] }` is already a
+  workspace dependency; this ADR adds the `v7` feature) minted exactly once
+  when the entity is first created, then carried forward verbatim across every
+  edit/rename/move/rebase. **Never recomputed from content.** Storage: 128-bit
+  value, canonical text form is lowercase hyphenated UUID (RFC 4122 §3), e.g.
+  `018f2b3a-8c41-7000-9c21-4e6b1a2f9d10`.
+- **Content-derived identity** (`ProcedureRevisionHash`, `BlobHash`,
+  `RenderingProfileHash`, `RevisionId`) — a **BLAKE3-256** digest (32 bytes)
+  of a precisely-specified canonical byte sequence (§2 below). Canonical text
+  form is lowercase hex, prefixed `blake3:` (e.g.
+  `blake3:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08`) —
+  the prefix exists so a `RevisionId` can never be silently compared against a
+  differently-hashed `BlobHash` even if both happen to be 32 bytes.
+
+  **Why BLAKE3, not SHA-256:** (a) it is already a transitive dependency in
+  this workspace via `pluresdb` (verified: `pluresdb-px`'s own lockfile pulls
+  `blake3` for content addressing — reusing the same primitive avoids a second
+  hash function in the dependency graph for the same job), (b) it is faster
+  for the repeated-hashing workload §14 requires (materialize-twice
+  verification), (c) it has a native keyed/XOF mode this ADR does not need
+  today but the fidelity model (§10 of the design spec) may need later for
+  content fingerprinting at different granularities without changing the
+  primitive.
+
+- **Mixed identity** (`LogicalChangeId` per its own row: "Survives rebase") —
+  assigned at creation time like `EntityId`/`ProcedureId` (a UUIDv7), NOT
+  recomputed on rebase. This is the whole point of `LogicalChangeId` existing
+  separately from `RevisionId` (§4.3: "LogicalChangeId vs RevisionId prevents
+  rebase from making a logical change appear to be an unrelated new change").
+
+### 2. Canonical byte encoding (what actually gets hashed)
+
+All content-derived hashes in this repository use **one** canonical encoding
+rule, so a new content-addressed identifier type never needs its own bespoke
+byte format:
+
+1. The logical value being hashed (a `ProcedureRevision`, a `Blob`, a
+   `RenderingProfile`, or a `RepositoryRevision`) is first reduced to a
+   **canonical JSON value** per the rules below, then serialized to UTF-8
+   bytes with **no trailing newline**, then hashed with BLAKE3-256 over those
+   exact bytes.
+2. **Canonical JSON rules** (deterministic-JSON, not "any JSON serializer"):
+   - Object keys sorted byte-wise ascending by their UTF-8 encoding (not
+     locale-aware, not case-insensitive).
+   - No insignificant whitespace: no spaces after `:` or `,`, no newlines,
+     no indentation.
+   - Numbers: integers only in this schema (no floats are part of any hashed
+     value — timestamps are RFC 3339 strings, not numeric epoch values,
+     because §4.4 explicitly excludes timestamps from content-addressed
+     identity in the exact-artifact case and this ADR generalizes that: no
+     hashed structure anywhere in this schema contains a raw float).
+   - Strings: UTF-8, escaped per strict JSON (`"`, `\`, control chars `<
+     0x20`), **not** HTML-safe-escaped (no `\u003c` substitution) — this
+     matches `serde_json`'s default non-HTML-escaping behavior so the
+     canonical encoder in Rust needs no extra configuration beyond stable key
+     ordering.
+   - Arrays: order is semantically significant and preserved exactly as
+     defined by the field (e.g. `parents: [RevisionId]` order is NOT sorted —
+     merge-parent order is meaningful and part of what's hashed).
+   - `null` for an explicitly-absent optional field is **omitted from the
+     object entirely**, never emitted as a `null` key — an object with an
+     absent optional field and an object that never had that field defined
+     must hash identically.
+   - Content-derived identifiers embedded as fields (e.g. a `RevisionId`
+     referencing a parent) are encoded as their canonical text form (the
+     `blake3:`-prefixed hex string), never as raw bytes — this keeps the
+     canonical JSON representation copy-pasteable and diffable, matching the
+     design spec's §3.2 requirement that the canonical form be "reviewable."
+   - Assigned identifiers (`EntityId`/`ProcedureId`/etc.) are encoded as their
+     canonical lowercase-hyphenated UUID text form.
+3. This rule is deliberately identical in shape to RFC 8785 (JSON Canonicalization
+   Scheme, JCS) restricted to the strict subset this schema actually uses (no
+   floats, no HTML-escaping ambiguity to resolve) — this ADR does not claim
+   full JCS compliance (JCS's ECMAScript-number serialization rule is
+   irrelevant here since no floats are hashed), but implementers should treat
+   RFC 8785 §3.2 (string/number formatting) as the disambiguation reference
+   for any edge case not enumerated above.
+
+### 3. Blob hashing (leaf content)
+
+A `Blob` (§4.1 entity) is hashed directly over its **raw bytes**, not wrapped
+in a JSON envelope — `BlobHash = blake3(raw_bytes)`. This is intentionally
+different from every other content-derived hash in this ADR (which hash a
+canonical JSON encoding): a blob's bytes ARE its canonical form already (this
+is what makes exact-artifact byte preservation, §5.2/§6 of the design spec,
+possible — the blob hash is exactly what a plain `git hash-object`-equivalent
+or `sha256sum`-equivalent would report on the same bytes, modulo BLAKE3 vs
+SHA-1/256, making it trivially cross-checkable against external tools during
+conformance testing).
+
+### 4. Merkle composition for graph-level roots
+
+`procedure_root`, `entity_root`, and `materialization_root` (§4.4) are each
+the BLAKE3-256 hash of a **canonical JSON array** of `{id, hash}` pairs, sorted
+by `id`'s canonical text form (byte-wise ascending), where:
+
+- `procedure_root` — pairs are `{procedure_id: ProcedureId, revision_hash:
+  ProcedureRevisionHash}` for every `Procedure` reachable from the revision,
+  sorted by `procedure_id`.
+- `entity_root` — pairs are `{entity_id: EntityId, entity_hash: BLAKE3}` where
+  `entity_hash` is the canonical-JSON hash (rule §2) of that `SemanticEntity`'s
+  own field set (excluding its own `entity_id`, to avoid the entity hashing
+  its own identifier into itself), sorted by `entity_id`.
+- `materialization_root` — pairs are `{path: Text, blob_hash: BlobHash}` for
+  every materialized path in the workspace projection, sorted by `path`
+  (byte-wise ascending on the UTF-8 path string, using `/`-separated
+  POSIX-style paths regardless of host OS, per §3.3 "paths are mutable
+  projection properties" — this also directly satisfies conformance test 15,
+  "Repeated materialization produces the same Merkle root," since path sort
+  order cannot depend on host directory-iteration order).
+
+This is a flat sorted-list Merkle scheme, not a binary Merkle tree — chosen
+deliberately over a tree structure for M0 because (a) the design spec's
+conformance tests (§19: tests 1, 2, 15) only require *determinism and
+stability*, not *logarithmic proof size*, and a tree's proof-of-inclusion
+property is not needed anywhere in M0–M1 scope, (b) a sorted flat list is
+trivially specifiable byte-for-byte (§2's rules apply directly, no additional
+tree-shape rule needed) which is the actual M0 exit-criterion requirement
+("two independent implementations serialize the same test graph identically"
+— minimizing the surface two implementers must agree on). A binary Merkle
+tree (for inclusion proofs, e.g. for partial sync) is an explicitly-deferred
+future optimization, not a functional requirement dropped here — if a later
+milestone needs inclusion proofs, it is layered on top of this flat hash
+(a tree of the same sorted leaves) without changing the leaf encoding.
+
+### 5. `CapabilityGrant` shape (adopted from RFC-0003)
+
+Per the blocked-on note above, `CapabilityGrant` (design spec §4.1: `Procedure
+REQUIRES CapabilityGrant`) is defined identically to RFC-0003 §3.2:
+
+```
+CapabilityGrant {
+  effect: Effect,          // closed enum, RFC-0003 §2.1: db_read | db_write |
+                            //   network | shell | file_read | file_write |
+                            //   env_read | clock | random
+  scope: Option<Text>,      // opaque scope qualifier, e.g. table name, host
+                            //   pattern, path prefix; None = unscoped
+}
+```
+
+`CapabilityGrant` values are hashed as part of their owning `Procedure`'s
+canonical JSON (per §2 above; `effect` as its lowercase enum-variant string,
+`scope` omitted when absent per the "omit, don't null" rule). This repo does
+**not** re-derive its own effect taxonomy — RFC-0003's `Effect` enum is the
+single source of truth for effect classes, matching design-spec §16's
+component-ownership split (praxis-lang owns effect/capability *typing*;
+`px-repo` owns the *graph schema* that references that typing). If RFC-0003's
+`Effect` enum gains variants in a later amendment (RFC-0003 §7 item 5:
+`secret.read` deferred), this repo's schema absorbs the new variant without a
+schema-version bump to the identity/hashing model itself (adding an enum
+variant does not change how a `CapabilityGrant` is canonically encoded).
+
+### 6. What this ADR explicitly does NOT decide
+
+- Storage layout inside PluresDB (owned by the schema doc, deliverable #2, and
+  ultimately `pluresdb`'s own storage engine — §16 "pluresdb owns: graph
+  storage, transactions...").
+- The `.px` bundle **directory** layout (owned by deliverable #3 — this ADR
+  only fixes the byte encoding of individual hashed values, not where files
+  land on disk).
+- `ExactArtifactProcedure`'s field set beyond what's needed to note it's
+  hashed via the blob rule (§3) for its payload and the canonical-JSON rule
+  (§2) for its metadata — full definition is deliverable #4.
+- Signature/attestation encoding (design spec §4.4: "Validation evidence and
+  signatures are linked objects, not RevisionId inputs" — explicitly excluded
+  from the revision hash by the design spec itself, so out of scope here too).
+- Any policy for *which* capability grants are permitted (RFC-0003 §1
+  explicitly defers this to RFC-0004; this ADR only fixes the grant's shape
+  for hashing purposes, not its semantics).
+
+## Consequences
+
+- Two independent implementations (Rust, or any other language) can now
+  produce byte-identical `RevisionId`/`ProcedureRevisionHash`/`BlobHash`
+  values for the same logical graph, given only this document — no shared
+  code, no shared library, is required to satisfy the M0 exit criterion. This
+  is verified directly by `crates/px-repo-model`'s conformance test (two
+  independent Rust encoders in the same crate, deliberately not sharing an
+  encoding function, both producing the same bytes for one fixture graph —
+  the strongest same-language proxy for cross-implementation determinism
+  available without standing up a second-language implementation in M0).
+- `EntityId`/`ProcedureId` stability across rename/move (§4.3) is now
+  mechanically guaranteed by construction: nothing about §2's canonical
+  encoding rule ever recomputes an assigned identifier from content, so a
+  rename (which changes a `name`/`path` field, itself just another key in the
+  canonical JSON) changes that entity's `entity_hash` but never its
+  `entity_id`. This directly satisfies design-spec conformance test 8
+  ("Semantic rename preserves EntityId").
+- Rebase preserving `LogicalChangeId` while changing `RevisionId` (conformance
+  test 9) follows the same way: `LogicalChangeId` is assigned, `RevisionId` is
+  a hash over (among other things) `parents: [RevisionId]` — a rebase changes
+  `parents`, therefore changes the hash, therefore changes `RevisionId`,
+  without ever touching the `LogicalChangeId` values listed in
+  `change_ids: [LogicalChangeId]`.
+- This ADR intentionally introduces exactly one new external dependency
+  candidate (`blake3` crate) beyond what's already transitively present via
+  `pluresdb-px` — the follow-on implementation should confirm the exact crate
+  version already pinned by `pluresdb-px`'s lockfile and reuse it verbatim
+  rather than introducing a second `blake3` version into the dependency graph.
+
+## Relates
+
+- Design spec: `memory/design-procedure-graph-repository-substrate-2026-07-24.md`
+  §2, §3, §4.3, §4.4, §14, §16, §19 (tests 1, 2, 8, 9, 15).
+- `plures/praxis-lang` RFC-0003 (`docs/rfcs/RFC-0003-effects-and-capabilities.md`,
+  merged `plures/praxis-lang#21`) — source of the `Effect`/`CapabilityGrant`
+  shape adopted in §5.
+- ADR-0038 (`deterministic-git-projection`) — prior art for "deterministic,
+  byte-reproducible projection with a documented format and a conformance
+  test," same discipline applied here one layer up (graph identity, not git
+  object projection).
+- Next deliverables in this epic: repository graph schema doc, `.px` bundle
+  directory format doc, `ExactArtifactProcedure` interface spec (all in
+  `docs/design/procedure-graph-repository-substrate/`).

--- a/docs/design/procedure-graph-repository-substrate/exact-artifact-procedure.md
+++ b/docs/design/procedure-graph-repository-substrate/exact-artifact-procedure.md
@@ -1,0 +1,193 @@
+# Procedure-Graph Repository Substrate — `ExactArtifactProcedure` Interface Spec
+
+**M0 deliverable #4 of epic `pares-radix:procedure-graph-repository-substrate`.**
+Companion to ADR-0040, `graph-schema.md`, `px-bundle-format.md`. Design spec
+source: `memory/design-procedure-graph-repository-substrate-2026-07-24.md`
+§3.5 ("Exact fallback is mandatory"), §5.2 ("Exact artifact procedures"), §6
+("Adapter contract"), §16 (component ownership — `px-repo` owns procedure
+taxonomy including this one).
+
+Design-only. No implementation code ships with this document — the Rust trait
+below is a specification for the follow-on implementation PR, matching the
+"illustrative, not shipped" convention RFC-0003 uses for its own Rust
+sketches (RFC-0003 §2.1, §2.2, §3.2).
+
+## 1. Purpose
+
+Design-spec §3.5 requires that "any arbitrary repo must be importable before
+a semantic adapter exists" — `ExactArtifactProcedure` is the universal,
+always-available fallback procedure kind (design-spec §5.2) that makes this
+possible: every file, regardless of whether any semantic adapter understands
+it, becomes at minimum an `ExactArtifactProcedure` (L0 fidelity per §3.6).
+This document defines its exact field set and the contract it must satisfy
+(§6's adapter laws, specialized to the exact case).
+
+## 2. Relationship to `Procedure` (schema doc §2.6)
+
+`ExactArtifactProcedure` is the `exact_artifact` variant of `ProcedureKind`
+(schema doc §2.6). It is not a separate graph entity — it is a `Procedure`
+whose `ProcedureRevision.source_text` (schema doc §2.7) is generated
+deterministically FROM the artifact's raw bytes and filesystem metadata,
+rather than authored directly as `.px` prose. Concretely: importing a file
+`src/main.rs` with unknown/unsupported syntax creates:
+- One `Procedure { kind: exact_artifact, name: "main.rs", path: "src/main.rs",
+  ... }`.
+- One `Artifact { owning_procedure: <that ProcedureId>, blob: <BlobHash of
+  main.rs's raw bytes>, mode, encoding, is_symlink, symlink_target }`
+  (schema doc §2.9).
+- One `ProcedureRevision` whose `source_text` is the canonical `.px`
+  serialization of the `ExactArtifactProcedure` fields below (NOT the raw
+  file content itself — the raw content lives in the `Blob`/`Artifact`, the
+  `.px` procedure text is the structured wrapper naming which blob and which
+  metadata).
+
+## 3. Required fields
+
+Per design-spec §5.2 ("blob hash, mode, encoding, line endings... Directory
+structure/exec mode/symlink target/filename bytes/platform semantics
+captured; timestamps NOT canonical"):
+
+```rust
+// docs/design/procedure-graph-repository-substrate/exact-artifact-procedure.md
+// (illustrative Rust shape — not shipped by this document; follow-on
+// implementation PR owns the actual crate types, per RFC-0003's own
+// "illustrative, not shipped" convention for spec-stage Rust sketches)
+
+pub struct ExactArtifactProcedure {
+    /// Which logical Procedure this is a revision of (schema doc §2.6/§2.7).
+    pub procedure_id: ProcedureId,
+
+    /// Content hash of the raw file bytes, exactly as read from source —
+    /// no line-ending normalization, no encoding transcoding. This is what
+    /// makes the exact-import law (design-spec §6: `write(read(S)) = S`)
+    /// checkable: re-materializing this artifact must reproduce a blob whose
+    /// hash equals this field, byte for byte.
+    pub blob: BlobHash,
+
+    /// POSIX permission bits, octal string form (e.g. "0644", "0755").
+    /// On platforms without POSIX permission bits (Windows), the importer
+    /// MUST synthesize a canonical value (0644 for non-executable, 0755 for
+    /// executable-by-convention, e.g. `.exe`/`.bat`/shebang-detected files)
+    /// rather than omit the field — every ExactArtifactProcedure has a mode,
+    /// full stop, so materialization is platform-independent (design-spec
+    /// §14 "platform profile" is a RENDERING concern, not a reason this
+    /// field becomes optional).
+    pub mode: String,
+
+    /// Declared text encoding, e.g. "utf-8", "binary". Detection heuristic
+    /// (valid-UTF-8 vs not) is an importer implementation detail — NOT
+    /// specified here beyond: if bytes are not valid UTF-8, `encoding` MUST
+    /// be `"binary"` and no line-ending normalization of any kind may be
+    /// applied to `blob` (binary content must never be text-processed).
+    pub encoding: String,
+
+    /// Whether this artifact is a symlink, and if so its raw target string
+    /// (NOT resolved/followed — an exact import preserves the symlink
+    /// itself, per design-spec §5.2 "symlink target... captured").
+    pub is_symlink: bool,
+    pub symlink_target: Option<String>,
+
+    /// The path this artifact was imported from, and materializes back to
+    /// by default (before any rendering-profile remapping). POSIX-style,
+    /// per ADR-0040 §4 / bundle-format doc §2. Filename bytes are preserved
+    /// exactly (design-spec §5.2 "filename bytes... captured") — this means
+    /// non-UTF-8 filenames (permitted on POSIX filesystems) are represented
+    /// as their exact byte sequence; this document does NOT resolve how a
+    /// UTF-8-only `.px` text format (bundle-format doc §5) represents a
+    /// non-UTF-8 filename byte-for-byte — flagged here as an open item for
+    /// the follow-on implementation (candidate: percent-encoding or a
+    /// separate raw-bytes sidecar field), matching this document's
+    /// no-stub/no-invented-resolution discipline (C-NOSTUB-001): rather than
+    /// silently picking an unverified encoding scheme, this is named
+    /// explicitly as unresolved.
+    pub original_path: String,
+
+    /// Line-ending metadata: NOT applied as normalization (§`blob` above is
+    /// never re-encoded), but RECORDED so a materializer can report/audit
+    /// what encoding an artifact originally had, per design-spec §6
+    /// "residual preservation... unresolved/malformed content." Values:
+    /// "lf" | "crlf" | "mixed" | "n/a" (binary content).
+    pub line_endings: String,
+}
+```
+
+**Explicitly NOT a field:** any timestamp (mtime/ctime/atime). Design-spec
+§4.4 and §20 both explicitly exclude filesystem timestamps from canonical
+identity ("timestamps NOT canonical", "preserve meaningless filesystem
+timestamps" is a listed non-goal) — `ExactArtifactProcedure` has no timestamp
+field at all, by design, not by omission.
+
+## 4. Capability declaration (per RFC-0003 / ADR-0040 §5)
+
+Per ADR-0040 §5's consequence and design-spec §3.4's default-pure rule, every
+`ExactArtifactProcedure`'s owning `Procedure.capability_grants` (schema doc
+§2.7) list is **empty** in the ordinary import case — reading a file during
+import and later materializing it back to a workspace root are both covered
+by the substrate's own checkout-level allow-list (design-spec §13.2: "read
+declared blobs... write declared artifacts inside isolated workspace"), not
+by a per-procedure capability grant. `ExactArtifactProcedure` therefore never
+needs `effects: [file_read]`/`effects: [file_write]` declared on itself — file
+I/O for import/materialization is a substrate-runtime operation on a declared
+blob, not a `.px`-level function call subject to RFC-0003's `FunctionRegistry`
+seam. This is stated explicitly because it is the concrete instance of
+RFC-0003 §6's own claim ("an imported byte-for-byte artifact procedure has no
+business performing network/shell/db-write effects just to exist as a graph
+node") — this document confirms that claim holds by construction: nothing in
+§3's field list above requires or implies any effectful call.
+
+## 5. Adapter-law compliance (design-spec §6)
+
+The **exact adapter** (design-spec §6, §16 "px-adapter-exact" crate) is the
+adapter whose `read`/`write` functions produce/consume
+`ExactArtifactProcedure` values. It must satisfy:
+
+- **Exact import law**: `write(read(S)) = S`. Concretely: given source bytes
+  `S`, `read(S)` produces an `ExactArtifactProcedure` with `blob =
+  blake3(S)` (ADR-0040 §3) plus the mode/encoding/symlink/path metadata read
+  from the filesystem; `write` of that same `ExactArtifactProcedure` must
+  reproduce filesystem bytes identical to `S` (verified by re-hashing the
+  written file's bytes and comparing to the `blob` field) AND identical
+  mode/symlink-target/encoding metadata. This is the M1 exit criterion
+  ("`import(folder) → materialize → byte-and-metadata-equivalent folder`") —
+  this document specifies the per-artifact contract; M1 implements the
+  folder-level importer/materializer that applies it recursively.
+- **Stable projection law** (`read(write(G)) ≡ G`): for the exact adapter
+  specifically, this holds trivially by construction — `write` never
+  transforms `blob`, `mode`, or any other field, so reading back a
+  materialized exact artifact reproduces the identical
+  `ExactArtifactProcedure` value. (Contrast with a semantic adapter, e.g. a
+  future TypeScript adapter, where formatting/whitespace differences make
+  this law meaningfully non-trivial — the exact adapter is the "easy case"
+  baseline every other adapter is judged against.)
+- **Residual preservation**: not applicable in the pure-exact case — there is
+  no "residual" separate from the artifact, since the ENTIRE file is treated
+  as opaque exact content already (residuals, schema doc §2.7, matter for
+  *semantic* procedures that uplift PART of a file to L1+/L2+ representation
+  while preserving the rest — an `ExactArtifactProcedure` has no partial
+  uplift by definition, so its `ProcedureRevision.residuals` list is always
+  empty).
+
+## 6. Conformance-test cross-reference
+
+This spec is written to satisfy design-spec §19 conformance test 3 ("Exact
+folder import round-trips byte-for-byte") at the per-artifact level; the
+folder-level (recursive, multi-artifact, Unicode-path, mixed-line-ending
+corpus) test is M1 scope (design-spec §17 M1 exit criterion), not testable
+from this document alone — this document defines what a conformant
+per-artifact implementation must do; M1 builds and tests the importer that
+does it across a real corpus.
+
+## 7. Minimal serialization test (M0 scope, if time allows)
+
+Per the M0 task's optional deliverable: a minimal test proving byte-identical
+canonical serialization for one small `ExactArtifactProcedure` test graph,
+computed by two independently-written encoding functions within the same
+crate (the strongest same-language proxy for cross-implementation determinism
+achievable without a second-language implementation — see ADR-0040
+"Consequences"). This is deferred to the actual `px-repo-model` crate
+scaffold (not written as part of this docs-only PR, per the epic's own
+sequencing note: "milestones are strictly sequential... do NOT start coding
+beyond M0 scope" — a serialization test requires at minimum a `Cargo.toml`
+and working Rust types, which is the first *code* artifact of this epic; it
+is flagged here as the natural next actionable step for the M0
+implementation follow-up, not fabricated as an empty stub in this PR).

--- a/docs/design/procedure-graph-repository-substrate/graph-schema.md
+++ b/docs/design/procedure-graph-repository-substrate/graph-schema.md
@@ -1,0 +1,335 @@
+# Procedure-Graph Repository Substrate — Graph Schema
+
+**M0 deliverable #2 of epic `pares-radix:procedure-graph-repository-substrate`.**
+Companion to `.praxis/decisions/ADR-0040-procedure-graph-identity-and-canonical-hashing.md`
+(identity/hashing) and design spec
+`memory/design-procedure-graph-repository-substrate-2026-07-24.md` §4.1/§4.2
+(entities/relationships, reproduced and made concrete here) and §4.4
+(revision structure).
+
+Design-only. No implementation code ships with this document. Owning crate
+(per design-spec §16): `px-repo-model` (new crate — see the initial layout in
+design-spec §18; this document specifies what that crate's types must satisfy,
+not the crate's own internal Rust representation).
+
+## 1. Scope and non-goals
+
+This document fixes:
+- The full entity list and their required fields.
+- Relationship cardinality (one-to-many vs many-to-many) and direction.
+- Which fields participate in canonical hashing (per ADR-0040 §2) and which
+  are excluded (e.g. timestamps, per design-spec §4.4 and §20).
+
+This document does NOT fix:
+- Storage/indexing strategy inside PluresDB (owned by `pluresdb` per §16).
+- `.px` bundle directory layout (deliverable #3).
+- `ExactArtifactProcedure`'s full field set (deliverable #4 — it is a subtype
+  of `Procedure` and is only summarized here for cross-reference).
+
+## 2. Entities
+
+Each entity below lists: identity type (per ADR-0040 §1), required fields,
+optional fields, and hashing treatment (per ADR-0040 §2–§4).
+
+### 2.1 `Repository`
+- Identity: none of its own — a `Repository` is the root container, addressed
+  by a stable, externally-assigned name/URI, not a content or graph identity.
+- Fields: `name: Text`, `default_ref: RefName` (e.g. `"main"`),
+  `created_at: RFC3339 Text` (metadata only, never hashed).
+- Relationships: `Repository CONTAINS Procedure` (1:N), `Repository HAS_REF
+  Ref` (1:N).
+
+### 2.2 `Revision` (`RepositoryRevision`, per design-spec §4.4)
+- Identity: `RevisionId` (content-derived — BLAKE3 over canonical JSON of the
+  fields below, per ADR-0040 §2, EXCLUDING `author`/`timestamp`/`message`
+  metadata fields per the rule that a revision's identity must be stable
+  under attestation/annotation but the design spec's own §4.4 struct includes
+  `author`/`timestamp`/`message` as struct fields — **this document resolves
+  that apparent tension**: `author`, `timestamp`, and `message` ARE included
+  in the hash, because unlike validation/attestation (explicitly excluded by
+  design-spec §4.4: "Validation evidence and signatures are linked objects,
+  not RevisionId inputs"), authorship and the commit message are asserted
+  facts about what the author intended this revision to be, not evidence
+  added by a third party afterward — the same distinction Git itself makes
+  (author+message are part of a commit's hash; a later GPG signature is not,
+  for signed commits using the detached-trailer convention). Timestamps ARE
+  hashed here specifically because a `Revision`'s timestamp is an author
+  assertion of when *that revision* was authored, not the ambient/materialized
+  filesystem mtimes design-spec §20 says are non-canonical ("preserve
+  meaningless filesystem timestamps" is the non-goal — a revision's own
+  `timestamp` field is meaningful, a file's `mtime` is not).
+- Fields (from design-spec §4.4, verbatim field names):
+  - `id: RevisionId` (self — excluded from its own hash input, same
+    self-reference rule as `entity_hash` in ADR-0040 §4)
+  - `parents: [RevisionId]` (order-significant, per ADR-0040 §2 array rule)
+  - `procedure_root: Hash` (per ADR-0040 §4)
+  - `entity_root: Hash` (per ADR-0040 §4)
+  - `change_ids: [LogicalChangeId]` (order-significant: the order changes were
+    applied within this revision, not sorted)
+  - `rendering_profile: RenderingProfileHash`
+  - `materialization_root: Hash` (per ADR-0040 §4)
+  - `author: PrincipalId` (Text — an opaque principal identifier; this
+    document does not define `PrincipalId`'s own format, deferred to whichever
+    milestone wires real authentication, per design-spec §13)
+  - `timestamp: RFC3339 Text`
+  - `message: Text`
+- Relationships: `Revision PARENT_OF Revision` (N:N, DAG — a revision may have
+  multiple parents for merges, multiple children if the graph is later
+  forked), `Revision INCLUDES ProcedureRevision` (1:N), `Revision RECORDS
+  LogicalChange` (1:N), `Ref POINTS_TO Revision` (N:1 — a ref points to exactly
+  one revision at a time, but a revision may be pointed to by multiple refs),
+  `Validation VALIDATES Revision` (N:1), `Attestation ATTESTS Revision` (N:1).
+
+### 2.3 `LogicalChange`
+- Identity: `LogicalChangeId` (assigned, UUIDv7 — per ADR-0040 §1, survives
+  rebase).
+- Fields: `id: LogicalChangeId`, `kind: Text` (e.g. `"rename"`, `"add_field"`,
+  free-form for M0, closed-enum candidate for M6 change-procedure work),
+  `summary: Text` (human-readable one-line description), `procedure_ids:
+  [ProcedureId]` (which procedures this logical change touched — order not
+  significant, MUST be sorted by canonical text form when hashed/serialized).
+- Relationships: `Revision RECORDS LogicalChange` (N:1 from `LogicalChange`'s
+  perspective — a change belongs to exactly one revision, the one that first
+  recorded it; the SAME `LogicalChangeId` may be referenced by a later
+  revision's `change_ids` list after a rebase per §4.3's rebase-preservation
+  rule, but "recorded by" vs "carried forward by" are the same relationship
+  type at the graph-query level — this is a modeling nuance the schema
+  implementation must get right: `change_ids` on a `Revision` is a reference
+  list, not an ownership list).
+- Hashing: a `LogicalChange`'s own `LogicalChangeId` is never recomputed;
+  its content (summary/kind/procedure_ids) is not independently hashed in M0
+  (no `LogicalChangeHash` type exists in ADR-0040 §1) — a `LogicalChange`'s
+  content is covered transitively via whichever `Revision.change_ids` entry
+  references it plus the `ProcedureRevisionHash`es of the procedures it
+  touched.
+
+### 2.4 `Workspace`
+- Identity: none of its own in M0 — a workspace is a local, ephemeral
+  materialization context (design-spec §3.3: "fully disposable/reconstructable
+  from `.px` bundle + referenced blobs"), addressed by a local path, not a
+  graph-portable identifier. (A future milestone may need a stable
+  `WorkspaceId` for multi-machine workspace sync; not required by M0's exit
+  criterion.)
+- Fields: `root_path: Text` (local, host-specific, never part of any hashed
+  value), `checked_out_revision: RevisionId`, `rendering_profile:
+  RenderingProfileHash`.
+- Relationships: none beyond referencing a `Revision` and `RenderingProfile`
+  by their content-derived identities.
+
+### 2.5 `Ref`
+- Identity: none of its own — a `Ref` is addressed by its `name` (a `RefName`,
+  e.g. `"main"`, `"refs/heads/feature-x"`), which is itself mutable pointer
+  metadata, not a stable entity identity (this matches design-spec §3.3:
+  "paths are mutable projection properties, not entity identities" — a ref
+  name is the graph-level analogue of a file path).
+- Fields: `name: RefName (Text)`, `target: RevisionId`.
+- Relationships: `Repository HAS_REF Ref` (1:N), `Ref POINTS_TO Revision`
+  (N:1).
+
+### 2.6 `Procedure`
+- Identity: `ProcedureId` (assigned, UUIDv7 — survives procedure edits per
+  ADR-0040 §1).
+- Fields: `id: ProcedureId`, `kind: ProcedureKind` (closed enum: `state |
+  exact_artifact | change | projection | reconciliation | validation |
+  compatibility` — mirroring design-spec §5's taxonomy 5.1–5.7 exactly),
+  `name: Text` (mutable, presentational — NOT part of `ProcedureId`), `path:
+  Text` (mutable, presentational, POSIX-style per ADR-0040 §4), `current_revision:
+  ProcedureRevisionHash`.
+- Relationships: `Repository CONTAINS Procedure` (1:N), `Procedure
+  HAS_REVISION ProcedureRevision` (1:N — full history), `Procedure PRODUCES
+  Artifact` (1:N), `Procedure DEPENDS_ON SemanticEntity` (N:N), `Procedure
+  REQUIRES CapabilityGrant` (1:N, per ADR-0040 §5).
+
+### 2.7 `ProcedureRevision`
+- Identity: `ProcedureRevisionHash` (content-derived — BLAKE3 over canonical
+  JSON of this revision's full `.px` source text plus its structured
+  metadata, per ADR-0040 §2).
+- Fields: `hash: ProcedureRevisionHash` (self, excluded from own hash input),
+  `procedure_id: ProcedureId` (which logical procedure this is a revision
+  of — included in the hash, since a `ProcedureRevisionHash` must be unique
+  per-owning-procedure even if two different procedures happen to share
+  identical `.px` text, per design-spec §3.6's progressive-uplift model where
+  distinct procedures may converge in content but never in identity),
+  `source_text: Text` (the canonical `.px` text — see bundle-format doc for
+  the on-disk encoding of this field), `capability_grants:
+  [CapabilityGrant]` (per ADR-0040 §5; order not significant, sorted by
+  `effect` variant name then `scope` when hashed), `residuals: [ResidualRef]`
+  (references to preserved non-canonical content per design-spec §6
+  "Residual preservation" — `ResidualRef` is `{blob_hash: BlobHash, kind:
+  Text, attachment_point: Text}`, defined here as a nested value type, not a
+  standalone graph entity, since residuals have no independent identity
+  outside their owning `ProcedureRevision`).
+- Relationships: `Procedure HAS_REVISION ProcedureRevision` (N:1 from this
+  entity's perspective).
+
+### 2.8 `SemanticEntity`
+- Identity: `EntityId` (assigned, UUIDv7 — survives rename/move per ADR-0040
+  §1).
+- Fields: `id: EntityId`, `entity_kind: Text` (open string in M0 — e.g.
+  `"type"`, `"function"`, `"module"`; a closed enum is deferred to whichever
+  semantic adapter milestone (M5) first needs entity kinds to be exhaustively
+  matched), `name: Text` (mutable), `owning_procedure: ProcedureId`.
+- Relationships: `Procedure DEPENDS_ON SemanticEntity` (N:N), `SemanticEntity
+  REFERENCES SemanticEntity` (N:N, and MAY be cyclic — e.g. mutually
+  recursive types; the schema does not forbid cycles, callers that need
+  acyclic traversal must detect and handle cycles themselves), `Conflict
+  INVOLVES SemanticEntity` (N:N).
+
+### 2.9 `Artifact`
+- Identity: none of its own — an `Artifact` is a projection-facing output,
+  identified by the combination of its owning `Procedure` and its
+  `PROJECTS_TO Path` relationship; its content identity lives entirely in the
+  `Blob` it references.
+- Fields: `owning_procedure: ProcedureId`, `blob: BlobHash`, `mode: Text`
+  (POSIX permission bits as an octal string, e.g. `"0644"`, `"0755"` for
+  executable — per design-spec §5.2 "exec mode... captured"), `encoding: Text`
+  (e.g. `"utf-8"`, `"binary"`), `is_symlink: Bool`, `symlink_target: Option<Text>`.
+- Relationships: `Procedure PRODUCES Artifact` (1:N), `Artifact PROJECTS_TO
+  Path` (1:1 per rendering profile — an artifact may project to different
+  paths under different rendering profiles, but within one profile the
+  mapping is 1:1), `Artifact USES_BLOB Blob` (N:1).
+
+### 2.10 `Blob`
+- Identity: `BlobHash` (content-derived — BLAKE3 over raw bytes directly, per
+  ADR-0040 §3, NOT wrapped in canonical JSON).
+- Fields: `hash: BlobHash` (self), `size_bytes: UInt64`, `content: Bytes`
+  (the raw payload — storage-layer concern whether this is inline or
+  externally chunked; schema-level, a `Blob` is addressed and hashed as one
+  logical byte sequence regardless of physical storage chunking).
+- Relationships: `Artifact USES_BLOB Blob` (N:1 — content-addressing means
+  many artifacts across many procedures/revisions may share one `Blob` when
+  bytes are identical, exactly like Git's blob dedup, noted explicitly in
+  design-spec §9.2 "Git already dedupes unchanged trees/blobs across commits
+  naturally").
+
+### 2.11 `Projection`
+- Identity: `ProjectionId` (assigned, UUIDv7 — "a named materialization
+  configuration", per ADR-0040 §1 table, stable across edits to the
+  configuration itself).
+- Fields: `id: ProjectionId`, `name: Text`, `adapter: Text` (references an
+  `Adapter` by name/version — see §2.12), `root_path: Text` (relative
+  materialization root within a workspace).
+- Relationships: `Projection USES_ADAPTER Adapter` (N:1).
+
+### 2.12 `Adapter`
+- Identity: none of its own graph-level identity in M0 — an `Adapter` is
+  referenced by `(name, version)` pair; its *behavior* is pinned by a
+  `RenderingProfileHash` (§2.13), not by an `AdapterId`, since the design
+  spec's determinism model (§14) pins "adapter implementation hash, adapter
+  schema version" as inputs INTO the rendering profile hash, not as a
+  separate first-class identity of their own in this schema.
+- Fields: `name: Text`, `version: Text`, `implementation_hash: BlobHash`
+  (content hash of the adapter's own implementation artifact, for §14's
+  determinism pinning).
+- Relationships: `Projection USES_ADAPTER Adapter` (N:1).
+
+### 2.13 `RenderingProfile`
+- Identity: `RenderingProfileHash` (content-derived — BLAKE3 over canonical
+  JSON of the fields below, per ADR-0040 §2).
+- Fields: `adapter_name: Text`, `adapter_version: Text`,
+  `adapter_implementation_hash: BlobHash`, `formatter_version: Text`,
+  `platform_profile: Text` (e.g. `"linux-x86_64"` — per design-spec §14
+  "platform profile" as a pinned determinism input), `parameters: Object`
+  (canonical-JSON-encodable configuration map, adapter-specific).
+- Relationships: `Workspace` and `Revision` both reference a
+  `RenderingProfileHash` by value (N:1 conceptually, no separate graph edge
+  type needed beyond the field reference itself).
+
+### 2.14 `Validation`
+- Identity: none of its own — a `Validation` result is scoped to the
+  `Revision` it validates; repeated validation runs are distinct
+  `Validation` records (not overwritten), each linked to the same
+  `RevisionId`.
+- Fields: `revision: RevisionId`, `kind: Text` (e.g. `"test_suite"`,
+  `"policy_check"`, `"type_check"`), `result: Text` (`"pass" | "fail" |
+  "error"`), `evidence_blob: Option<BlobHash>` (e.g. test output log),
+  `run_at: RFC3339 Text`.
+- Relationships: `Validation VALIDATES Revision` (N:1).
+
+### 2.15 `Attestation`
+- Identity: none of its own — same shape as `Validation`.
+- Fields: `revision: RevisionId`, `principal: PrincipalId`, `statement: Text`,
+  `signature: Option<Bytes>` (deferred — signature scheme not fixed by M0),
+  `attested_at: RFC3339 Text`.
+- Relationships: `Attestation ATTESTS Revision` (N:1).
+
+### 2.16 `Conflict`
+- Identity: none of its own in M0 (a future milestone, M6, may need a stable
+  `ConflictId` for conflict-resolution UI referencing across sessions — not
+  required by M0's exit criterion; this schema leaves room for it as a later
+  additive field without breaking anything specified here).
+- Fields: `base: RevisionId`, `left: RevisionId`, `right: RevisionId`,
+  `subject_entities: [EntityId]`, `reason: Text`, `alternatives: [Text]`
+  (human-readable candidate resolutions — structured resolution options are
+  M6 scope per design-spec §12.3).
+- Relationships: `Conflict INVOLVES SemanticEntity` (N:N).
+
+### 2.17 `CapabilityGrant`
+- Identity: none of its own — a value type, not an independently-addressed
+  entity (matches design-spec §4.1 listing it alongside entities, but its
+  actual shape, per ADR-0040 §5, is a plain struct attached to a `Procedure`,
+  not something separately queried by its own ID).
+- Fields: per ADR-0040 §5 — `effect: Effect`, `scope: Option<Text>`.
+- Relationships: `Procedure REQUIRES CapabilityGrant` (1:N).
+
+### 2.18 `DraftOverlay`
+- Identity: none of its own — scoped to the `Artifact`/path it overlays;
+  addressed by that path within a workspace, not a portable graph identity
+  (drafts are inherently workspace-local and transient per design-spec §8.2).
+- Fields: `artifact_path: Text`, `prior_owner: Option<ProcedureId>`,
+  `content_blob: BlobHash`, `parser_state: Text` (`"incomplete" | "invalid" |
+  "recoverable"`), `diagnostics: [Text]`.
+- Relationships: none beyond referencing an `Artifact`'s path and a `Blob`.
+
+### 2.19 `ExternalImport`
+- Identity: none of its own in M0 — addressed by its source commit/patch
+  reference (e.g. a Git commit SHA string) plus the target `Repository`; a
+  stable `ExternalImportId` is deferred to M7 (external contribution
+  workflow) when import review-state needs to be tracked across sessions.
+- Fields: `source_ref: Text` (e.g. a Git commit SHA), `proposed_changes:
+  [LogicalChangeId]`, `fidelity_report: FidelityVector` (per design-spec §10
+  — structure defined in the fidelity-vector schema, itself a future
+  deliverable per epic backlog item 14, not fixed by this document).
+- Relationships: `ExternalImport PROPOSES LogicalChange` (1:N).
+
+## 3. Relationship summary table
+
+| Relationship | From | To | Cardinality |
+|---|---|---|---|
+| CONTAINS | Repository | Procedure | 1:N |
+| HAS_REF | Repository | Ref | 1:N |
+| POINTS_TO | Ref | Revision | N:1 |
+| PARENT_OF | Revision | Revision | N:N (DAG) |
+| INCLUDES | Revision | ProcedureRevision | 1:N |
+| RECORDS | Revision | LogicalChange | 1:N |
+| HAS_REVISION | Procedure | ProcedureRevision | 1:N |
+| PRODUCES | Procedure | Artifact | 1:N |
+| DEPENDS_ON | Procedure | SemanticEntity | N:N |
+| REQUIRES | Procedure | CapabilityGrant | 1:N |
+| PROJECTS_TO | Artifact | Path (value) | 1:1 per profile |
+| USES_BLOB | Artifact | Blob | N:1 |
+| REFERENCES | SemanticEntity | SemanticEntity | N:N (may cycle) |
+| USES_ADAPTER | Projection | Adapter | N:1 |
+| VALIDATES | Validation | Revision | N:1 |
+| ATTESTS | Attestation | Revision | N:1 |
+| INVOLVES | Conflict | SemanticEntity | N:N |
+| PROPOSES | ExternalImport | LogicalChange | 1:N |
+
+## 4. Conformance-test cross-reference
+
+This schema is written to directly satisfy design-spec §19 conformance tests
+1, 2, 8, 9, 15 (see ADR-0040 "Consequences" for the identity-level argument);
+tests 3–7, 10–14, 16–18 are M1+ scope and depend on the exact-artifact
+importer, reconciliation engine, and merge logic respectively — not
+satisfiable by schema alone, listed here only so the M0 reader can see which
+tests this document does and does not close.
+
+## 5. Open items carried to later deliverables
+
+- `PrincipalId` format (authentication milestone, not M0).
+- `FidelityVector` full structure (epic backlog item 14).
+- `ProcedureKind`/`entity_kind` closed-enum promotion timing (M5/M6 —
+  deliberately left open string in M0 per design-spec §3.6 progressive
+  uplift).
+- Signature scheme for `Attestation.signature` (deferred, unblocked whenever
+  a concrete signing mechanism is chosen).

--- a/docs/design/procedure-graph-repository-substrate/px-bundle-format.md
+++ b/docs/design/procedure-graph-repository-substrate/px-bundle-format.md
@@ -1,0 +1,213 @@
+# Procedure-Graph Repository Substrate — `.px` Bundle Directory Format
+
+**M0 deliverable #3 of epic `pares-radix:procedure-graph-repository-substrate`.**
+Companion to `.praxis/decisions/ADR-0040-procedure-graph-identity-and-canonical-hashing.md`
+and `docs/design/procedure-graph-repository-substrate/graph-schema.md`. Design
+spec source: `memory/design-procedure-graph-repository-substrate-2026-07-24.md`
+§9.2 (canonical Git tree layout — reproduced and made concrete below) and §3.2
+("`.px` is the canonical portable representation").
+
+Design-only. No implementation code ships with this document.
+
+## 1. Purpose
+
+The design spec (§9.2) sketches the canonical Git tree shape but does not
+specify byte-level encoding, file naming rules, or partitioning scheme needed
+for two independent implementations to produce an identical tree for the same
+graph revision (the M0 exit criterion). This document fixes those details.
+
+## 2. Directory layout (elaborates design-spec §9.2)
+
+```
+.px/
+  repository.px
+  revision.px
+  change.px
+  procedures/
+    <partition>/<ProcedureId>.px
+  residuals/
+    <BlobHash-hex>.px
+  blobs/
+    <BlobHash-hex>
+  adapters.lock
+  schemas.lock
+  rendering.lock
+  projection-manifest.px
+```
+
+All paths are POSIX-style (`/` separator) regardless of host OS, per
+ADR-0040 §4's path-sorting rule — this directory layout is itself hashed as
+part of `materialization_root`, so path separator ambiguity would break
+byte-identical serialization exactly as it would break Merkle-root
+determinism.
+
+## 3. File-by-file specification
+
+### 3.1 `repository.px`
+One `.px` state-procedure document (design-spec §5.1) describing the
+`Repository` entity itself: `name`, `default_ref`. Canonical `.px` text
+encoding per §5 below. Not content-addressed itself (a `Repository` has no
+identity of its own per the schema doc §2.1) — this file's bytes are
+deterministic given the `Repository`'s current field values, but the file is
+not looked up BY a hash; it is looked up by its fixed path.
+
+### 3.2 `revision.px`
+One `.px` document per **current** revision (the one `HEAD`/the active `Ref`
+points to) — NOT a full history dump; history is reconstructed by walking
+`parents` through Git commit ancestry once exported via `git.px` (design-spec
+§9), or by walking prior `revision.px` blobs stored under earlier Git tree
+states. Contains the full `RepositoryRevision` struct (schema doc §2.2) in
+canonical `.px` form. The file's bytes MUST hash (per ADR-0040 §2) to exactly
+the `RevisionId` recorded as this revision's identity — this is the concrete,
+checkable form of the M0 exit criterion: given a `revision.px`, recomputing
+`RevisionId` from its bytes and comparing to the `RevisionId` an independent
+implementation assigns is the conformance check.
+
+### 3.3 `change.px`
+One `.px` document containing the list of `LogicalChange` records introduced
+by this revision (schema doc §2.3), i.e. the content backing
+`revision.px`'s `change_ids` field. Entries ordered exactly as listed in
+`change_ids` (order-significant, not sorted — schema doc §2.3).
+
+### 3.4 `procedures/<partition>/<ProcedureId>.px`
+One file per `Procedure`'s current `ProcedureRevision` (schema doc §2.6/§2.7).
+**Partitioning rule:** `<partition>` is the first two lowercase hex characters
+of the `ProcedureId` UUID with hyphens stripped (e.g. `ProcedureId
+018f2b3a-8c41-7000-9c21-4e6b1a2f9d10` → partition `01`, file
+`procedures/01/018f2b3a-8c41-7000-9c21-4e6b1a2f9d10.px`). This mirrors Git's
+own loose-object two-character sharding convention (`.git/objects/<xx>/<rest>`)
+for the same reason Git adopted it — avoiding directories with an unbounded
+flat file count — and keeps this bundle format visually/operationally
+familiar to anyone who has worked inside a `.git` directory, consistent with
+design-spec §2's explicit citation of Git's object model as the mapping
+target for this bundle. Partitioning is purely a filesystem/lookup
+convenience; it is NOT part of any hashed value (a `ProcedureRevisionHash`
+does not encode which partition directory holds its file).
+
+### 3.5 `residuals/<BlobHash-hex>.px`
+One file per distinct residual (schema doc §2.7 `ResidualRef`) — structured
+`.px` metadata (kind, attachment point) wrapping a reference to the residual's
+own content stored under `blobs/`. Filename is the residual's OWN content
+hash (a `BlobHash`, hex, no `blake3:` prefix in the filename — see §4 below on
+filename vs canonical-text-form encoding), not the `ProcedureRevisionHash` of
+the procedure it's attached to (a residual may be shared/referenced by
+multiple procedure revisions if byte-identical, same dedup argument as
+`blobs/`).
+
+### 3.6 `blobs/<BlobHash-hex>`
+Raw blob bytes (schema doc §2.10), stored verbatim — no `.px` wrapper, no
+extension. Filename is the lowercase hex `BlobHash` **without** the `blake3:`
+prefix used in canonical JSON text form (ADR-0040 §1) — the prefix exists to
+disambiguate hash types when a hash value appears embedded as a field inside
+JSON; a blob file's location is already unambiguously "a blob" by directory
+context, so the prefix is redundant there and dropped for path brevity,
+matching Git's own bare-hex object filenames. Same two-character-partition
+sharding as §3.4 is RECOMMENDED for blobs at scale (`blobs/<xx>/<rest>`) but
+NOT required for M0 conformance (a flat `blobs/` directory is valid for the
+test-graph scale used in the M0 conformance corpus); this is called out
+explicitly as an implementation choice, not a hashed/canonical property.
+
+### 3.7 `adapters.lock`
+Canonical JSON (per ADR-0040 §2 encoding rules) array of `{name, version,
+implementation_hash}` triples (schema doc §2.12 `Adapter`), sorted by `name`
+then `version`. Analogous to a package-manager lockfile — pins exactly which
+adapter implementations this revision's projections depend on, per
+design-spec §14's determinism requirement.
+
+### 3.8 `schemas.lock`
+Canonical JSON recording the schema-doc version this bundle was produced
+against (a simple `{schema_version: Text}` for M0 — this document IS schema
+version `"m0-2026-07-31"`; a future schema revision increments this string).
+Exists so a loader can detect "this bundle predates a schema change" rather
+than silently misinterpreting fields, per design-spec §14 "Adapter upgrades
+must be explicit migration changes — never silently reformat the repo,"
+generalized here to schema versions, not just adapter versions.
+
+### 3.9 `rendering.lock`
+Canonical JSON of the current `RenderingProfile` (schema doc §2.13),
+content-addressed by its own `RenderingProfileHash` — this file's bytes MUST
+hash to the `rendering_profile` field value recorded in `revision.px`, same
+self-consistency check as §3.2.
+
+### 3.10 `projection-manifest.px`
+One `.px` document listing every `Projection` (schema doc §2.11) and its
+`Artifact → Path` mapping (schema doc §2.9's `PROJECTS_TO` relationship) for
+the CURRENT `materialization_root`. This is the file a materializer reads to
+know which blobs go to which output paths — i.e., the concrete input to
+`materialize(G, R) = W` (design-spec §1).
+
+## 4. Hash filename convention vs canonical text form
+
+Two distinct hex encodings appear in this bundle, and they must not be
+confused:
+
+- **Canonical text form** (used INSIDE `.px`/JSON field values, per ADR-0040
+  §1): `blake3:<64 lowercase hex chars>` — always prefixed, always used when a
+  hash appears as embedded structured data.
+- **Bare filename form** (used for `blobs/`, `residuals/`, `procedures/`
+  paths): `<64 lowercase hex chars>` (or the ProcedureId UUID form for
+  `procedures/`) — never prefixed, since the directory context already
+  disambiguates the hash's type.
+
+A conformant implementation MUST be able to convert between these two forms
+mechanically (strip/add the `blake3:` prefix) — this is stated explicitly
+because a subtle mismatch here (e.g. one implementation using the prefixed
+form as a filename) would silently break byte-for-byte tree comparison
+between independent implementations, defeating the M0 exit criterion.
+
+## 5. `.px` text encoding within bundle files
+
+Every `.px` file in this bundle (`repository.px`, `revision.px`, `change.px`,
+`procedures/*.px`, `residuals/*.px`, `projection-manifest.px`) is:
+
+- UTF-8, **no BOM**.
+- **LF line endings only** (`\n`, never `\r\n`) — this is a hard requirement
+  distinct from a stylistic preference: mixed line endings would make the
+  same logical content hash differently depending on which platform produced
+  it, directly defeating determinism (design-spec §14). Any implementation
+  running on Windows MUST normalize to LF before writing bundle files (this is
+  the same class of defect flagged elsewhere in this workspace's own tooling
+  notes about PowerShell `-replace` introducing bare `\r` bytes — a concrete,
+  previously-hit failure mode this bundle format explicitly guards against by
+  fixing LF-only as a conformance requirement, not an assumption).
+- **Exactly one trailing newline** at end-of-file (POSIX text-file
+  convention) — but this trailing newline is NOT part of what gets hashed
+  (per ADR-0040 §2: hashing operates over the canonical-JSON-then-UTF-8
+  encoding of the LOGICAL value, not the literal file bytes on disk for
+  `.px`-formatted structural files; only `blobs/<hash>` files are hashed as
+  literal raw bytes per ADR-0040 §3). This means a `.px` file's on-disk
+  trailing newline is a filesystem/editor courtesy, not a hash input — two
+  implementations may differ on trailing-newline presence in the WRITTEN file
+  without breaking the M0 exit criterion, since the exit criterion is about
+  the `revision.px` **content hash matching the recorded RevisionId**, which
+  is computed from the logical value, not literal file bytes. (Contrast with
+  `blobs/<hash>`, where file bytes ARE the hash input exactly, with no
+  normalization license at all.)
+- No trailing whitespace on any line (lint-level convention for reviewability
+  per design-spec §3.2 "reviewable serialization" — not a hash-affecting rule
+  per the point above, but enforced by tooling to keep diffs clean).
+
+## 6. Directory-level determinism note
+
+`materialization_root` (ADR-0040 §4) is computed from the `.px` bundle's
+LOGICAL contents (sorted `{path, blob_hash}` pairs), not from directory
+listing order, mtimes, or any filesystem metadata — so this bundle format's
+directory layout is a **lookup/storage convenience**, not itself a hash
+input. Two implementations that choose different (but internally consistent)
+partitioning schemes for `procedures/` or `blobs/` would still agree on every
+content hash and every Merkle root; they would only disagree on where a given
+file physically lives on disk. The M0 exit criterion ("two independent
+implementations serialize the same test graph identically") is satisfied at
+the hash/canonical-JSON level (ADR-0040) regardless of directory-layout
+choice — this document's specific partitioning scheme (§3.4, §3.6) is
+RECOMMENDED for interoperability and Git-familiarity, not itself
+independently conformance-tested beyond "produces the files listed in §2."
+
+## 7. Relationship to `git.px` (design-spec §9)
+
+This directory IS the tree `git.px` (design-spec §9.1) serializes into Git
+blobs/trees/commits — `.px/` as specified here is exactly the tree structure
+design-spec §9.2 names; this document is the byte-level elaboration `git.px`'s
+own implementation (M4 milestone, out of scope for M0) will need. Nothing in
+`git.px`'s responsibilities changes this document's layout; `git.px` only adds
+the Git object-ID mapping layer (design-spec §9.3) on top of it.


### PR DESCRIPTION
## Summary

M0 milestone (design-only) of epic `pares-radix:procedure-graph-repository-substrate`. Full design spec: OpenClaw workspace `memory/design-procedure-graph-repository-substrate-2026-07-24.md` (source of truth, read in full for this work).

Blocker (`plures/praxis-lang` RFC-0003, effects/capabilities) merged as `plures/praxis-lang#21`. This PR adopts RFC-0003's `Effect`/`CapabilityGrant` shape directly (see ADR-0040 section 5).

## M0 deliverables (design-spec section 22, items 1-4)

1. `.praxis/decisions/ADR-0040-procedure-graph-identity-and-canonical-hashing.md` — identity model (assigned UUIDv7 vs content-derived BLAKE3 hashes), canonical-JSON encoding rule, blob hashing, flat sorted-Merkle composition for procedure_root/entity_root/materialization_root, and the CapabilityGrant shape adopted from RFC-0003.
2. `docs/design/procedure-graph-repository-substrate/graph-schema.md` — full entity/relationship schema (design-spec sections 4.1/4.2/4.4), cross-referenced against conformance tests 1/2/8/9/15.
3. `docs/design/procedure-graph-repository-substrate/px-bundle-format.md` — `.px` bundle directory format elaborated to byte level (design-spec section 9.2).
4. `docs/design/procedure-graph-repository-substrate/exact-artifact-procedure.md` — `ExactArtifactProcedure` interface spec (design-spec section 5.2), including an explicitly-flagged open item (non-UTF-8 filename byte representation in a UTF-8 `.px` text format) rather than an invented resolution.

## Scope discipline

- **Design-only. No implementation code.** Per the epic's own sequencing rule ("milestones are strictly sequential") and this repo's no-stub policy (C-NOSTUB-001), the M0 minimal-serialization conformance test is intentionally NOT included here — it requires an actual `px-repo-model` crate scaffold (Cargo.toml + working types), which is the first *code* artifact of this epic and is flagged in the ExactArtifactProcedure doc (section 7) as the natural next actionable step, not fabricated as a stub in this docs PR.
- New crate ownership per design-spec section 16: this substrate belongs in a new `px-repo`/`px-repo-model` crate (not `praxis-lang`, not `pares-radix` core UI, not a plain `pluresdb` crate) — this PR does not scaffold that crate yet (docs-only), consistent with the sequential-milestone gate.
- If a referenced section/file was inaccessible, this PR says so explicitly rather than inventing content (see the ExactArtifactProcedure doc's open item and ADR-0040's blocked-on note).
