### PR TITLE
feat(px-repo-model): scaffold canonical repository graph model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5628,6 +5628,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "px-repo-model"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "uuid",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/px-repo-model",
     "crates/radix-core",
     "crates/mcp-client",
     "crates/privacy",

--- a/crates/px-repo-model/Cargo.toml
+++ b/crates/px-repo-model/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "px-repo-model"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Procedure-graph repository substrate: graph schema types and canonical identity/hashing (ADR-0040, M0)."
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true, features = ["v7", "serde"] }
+blake3 = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/px-repo-model/src/canonical.rs
+++ b/crates/px-repo-model/src/canonical.rs
@@ -1,0 +1,168 @@
+//! Canonical JSON encoding rules (ADR-0040 §2) — the single encoding used
+//! for every content-derived hash EXCEPT `BlobHash` (which hashes raw bytes
+//! directly, ADR-0040 §3).
+//!
+//! Rules implemented here:
+//! - Object keys sorted byte-wise ascending by UTF-8 encoding.
+//! - No insignificant whitespace.
+//! - No floats anywhere in this schema (enforced by construction: this
+//!   encoder rejects `serde_json::Number` values that are not integers).
+//! - Strings escaped per strict JSON, not HTML-safe-escaped.
+//! - Arrays preserve their given order (order significance is a caller
+//!   concern - this encoder never reorders array elements).
+//! - `null` for an absent optional field must never be emitted; callers
+//!   build a `serde_json::Value::Object` that simply omits the key.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::identity::ContentHash;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CanonicalError {
+    #[error("value contains a float, which is not permitted anywhere in this schema: {0}")]
+    FloatNotAllowed(String),
+    #[error("value contains an explicit null, which must be omitted instead: key {0:?}")]
+    ExplicitNullNotAllowed(String),
+    #[error("serde_json serialization failed: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// Serialize `value` to the canonical JSON byte encoding specified by
+/// ADR-0040 §2, then return the raw UTF-8 bytes (no trailing newline).
+pub fn to_canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, CanonicalError> {
+    let json_value = serde_json::to_value(value)?;
+    let canonical = canonicalize_value(json_value, "$")?;
+    Ok(write_canonical(&canonical))
+}
+
+/// Hash `value` per ADR-0040 §2: canonical JSON bytes, then BLAKE3-256.
+pub fn hash_canonical_json<T: Serialize>(value: &T) -> Result<ContentHash, CanonicalError> {
+    let bytes = to_canonical_bytes(value)?;
+    Ok(ContentHash::of_raw_bytes(&bytes))
+}
+
+/// Recursively validate + normalize a `serde_json::Value` per the canonical
+/// rules: reject floats, reject explicit nulls inside objects (arrays may
+/// still legally contain `null` if a schema ever needs it - the "omit,
+/// don't null" rule in ADR-0040 §2 is specifically about *optional object
+/// fields*), and sort object keys byte-wise ascending.
+fn canonicalize_value(value: Value, path: &str) -> Result<Value, CanonicalError> {
+    match value {
+        Value::Null => Ok(Value::Null),
+        Value::Bool(b) => Ok(Value::Bool(b)),
+        Value::Number(n) => {
+            if n.is_i64() || n.is_u64() {
+                Ok(Value::Number(n))
+            } else {
+                Err(CanonicalError::FloatNotAllowed(path.to_string()))
+            }
+        }
+        Value::String(s) => Ok(Value::String(s)),
+        Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for (i, item) in items.into_iter().enumerate() {
+                out.push(canonicalize_value(item, &format!("{path}[{i}]"))?);
+            }
+            Ok(Value::Array(out))
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> = Vec::with_capacity(map.len());
+            for (k, v) in map.into_iter() {
+                if v.is_null() {
+                    return Err(CanonicalError::ExplicitNullNotAllowed(format!(
+                        "{path}.{k}"
+                    )));
+                }
+                let child_path = format!("{path}.{k}");
+                entries.push((k.clone(), canonicalize_value(v, &child_path)?));
+            }
+            // Byte-wise ascending sort by UTF-8 encoding of the key.
+            entries.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+            let mut out = serde_json::Map::new();
+            for (k, v) in entries {
+                out.insert(k, v);
+            }
+            Ok(Value::Object(out))
+        }
+    }
+}
+
+/// Write a value that has already been canonicalized (sorted keys, no
+/// floats, no explicit object nulls) to compact JSON bytes with no
+/// insignificant whitespace. `serde_json::to_vec` on a `serde_json::Map`
+/// preserves insertion order, which is why `canonicalize_value` sorts the
+/// map before this step rather than relying on any serializer-level key
+/// sorting.
+fn write_canonical(value: &Value) -> Vec<u8> {
+    // serde_json's compact writer already omits all insignificant
+    // whitespace and does not HTML-escape by default, matching ADR-0040 §2.
+    serde_json::to_vec(value).expect("canonicalized Value must always serialize")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn sorts_object_keys_byte_wise_ascending() {
+        let value = json!({"b": 1, "a": 2, "A": 3});
+        let bytes = to_canonical_bytes(&value).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        // 'A' (0x41) sorts before 'a' (0x61) and 'b' (0x62) byte-wise.
+        assert_eq!(text, r#"{"A":3,"a":2,"b":1}"#);
+    }
+
+    #[test]
+    fn rejects_float_values() {
+        let value = json!({"x": 1.5});
+        let err = to_canonical_bytes(&value).unwrap_err();
+        assert!(matches!(err, CanonicalError::FloatNotAllowed(_)));
+    }
+
+    #[test]
+    fn rejects_explicit_null_in_object() {
+        let value = json!({"x": null});
+        let err = to_canonical_bytes(&value).unwrap_err();
+        assert!(matches!(err, CanonicalError::ExplicitNullNotAllowed(_)));
+    }
+
+    #[test]
+    fn omitted_optional_field_and_never_present_field_hash_identically() {
+        let with_present_value = json!({"a": 1, "b": 2});
+        let without_key_at_all = json!({"a": 1});
+        // Simulate "explicitly absent" by simply not inserting the key at
+        // all -- the ADR-0040 rule is enforced by callers constructing their
+        // Value without ever inserting None-valued keys; this encoder's job
+        // is only to refuse to accept an explicit null if one slips through.
+        let h1 = hash_canonical_json(&with_present_value).unwrap();
+        let h2 = hash_canonical_json(&without_key_at_all).unwrap();
+        assert_ne!(h1, h2, "differing content must hash differently");
+    }
+
+    #[test]
+    fn arrays_preserve_order_and_are_not_sorted() {
+        let value = json!({"parents": ["z", "a", "m"]});
+        let bytes = to_canonical_bytes(&value).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert_eq!(text, r#"{"parents":["z","a","m"]}"#);
+    }
+
+    #[test]
+    fn no_insignificant_whitespace_in_output() {
+        let value = json!({"a": [1, 2, 3], "b": {"nested": true}});
+        let bytes = to_canonical_bytes(&value).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(!text.contains(' '));
+        assert!(!text.contains('\n'));
+    }
+
+    #[test]
+    fn hashing_is_deterministic_across_repeated_calls() {
+        let value = json!({"z": 1, "a": 2, "m": [3, 2, 1]});
+        let h1 = hash_canonical_json(&value).unwrap();
+        let h2 = hash_canonical_json(&value).unwrap();
+        assert_eq!(h1, h2);
+    }
+}

--- a/crates/px-repo-model/src/conformance_test.rs
+++ b/crates/px-repo-model/src/conformance_test.rs
@@ -1,0 +1,254 @@
+//! M0 exit-criterion conformance test (design-spec §17: "Exit: two
+//! independent implementations serialize the same test graph identically").
+//!
+//! **Approach taken and why:** a true second-language implementation is out
+//! of scope for this milestone (M5 is the first milestone that stands up a
+//! second concrete language surface, and even then it's a semantic adapter,
+//! not a from-scratch re-implementation of this hashing spec). Per
+//! ADR-0040's own "Consequences" section, this crate satisfies the M0 exit
+//! criterion via **two independently-written Rust encoding functions**
+//! within this same crate that deliberately do not share an encoding
+//! function or intermediate representation: `canonical::hash_canonical_json`
+//! (the crate's actual production path, going through `serde_json::Value`
+//! and a generic canonicalizer) versus `reference_encode_and_hash` below (a
+//! hand-rolled encoder written directly against ADR-0040 §2's prose rules,
+//! walking the test graph's own Rust struct fields by hand with no
+//! `serde_json::Value` intermediate step and no shared helper functions).
+//! Both must independently arrive at byte-identical canonical JSON — and
+//! therefore identical BLAKE3 hashes — for the same logical test graph. This
+//! is the strongest same-language proxy for cross-implementation determinism
+//! achievable without a second-language implementation, matching this
+//! milestone's own scope note in `exact-artifact-procedure.md` §7.
+
+use crate::identity::{BlobHash, ContentHash, EntityId, ProcedureId};
+use crate::schema::{CapabilityGrant, Effect, ProcedureRevisionContent, ResidualRef};
+
+/// Build one fixed test graph: a single `ProcedureRevisionContent` with a
+/// non-trivial field set (capability grants, residuals, non-ASCII text) so
+/// the two encoders have real work to agree on, not a trivial empty struct.
+fn build_test_procedure_revision() -> (ProcedureId, ProcedureRevisionContent) {
+    let procedure_id =
+        ProcedureId::parse_canonical_text("018f2b3a-8c41-7000-9c21-4e6b1a2f9d10").unwrap();
+    let residual_blob = BlobHash::of_raw_bytes(b"// preserved trailing comment\n");
+    let content = ProcedureRevisionContent {
+        procedure_id,
+        source_text: "procedure module AuthModule { }\n// unicode: caf\u{e9} \u{2713}".to_string(),
+        capability_grants: vec![
+            CapabilityGrant {
+                effect: Effect::DbRead,
+                scope: Some("users".to_string()),
+            },
+            CapabilityGrant {
+                effect: Effect::Clock,
+                scope: None,
+            },
+        ],
+        residuals: vec![ResidualRef {
+            blob_hash: residual_blob,
+            kind: "line_comment".to_string(),
+            attachment_point: "AuthModule:end".to_string(),
+        }],
+    };
+    (procedure_id, content)
+}
+
+/// Second, independently-written encoder: walks `ProcedureRevisionContent`'s
+/// fields directly by hand and builds the canonical JSON text itself,
+/// applying ADR-0040 §2's rules from prose rather than calling
+/// `canonical::canonicalize_value`/`write_canonical`. Deliberately
+/// hand-rolls JSON string escaping and key ordering rather than importing
+/// any helper from the `canonical` module, so this function shares no code
+/// path with `canonical::hash_canonical_json`.
+fn reference_encode_and_hash(content: &ProcedureRevisionContent) -> ContentHash {
+    let mut out = String::new();
+    out.push('{');
+
+    // Object keys, sorted byte-wise ascending by UTF-8 encoding:
+    // "capability_grants" < "procedure_id" < "residuals" < "source_text"
+    // (verified by direct byte comparison of the key strings below, not
+    // assumed - 'c' < 'p' < 'r' < 's' in ASCII, and none of these keys share
+    // a prefix that would require deeper comparison).
+    out.push_str("\"capability_grants\":[");
+    for (i, grant) in content.capability_grants.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        // CapabilityGrant keys sorted: "effect" < "scope".
+        out.push_str("\"effect\":\"");
+        out.push_str(reference_effect_variant_name(grant.effect));
+        out.push('"');
+        if let Some(scope) = &grant.scope {
+            out.push_str(",\"scope\":\"");
+            out.push_str(&reference_escape_json_string(scope));
+            out.push('"');
+        }
+        out.push('}');
+    }
+    out.push(']');
+
+    out.push_str(",\"procedure_id\":\"");
+    out.push_str(&content.procedure_id.to_canonical_text());
+    out.push('"');
+
+    out.push_str(",\"residuals\":[");
+    for (i, residual) in content.residuals.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        // ResidualRef keys sorted: "attachment_point" < "blob_hash" < "kind".
+        out.push_str("\"attachment_point\":\"");
+        out.push_str(&reference_escape_json_string(&residual.attachment_point));
+        out.push_str("\",\"blob_hash\":\"");
+        out.push_str(&residual.blob_hash.to_canonical_text());
+        out.push_str("\",\"kind\":\"");
+        out.push_str(&reference_escape_json_string(&residual.kind));
+        out.push('"');
+        out.push('}');
+    }
+    out.push(']');
+
+    out.push_str(",\"source_text\":\"");
+    out.push_str(&reference_escape_json_string(&content.source_text));
+    out.push('"');
+
+    out.push('}');
+
+    ContentHash::of_raw_bytes(out.as_bytes())
+}
+
+/// Hand-rolled variant-name mapping matching `#[serde(rename_all =
+/// "snake_case")]` on `Effect`, written independently from the `serde`
+/// derive rather than calling into it.
+fn reference_effect_variant_name(effect: Effect) -> &'static str {
+    match effect {
+        Effect::DbRead => "db_read",
+        Effect::DbWrite => "db_write",
+        Effect::Network => "network",
+        Effect::Shell => "shell",
+        Effect::FileRead => "file_read",
+        Effect::FileWrite => "file_write",
+        Effect::EnvRead => "env_read",
+        Effect::Clock => "clock",
+        Effect::Random => "random",
+    }
+}
+
+/// Hand-rolled strict-JSON string escaping (ADR-0040 §2: quote, backslash,
+/// control chars < 0x20 escaped; NOT HTML-safe-escaped, so `<`/`>`/`&` pass
+/// through unescaped, matching `serde_json`'s default behavior).
+fn reference_escape_json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[test]
+fn two_independent_encoders_produce_byte_identical_hash_for_the_same_test_graph() {
+    let (_procedure_id, content) = build_test_procedure_revision();
+
+    // Encoder 1: the crate's actual production canonical-JSON path
+    // (generic Value-based canonicalizer in `canonical.rs`).
+    let production_hash = crate::canonical::hash_canonical_json(&content)
+        .expect("production encoder must succeed on a well-formed fixture");
+
+    // Encoder 2: independently hand-written field-by-field encoder above,
+    // sharing no function or intermediate type with encoder 1.
+    let reference_hash = reference_encode_and_hash(&content);
+
+    assert_eq!(
+        production_hash, reference_hash,
+        "two independently-written encoders must produce byte-identical \
+         canonical serialization (and therefore identical hashes) for the \
+         same logical test graph -- this is the M0 exit criterion"
+    );
+
+    // Also assert the actual canonical bytes match exactly, not just the
+    // hash (a hash collision would be an absurdly wrong way to pass this
+    // test, but asserting bytes directly closes that gap).
+    let production_bytes = crate::canonical::to_canonical_bytes(&content).unwrap();
+    let production_text = String::from_utf8(production_bytes).unwrap();
+
+    // Re-run the reference encoder's exact string-building logic (same
+    // function, called again) to get its literal text for a direct string
+    // comparison against the production encoder's output.
+    let reference_text = reference_encode_json_text(&content);
+    assert_eq!(
+        production_text, reference_text,
+        "canonical JSON text must be byte-identical between both encoders"
+    );
+}
+
+/// Same field-walk as `reference_encode_and_hash`, but returns the text
+/// instead of hashing it, for the byte-level text-comparison assertion.
+fn reference_encode_json_text(content: &ProcedureRevisionContent) -> String {
+    let mut out = String::new();
+    out.push('{');
+    out.push_str("\"capability_grants\":[");
+    for (i, grant) in content.capability_grants.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        out.push_str("\"effect\":\"");
+        out.push_str(reference_effect_variant_name(grant.effect));
+        out.push('"');
+        if let Some(scope) = &grant.scope {
+            out.push_str(",\"scope\":\"");
+            out.push_str(&reference_escape_json_string(scope));
+            out.push('"');
+        }
+        out.push('}');
+    }
+    out.push(']');
+    out.push_str(",\"procedure_id\":\"");
+    out.push_str(&content.procedure_id.to_canonical_text());
+    out.push('"');
+    out.push_str(",\"residuals\":[");
+    for (i, residual) in content.residuals.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        out.push_str("\"attachment_point\":\"");
+        out.push_str(&reference_escape_json_string(&residual.attachment_point));
+        out.push_str("\",\"blob_hash\":\"");
+        out.push_str(&residual.blob_hash.to_canonical_text());
+        out.push_str("\",\"kind\":\"");
+        out.push_str(&reference_escape_json_string(&residual.kind));
+        out.push('"');
+        out.push('}');
+    }
+    out.push(']');
+    out.push_str(",\"source_text\":\"");
+    out.push_str(&reference_escape_json_string(&content.source_text));
+    out.push('"');
+    out.push('}');
+    out
+}
+
+#[test]
+fn entity_id_and_procedure_id_are_independent_of_each_other_by_type() {
+    // Sanity check that the fixture graph's identity types actually match
+    // the schema doc's field types (EntityId vs ProcedureId are distinct
+    // Rust types, not interchangeable even though both wrap Uuid).
+    let entity_id = EntityId::new();
+    let procedure_id = ProcedureId::new();
+    assert_ne!(
+        entity_id.to_canonical_text(),
+        procedure_id.to_canonical_text()
+    );
+}

--- a/crates/px-repo-model/src/exact_artifact.rs
+++ b/crates/px-repo-model/src/exact_artifact.rs
@@ -1,0 +1,128 @@
+//! Exact-artifact procedure data and invariants.
+//!
+//! This is the universal lossless fallback described by
+//! `exact-artifact-procedure.md`: raw file bytes remain in a [`BlobHash`],
+//! while this record captures the metadata needed to materialize them without
+//! transformation. Import/export I/O belongs to the M1 exact adapter; this
+//! crate owns the durable, validated graph representation.
+
+use serde::{Deserialize, Serialize};
+
+use crate::identity::{BlobHash, ProcedureId};
+
+/// The canonical line-ending labels fixed by `exact-artifact-procedure.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LineEndings {
+    Lf,
+    Crlf,
+    Mixed,
+    #[serde(rename = "n/a")]
+    NotApplicable,
+}
+
+/// Metadata for a `ProcedureKind::ExactArtifact` procedure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExactArtifactProcedure {
+    pub procedure_id: ProcedureId,
+    pub blob: BlobHash,
+    /// Four-digit POSIX permission representation, such as `0644` or `0755`.
+    pub mode: String,
+    /// Declared encoding, with `binary` for non-text bytes.
+    pub encoding: String,
+    pub is_symlink: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symlink_target: Option<String>,
+    /// POSIX-style original path. The M0 spec deliberately leaves exact
+    /// non-UTF-8 filename encoding open, so this String is valid only for
+    /// paths expressible in canonical UTF-8 `.px` text.
+    pub original_path: String,
+    pub line_endings: LineEndings,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ExactArtifactError {
+    #[error("mode {0:?} must be exactly four ASCII octal digits")]
+    InvalidMode(String),
+    #[error("original path must be non-empty, relative, and POSIX-style")]
+    InvalidOriginalPath,
+    #[error("a symlink requires a non-empty symlink target")]
+    MissingSymlinkTarget,
+    #[error("a non-symlink must not carry a symlink target")]
+    UnexpectedSymlinkTarget,
+    #[error("binary content must use line_endings = n/a")]
+    BinaryLineEndingsMustBeNotApplicable,
+    #[error("text content must use line_endings other than n/a")]
+    TextLineEndingsMustBeDeclared,
+}
+
+impl ExactArtifactProcedure {
+    /// Validate the field-level contract that M0 can establish without
+    /// filesystem I/O. This does not inspect the blob: actual byte recovery
+    /// is the M1 exact-adapter responsibility.
+    pub fn validate(&self) -> Result<(), ExactArtifactError> {
+        if self.mode.len() != 4 || !self.mode.bytes().all(|byte| (b'0'..=b'7').contains(&byte)) {
+            return Err(ExactArtifactError::InvalidMode(self.mode.clone()));
+        }
+        if self.original_path.is_empty()
+            || self.original_path.starts_with('/')
+            || self.original_path.contains('\\')
+        {
+            return Err(ExactArtifactError::InvalidOriginalPath);
+        }
+        match (self.is_symlink, self.symlink_target.as_deref()) {
+            (true, Some(target)) if !target.is_empty() => {}
+            (true, _) => return Err(ExactArtifactError::MissingSymlinkTarget),
+            (false, Some(_)) => return Err(ExactArtifactError::UnexpectedSymlinkTarget),
+            (false, None) => {}
+        }
+        if self.encoding == "binary" && self.line_endings != LineEndings::NotApplicable {
+            return Err(ExactArtifactError::BinaryLineEndingsMustBeNotApplicable);
+        }
+        if self.encoding != "binary" && self.line_endings == LineEndings::NotApplicable {
+            return Err(ExactArtifactError::TextLineEndingsMustBeDeclared);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> ExactArtifactProcedure {
+        ExactArtifactProcedure {
+            procedure_id: ProcedureId::new(),
+            blob: BlobHash::of_raw_bytes(b"hello\n"),
+            mode: "0644".to_owned(),
+            encoding: "utf-8".to_owned(),
+            is_symlink: false,
+            symlink_target: None,
+            original_path: "src/main.rs".to_owned(),
+            line_endings: LineEndings::Lf,
+        }
+    }
+
+    #[test]
+    fn accepts_a_real_text_artifact_record() {
+        assert_eq!(valid().validate(), Ok(()));
+    }
+
+    #[test]
+    fn rejects_invalid_metadata_combinations() {
+        let mut artifact = valid();
+        artifact.mode = "644".to_owned();
+        assert!(matches!(artifact.validate(), Err(ExactArtifactError::InvalidMode(_))));
+
+        let mut artifact = valid();
+        artifact.is_symlink = true;
+        assert_eq!(artifact.validate(), Err(ExactArtifactError::MissingSymlinkTarget));
+
+        let mut artifact = valid();
+        artifact.encoding = "binary".to_owned();
+        assert_eq!(
+            artifact.validate(),
+            Err(ExactArtifactError::BinaryLineEndingsMustBeNotApplicable)
+        );
+    }
+}

--- a/crates/px-repo-model/src/identity.rs
+++ b/crates/px-repo-model/src/identity.rs
@@ -1,0 +1,270 @@
+//! Content-derived and assigned identity types for the procedure-graph
+//! repository substrate (ADR-0040 §1).
+//!
+//! Two identifier kinds:
+//! - **Assigned** identity (`EntityId`, `ProcedureId`, `LogicalChangeId`,
+//!   `ProjectionId`): a UUIDv7, minted once, never recomputed from content.
+//! - **Content-derived** identity (`RevisionId`, `ProcedureRevisionHash`,
+//!   `BlobHash`, `RenderingProfileHash`): a BLAKE3-256 digest of a canonical
+//!   byte sequence, rendered in canonical text form as `blake3:<64 hex>`.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Canonical text-form prefix for every content-derived hash (ADR-0040 §1).
+/// Exists so a hash of one kind (e.g. `BlobHash`) can never be silently
+/// compared against a differently-typed hash even though both are 32 bytes.
+const HASH_PREFIX: &str = "blake3:";
+
+/// A BLAKE3-256 content-derived identifier, always serialized/deserialized
+/// in canonical text form (`blake3:<64 lowercase hex chars>`, ADR-0040 §1).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ContentHash([u8; 32]);
+
+impl ContentHash {
+    /// Wrap a raw 32-byte BLAKE3 digest.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        ContentHash(bytes)
+    }
+
+    /// Hash raw bytes directly (ADR-0040 §3 — used for `BlobHash` only;
+    /// every other content-derived hash goes through canonical JSON first,
+    /// see `crate::canonical::hash_canonical_json`).
+    pub fn of_raw_bytes(bytes: &[u8]) -> Self {
+        ContentHash(*blake3::hash(bytes).as_bytes())
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Canonical text form used INSIDE `.px`/JSON field values (ADR-0040 §1):
+    /// `blake3:<64 lowercase hex chars>`.
+    pub fn to_canonical_text(&self) -> String {
+        format!("{HASH_PREFIX}{}", hex_lower(&self.0))
+    }
+
+    /// Bare filename form used for `blobs/`/`residuals/` paths in the bundle
+    /// format (bundle-format doc §4): 64 lowercase hex chars, no prefix.
+    pub fn to_bare_hex(&self) -> String {
+        hex_lower(&self.0)
+    }
+
+    pub fn parse_canonical_text(text: &str) -> Result<Self, IdentityError> {
+        let hex_part = text
+            .strip_prefix(HASH_PREFIX)
+            .ok_or_else(|| IdentityError::MissingHashPrefix(text.to_string()))?;
+        Self::parse_bare_hex(hex_part)
+    }
+
+    pub fn parse_bare_hex(hex_part: &str) -> Result<Self, IdentityError> {
+        if hex_part.len() != 64 {
+            return Err(IdentityError::InvalidHashLength(hex_part.len()));
+        }
+        let mut out = [0u8; 32];
+        for i in 0..32 {
+            let byte_str = &hex_part[i * 2..i * 2 + 2];
+            out[i] = u8::from_str_radix(byte_str, 16)
+                .map_err(|_| IdentityError::InvalidHashHex(hex_part.to_string()))?;
+        }
+        Ok(ContentHash(out))
+    }
+}
+
+fn hex_lower(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+impl fmt::Debug for ContentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ContentHash({})", self.to_canonical_text())
+    }
+}
+
+impl fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_canonical_text())
+    }
+}
+
+impl Serialize for ContentHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_canonical_text())
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        ContentHash::parse_canonical_text(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    #[error("hash text {0:?} is missing the required 'blake3:' prefix")]
+    MissingHashPrefix(String),
+    #[error("hash hex part has invalid length {0} (expected 64)")]
+    InvalidHashLength(usize),
+    #[error("hash hex part {0:?} is not valid lowercase hex")]
+    InvalidHashHex(String),
+}
+
+/// Declares a content-derived identifier newtype wrapping [`ContentHash`],
+/// with its own `Debug`/`Display`/serde impls so distinct hash *kinds*
+/// remain distinct Rust types (ADR-0040 §1's "never silently conflated"
+/// requirement, enforced at the type level, not just the text-prefix level).
+macro_rules! content_hash_newtype {
+    ($name:ident) => {
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub ContentHash);
+
+        impl $name {
+            pub fn of_raw_bytes(bytes: &[u8]) -> Self {
+                $name(ContentHash::of_raw_bytes(bytes))
+            }
+
+            pub fn from_content_hash(hash: ContentHash) -> Self {
+                $name(hash)
+            }
+
+            pub fn to_canonical_text(&self) -> String {
+                self.0.to_canonical_text()
+            }
+
+            pub fn to_bare_hex(&self) -> String {
+                self.0.to_bare_hex()
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}({})", stringify!($name), self.0.to_canonical_text())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0.to_canonical_text())
+            }
+        }
+    };
+}
+
+content_hash_newtype!(RevisionId);
+content_hash_newtype!(ProcedureRevisionHash);
+content_hash_newtype!(BlobHash);
+content_hash_newtype!(RenderingProfileHash);
+
+/// Declares an assigned-identity newtype wrapping a UUIDv7 (ADR-0040 §1):
+/// minted once at creation, carried forward verbatim, never recomputed from
+/// content.
+macro_rules! assigned_id_newtype {
+    ($name:ident) => {
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub Uuid);
+
+        impl $name {
+            /// Mint a new identity (UUIDv7, time-ordered).
+            pub fn new() -> Self {
+                $name(Uuid::now_v7())
+            }
+
+            /// Canonical text form: lowercase hyphenated UUID (RFC 4122 §3).
+            pub fn to_canonical_text(&self) -> String {
+                self.0.hyphenated().to_string()
+            }
+
+            pub fn parse_canonical_text(text: &str) -> Result<Self, IdentityError> {
+                Uuid::parse_str(text)
+                    .map($name)
+                    .map_err(|_| IdentityError::InvalidHashHex(text.to_string()))
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}({})", stringify!($name), self.to_canonical_text())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.to_canonical_text())
+            }
+        }
+    };
+}
+
+assigned_id_newtype!(EntityId);
+assigned_id_newtype!(ProcedureId);
+assigned_id_newtype!(LogicalChangeId);
+assigned_id_newtype!(ProjectionId);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_hash_round_trips_canonical_text() {
+        let h = ContentHash::of_raw_bytes(b"hello world");
+        let text = h.to_canonical_text();
+        assert!(text.starts_with("blake3:"));
+        assert_eq!(text.len(), "blake3:".len() + 64);
+        let parsed = ContentHash::parse_canonical_text(&text).unwrap();
+        assert_eq!(h, parsed);
+    }
+
+    #[test]
+    fn distinct_hash_kinds_do_not_compare_equal_by_type() {
+        // Same underlying bytes, different newtypes -- this is a compile-time
+        // guarantee (BlobHash and RevisionId are not comparable), verified
+        // here only by confirming both wrap the identical ContentHash value.
+        let raw = ContentHash::of_raw_bytes(b"same content");
+        let blob = BlobHash::from_content_hash(raw);
+        let rev = RevisionId::from_content_hash(raw);
+        assert_eq!(blob.to_bare_hex(), rev.to_bare_hex());
+        assert_eq!(blob.to_canonical_text(), rev.to_canonical_text());
+    }
+
+    #[test]
+    fn assigned_id_is_time_ordered_and_stable() {
+        let a = ProcedureId::new();
+        let b = ProcedureId::new();
+        assert_ne!(a, b);
+        let text = a.to_canonical_text();
+        let parsed = ProcedureId::parse_canonical_text(&text).unwrap();
+        assert_eq!(a, parsed);
+    }
+
+    #[test]
+    fn blob_hash_matches_official_blake3_empty_input_vector() {
+        // Official BLAKE3 test vector for zero-length input (first 32 bytes
+        // / 64 hex chars of the published extended-output test vector).
+        let h = ContentHash::of_raw_bytes(b"");
+        assert_eq!(
+            h.to_bare_hex(),
+            "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        );
+    }
+}

--- a/crates/px-repo-model/src/lib.rs
+++ b/crates/px-repo-model/src/lib.rs
@@ -1,0 +1,12 @@
+//! px-repo-model: repository graph schema types and canonical
+//! identity/hashing (ADR-0040, graph-schema.md, px-bundle-format.md — M0
+//! deliverables of epic `pares-radix:procedure-graph-repository-substrate`).
+
+pub mod canonical;
+pub mod exact_artifact;
+pub mod identity;
+pub mod merkle;
+pub mod schema;
+
+#[cfg(test)]
+mod conformance_test;

--- a/crates/px-repo-model/src/merkle.rs
+++ b/crates/px-repo-model/src/merkle.rs
@@ -1,0 +1,121 @@
+//! Merkle composition rules for graph-level roots (`procedure_root`,
+//! `entity_root`, `materialization_root`) per ADR-0040 §4: a flat, sorted
+//! list of `{id, hash}` pairs, hashed as one canonical JSON array.
+
+use serde::Serialize;
+
+use crate::canonical::hash_canonical_json;
+use crate::identity::{BlobHash, ContentHash, EntityId, ProcedureId, ProcedureRevisionHash};
+
+#[derive(Debug, Clone, Serialize)]
+struct ProcedureRootEntry {
+    procedure_id: ProcedureId,
+    revision_hash: ProcedureRevisionHash,
+}
+
+/// Compute `procedure_root` (ADR-0040 §4): BLAKE3 of the canonical-JSON
+/// array of `{procedure_id, revision_hash}` pairs, sorted by
+/// `procedure_id`'s canonical text form, byte-wise ascending.
+pub fn procedure_root(
+    mut entries: Vec<(ProcedureId, ProcedureRevisionHash)>,
+) -> Result<ContentHash, crate::canonical::CanonicalError> {
+    entries.sort_by_key(|(id, _)| id.to_canonical_text());
+    let payload: Vec<ProcedureRootEntry> = entries
+        .into_iter()
+        .map(|(procedure_id, revision_hash)| ProcedureRootEntry {
+            procedure_id,
+            revision_hash,
+        })
+        .collect();
+    hash_canonical_json(&payload)
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EntityRootEntry {
+    entity_id: EntityId,
+    entity_hash: ContentHash,
+}
+
+/// Compute `entity_root` (ADR-0040 §4): BLAKE3 of the canonical-JSON array
+/// of `{entity_id, entity_hash}` pairs, sorted by `entity_id`.
+/// `entity_hash` is the caller-supplied per-entity content hash (already
+/// computed excluding the entity's own `entity_id`, per ADR-0040 §4).
+pub fn entity_root(
+    mut entries: Vec<(EntityId, ContentHash)>,
+) -> Result<ContentHash, crate::canonical::CanonicalError> {
+    entries.sort_by_key(|(id, _)| id.to_canonical_text());
+    let payload: Vec<EntityRootEntry> = entries
+        .into_iter()
+        .map(|(entity_id, entity_hash)| EntityRootEntry {
+            entity_id,
+            entity_hash,
+        })
+        .collect();
+    hash_canonical_json(&payload)
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MaterializationRootEntry {
+    path: String,
+    blob_hash: BlobHash,
+}
+
+/// Compute `materialization_root` (ADR-0040 §4): BLAKE3 of the
+/// canonical-JSON array of `{path, blob_hash}` pairs, sorted by `path`
+/// byte-wise ascending on the UTF-8 POSIX-style path string.
+pub fn materialization_root(
+    mut entries: Vec<(String, BlobHash)>,
+) -> Result<ContentHash, crate::canonical::CanonicalError> {
+    entries.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+    let payload: Vec<MaterializationRootEntry> = entries
+        .into_iter()
+        .map(|(path, blob_hash)| MaterializationRootEntry { path, blob_hash })
+        .collect();
+    hash_canonical_json(&payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn procedure_root_is_order_independent_at_the_input_level() {
+        let a = ProcedureId::new();
+        let b = ProcedureId::new();
+        let hash_a = ProcedureRevisionHash::of_raw_bytes(b"a");
+        let hash_b = ProcedureRevisionHash::of_raw_bytes(b"b");
+
+        let root_1 = procedure_root(vec![(a, hash_a), (b, hash_b)]).unwrap();
+        let root_2 = procedure_root(vec![(b, hash_b), (a, hash_a)]).unwrap();
+        assert_eq!(
+            root_1, root_2,
+            "sorting by procedure_id must make input order irrelevant"
+        );
+    }
+
+    #[test]
+    fn materialization_root_sorts_paths_byte_wise() {
+        let blob = BlobHash::of_raw_bytes(b"x");
+        let root_1 = materialization_root(vec![
+            ("z/file.txt".to_string(), blob),
+            ("a/file.txt".to_string(), blob),
+        ])
+        .unwrap();
+        let root_2 = materialization_root(vec![
+            ("a/file.txt".to_string(), blob),
+            ("z/file.txt".to_string(), blob),
+        ])
+        .unwrap();
+        assert_eq!(root_1, root_2);
+    }
+
+    #[test]
+    fn different_content_produces_different_roots() {
+        let a = ProcedureId::new();
+        let hash_a = ProcedureRevisionHash::of_raw_bytes(b"a");
+        let hash_a2 = ProcedureRevisionHash::of_raw_bytes(b"a-changed");
+        let root_1 = procedure_root(vec![(a, hash_a)]).unwrap();
+        let root_2 = procedure_root(vec![(a, hash_a2)]).unwrap();
+        assert_ne!(root_1, root_2);
+    }
+}

--- a/crates/px-repo-model/src/schema.rs
+++ b/crates/px-repo-model/src/schema.rs
@@ -1,0 +1,321 @@
+//! Repository graph schema entity types (graph-schema.md §2). This module
+//! defines the field sets and canonical-JSON shape (via `serde`) for every
+//! M0 graph entity. The types deliberately model only the schema's stated
+//! data; querying, persistence, import, and materialization belong to later
+//! milestones and are not advertised by this crate.
+
+use serde::{Deserialize, Serialize};
+
+use crate::identity::{
+    BlobHash, ContentHash, EntityId, LogicalChangeId, ProcedureId,
+    ProcedureRevisionHash, ProjectionId, RenderingProfileHash, RevisionId,
+};
+
+/// RFC-0003 §2.1 closed `Effect` enum, adopted verbatim per ADR-0040 §5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Effect {
+    DbRead,
+    DbWrite,
+    Network,
+    Shell,
+    FileRead,
+    FileWrite,
+    EnvRead,
+    Clock,
+    Random,
+}
+
+/// `CapabilityGrant` value type (graph-schema.md §2.17, ADR-0040 §5).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CapabilityGrant {
+    pub effect: Effect,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// `ResidualRef` nested value type (graph-schema.md §2.7).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ResidualRef {
+    pub blob_hash: BlobHash,
+    pub kind: String,
+    pub attachment_point: String,
+}
+
+/// `ProcedureKind` closed enum (graph-schema.md §2.6, mirrors design-spec
+/// §5's taxonomy 5.1-5.7 exactly).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcedureKind {
+    State,
+    ExactArtifact,
+    Change,
+    Projection,
+    Reconciliation,
+    Validation,
+    Compatibility,
+}
+
+/// `Procedure` entity (graph-schema.md §2.6). `id`/`current_revision` are
+/// not part of the entity's own hashed content when the procedure appears
+/// nested inside a `procedure_root` pair (ADR-0040 §4 hashes `{procedure_id,
+/// revision_hash}` pairs directly, not this whole struct) - this struct is
+/// the full logical record as stored/queried, useful for the conformance
+/// test's fixture graph builder even though ADR-0040 §4's Merkle rule only
+/// consumes a projection of it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Procedure {
+    pub id: ProcedureId,
+    pub kind: ProcedureKind,
+    pub name: String,
+    pub path: String,
+    pub current_revision: ProcedureRevisionHash,
+}
+
+/// `ProcedureRevision` entity (graph-schema.md §2.7). Content-derived
+/// identity: `ProcedureRevisionHash = hash_canonical_json(ProcedureRevisionContent)`
+/// where `ProcedureRevisionContent` is this struct's fields minus its own
+/// self-referential `hash` field (ADR-0040 §4's self-exclusion rule, applied
+/// here to a per-entity hash rather than a Merkle root).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProcedureRevisionContent {
+    pub procedure_id: ProcedureId,
+    pub source_text: String,
+    /// Sorted by `effect` variant name then `scope`, per graph-schema.md
+    /// §2.7 - caller is responsible for sorting before hashing; this type
+    /// does not silently re-sort a caller-provided order (array order is
+    /// semantically significant per ADR-0040 §2, so a hashing helper must
+    /// never mutate it - see `canonical::hash_canonical_json`, which hashes
+    /// exactly what's given).
+    pub capability_grants: Vec<CapabilityGrant>,
+    pub residuals: Vec<ResidualRef>,
+}
+
+/// `SemanticEntity` entity (graph-schema.md §2.8). Per ADR-0040 §4's
+/// `entity_root` rule, `entity_hash` excludes the entity's own `id` field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticEntityContent {
+    pub entity_kind: String,
+    pub name: String,
+    pub owning_procedure: ProcedureId,
+}
+
+/// `Blob` entity (graph-schema.md §2.10). Hashed directly over
+/// `content` (ADR-0040 §3), never wrapped in canonical JSON - this struct
+/// only carries the raw bytes; `BlobHash::of_raw_bytes(&content)` is how a
+/// caller computes its identity, not this module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Blob {
+    pub content: Vec<u8>,
+}
+
+impl Blob {
+    pub fn hash(&self) -> BlobHash {
+        BlobHash::of_raw_bytes(&self.content)
+    }
+
+    pub fn size_bytes(&self) -> u64 {
+        self.content.len() as u64
+    }
+}
+
+/// `Revision` entity content (graph-schema.md §2.2). Per this document's
+/// resolution of the design-spec §4.4 tension: `author`/`timestamp`/`message`
+/// ARE included in the hash (asserted facts about the revision), while
+/// validation/attestation records are explicitly excluded (linked objects,
+/// not RevisionId inputs). This struct's own `id: RevisionId` field is
+/// deliberately NOT present here - `RevisionContent` is exactly the set of
+/// fields that get hashed to produce `RevisionId`; the full `Revision`
+/// record (with its own id attached) is a separate concern for storage,
+/// out of scope for the M0 serialization conformance test.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RevisionContent {
+    /// Order-significant (ADR-0040 §2 array rule) - not sorted.
+    pub parents: Vec<RevisionId>,
+    pub procedure_root: crate::identity::ContentHash,
+    pub entity_root: crate::identity::ContentHash,
+    /// Order-significant: the order changes were applied within this
+    /// revision, not sorted (graph-schema.md §2.2).
+    pub change_ids: Vec<LogicalChangeId>,
+    pub rendering_profile: RenderingProfileHash,
+    pub materialization_root: crate::identity::ContentHash,
+    pub author: String,
+    pub timestamp: String,
+    pub message: String,
+}
+
+/// `Repository` entity (graph-schema.md §2.1). `created_at` is ambient
+/// metadata and callers must not include this full record in a content hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Repository {
+    pub name: String,
+    pub default_ref: String,
+    pub created_at: String,
+}
+
+/// `LogicalChange` entity (graph-schema.md §2.3). `procedure_ids` is
+/// unordered in the schema; use [`LogicalChange::canonicalize`] before
+/// serialization when a stable representation is needed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogicalChange {
+    pub id: LogicalChangeId,
+    pub kind: String,
+    pub summary: String,
+    pub procedure_ids: Vec<ProcedureId>,
+}
+
+impl LogicalChange {
+    pub fn canonicalize(&mut self) {
+        self.procedure_ids
+            .sort_by_key(|procedure_id| procedure_id.to_canonical_text());
+    }
+}
+
+/// Local, reconstructable `Workspace` context (graph-schema.md §2.4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Workspace {
+    pub root_path: String,
+    pub checked_out_revision: RevisionId,
+    pub rendering_profile: RenderingProfileHash,
+}
+
+/// Mutable named pointer to a revision (graph-schema.md §2.5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Ref {
+    pub name: String,
+    pub target: RevisionId,
+}
+
+/// Projection-facing output whose content identity is its referenced blob
+/// (graph-schema.md §2.9).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Artifact {
+    pub owning_procedure: ProcedureId,
+    pub blob: BlobHash,
+    pub mode: String,
+    pub encoding: String,
+    pub is_symlink: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symlink_target: Option<String>,
+}
+
+/// Named materialization configuration (graph-schema.md §2.11).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Projection {
+    pub id: ProjectionId,
+    pub name: String,
+    pub adapter: String,
+    pub root_path: String,
+}
+
+/// Adapter implementation pin (graph-schema.md §2.12).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Adapter {
+    pub name: String,
+    pub version: String,
+    pub implementation_hash: BlobHash,
+}
+
+/// Hash input for a `RenderingProfile` (graph-schema.md §2.13). Parameters
+/// are kept as a JSON object because the adapter-specific schema is
+/// intentionally open in M0; canonical encoding still rejects floats and
+/// sorts keys according to ADR-0040 when this value is hashed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RenderingProfileContent {
+    pub adapter_name: String,
+    pub adapter_version: String,
+    pub adapter_implementation_hash: BlobHash,
+    pub formatter_version: String,
+    pub platform_profile: String,
+    pub parameters: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A validation observation is deliberately not content-addressed
+/// (graph-schema.md §2.14); its timestamp/evidence must not change a
+/// `RevisionId`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Validation {
+    pub revision: RevisionId,
+    pub kind: String,
+    pub result: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_blob: Option<BlobHash>,
+    pub run_at: String,
+}
+
+/// Detached statement about a revision (graph-schema.md §2.15).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attestation {
+    pub revision: RevisionId,
+    pub principal: String,
+    pub statement: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Vec<u8>>,
+    pub attested_at: String,
+}
+
+/// A merge/reconciliation conflict (graph-schema.md §2.16).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Conflict {
+    pub base: RevisionId,
+    pub left: RevisionId,
+    pub right: RevisionId,
+    pub subject_entities: Vec<EntityId>,
+    pub reason: String,
+    pub alternatives: Vec<String>,
+}
+
+/// Workspace-local draft that preserves a parse-recovery state
+/// (graph-schema.md §2.18).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DraftOverlay {
+    pub artifact_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prior_owner: Option<ProcedureId>,
+    pub content_blob: BlobHash,
+    pub parser_state: String,
+    pub diagnostics: Vec<String>,
+}
+
+/// External proposal metadata (graph-schema.md §2.19). `fidelity_report` is
+/// an open JSON object because the referenced FidelityVector schema is
+/// explicitly deferred by graph-schema.md §5; pretending it has a closed
+/// Rust layout here would invent protocol semantics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExternalImport {
+    pub source_ref: String,
+    pub proposed_changes: Vec<LogicalChangeId>,
+    pub fidelity_report: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Compute a content-derived `ProcedureRevisionHash` from the exact fields
+/// that define it (graph-schema.md §2.7), excluding the self hash by using
+/// `ProcedureRevisionContent` rather than a record that carries its hash.
+pub fn procedure_revision_hash(
+    content: &ProcedureRevisionContent,
+) -> Result<ProcedureRevisionHash, crate::canonical::CanonicalError> {
+    crate::canonical::hash_canonical_json(content).map(ProcedureRevisionHash::from_content_hash)
+}
+
+/// Compute an entity's content hash excluding its assigned `EntityId`, as
+/// mandated by ADR-0040 §4's self-exclusion rule.
+pub fn semantic_entity_hash(
+    content: &SemanticEntityContent,
+) -> Result<ContentHash, crate::canonical::CanonicalError> {
+    crate::canonical::hash_canonical_json(content)
+}
+
+/// Compute the `RevisionId` from `RevisionContent`, which intentionally has
+/// no self `id` field (graph-schema.md §2.2).
+pub fn revision_id(
+    content: &RevisionContent,
+) -> Result<RevisionId, crate::canonical::CanonicalError> {
+    crate::canonical::hash_canonical_json(content).map(RevisionId::from_content_hash)
+}
+
+/// Compute a `RenderingProfileHash` from the profile's deterministic inputs.
+pub fn rendering_profile_hash(
+    content: &RenderingProfileContent,
+) -> Result<RenderingProfileHash, crate::canonical::CanonicalError> {
+    crate::canonical::hash_canonical_json(content).map(RenderingProfileHash::from_content_hash)
+}


### PR DESCRIPTION
## Summary
- adds the px-repo-model workspace crate for ADR-0040 content/assigned identity types, canonical JSON hashing, and deterministic flat Merkle roots
- models the complete M0 graph-schema entity surface plus validated ExactArtifactProcedure metadata
- adds the M0 conformance test: two independently-written Rust encoders serialize the same non-trivial ProcedureRevision graph to byte-identical canonical JSON and BLAKE3 hash

## M0 conformance interpretation
ADR-0040 and xact-artifact-procedure.md explicitly permit two independent Rust encoders in one crate as the strongest same-language proxy until a second language surface exists. The production encoder uses a generic serde_json Value canonicalizer; the reference encoder walks the fixture fields directly and hand-writes strict JSON. The test asserts both equal hashes and literal byte-identical JSON.

## ExactArtifactProcedure note
The implementation validates the documented metadata contract (POSIX mode, symlink consistency, binary/text line-ending rules, POSIX paths). It intentionally does not invent a non-UTF-8 filename representation or an exact .px source-text grammar: both are expressly open in the M0 specification; filesystem import/materialization is M1 adapter scope.

## Validation
- cargo test -p px-repo-model (18 passed)
- cargo build --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --release -p px-repo-model

cargo test --workspace was started and progressed through workspace suites but the runner killed the long-running process before a final status; the crate-level tests passed.