### PR TITLE
feat(px-adapter-exact): M1 exact filesystem importer and materializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,6 +5589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
+name = "px-adapter-exact"
+version = "0.1.0"
+dependencies = [
+ "px-repo-model",
+ "tempfile",
+ "thiserror 2.0.19",
+ "walkdir",
+]
+
+[[package]]
 name = "px-ast"
 version = "0.0.0"
 source = "git+https://github.com/plures/praxis-lang.git?rev=37be99e95f2db8e530ea7dd24ec2d0b01113ceeb#37be99e95f2db8e530ea7dd24ec2d0b01113ceeb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/px-repo-model",
+    "crates/px-adapter-exact",
     "crates/radix-core",
     "crates/mcp-client",
     "crates/privacy",

--- a/crates/px-adapter-exact/Cargo.toml
+++ b/crates/px-adapter-exact/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "px-adapter-exact"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "M1 exact-artifact adapter: recursive filesystem importer and deterministic materializer over px-repo-model (ADR-0040, exact-artifact-procedure.md)."
+
+[dependencies]
+px-repo-model = { path = "../px-repo-model" }
+walkdir = { workspace = true }
+thiserror = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/px-adapter-exact/src/importer.rs
+++ b/crates/px-adapter-exact/src/importer.rs
@@ -1,0 +1,202 @@
+//! Recursive filesystem importer (M1 exit criterion, exact-artifact-procedure.md
+//! §5 "exact import law": `read(S)` half of `write(read(S)) = S`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use px_repo_model::exact_artifact::{ExactArtifactProcedure, LineEndings};
+use px_repo_model::identity::ProcedureId;
+use px_repo_model::schema::Blob;
+use walkdir::WalkDir;
+
+use crate::tree::{ImportedDirectory, ImportedFile, ImportedTree};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ImportError {
+    #[error("import root {0:?} does not exist or is not a directory")]
+    RootNotADirectory(PathBuf),
+    #[error("path {0:?} is not representable as a UTF-8 POSIX-style relative path (non-UTF-8 filenames are out of M1 scope, per exact-artifact-procedure.md §3)")]
+    NonUtf8Path(PathBuf),
+    #[error("io error at {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("walkdir error: {0}")]
+    WalkDir(#[from] walkdir::Error),
+}
+
+/// Recursively import a real filesystem directory into an [`ImportedTree`].
+///
+/// Scope (M1, see crate docs): regular files, directories, and symlinks with
+/// UTF-8-representable relative paths. The importer never dereferences
+/// symlinks (a symlink is captured by its raw target string, never followed
+/// into the pointed-at content) and never mutates the source tree.
+pub fn import_tree(root: &Path) -> Result<ImportedTree, ImportError> {
+    let root_metadata = fs::symlink_metadata(root)
+        .map_err(|source| ImportError::Io { path: root.to_path_buf(), source })?;
+    if !root_metadata.is_dir() {
+        return Err(ImportError::RootNotADirectory(root.to_path_buf()));
+    }
+
+    let mut tree = ImportedTree::default();
+
+    for entry in WalkDir::new(root).follow_links(false).min_depth(1) {
+        let entry = entry?;
+        let absolute_path = entry.path();
+        let relative_path = absolute_path
+            .strip_prefix(root)
+            .expect("walkdir yields paths rooted at the walked root");
+        let posix_path = to_posix_relative_path(relative_path)
+            .ok_or_else(|| ImportError::NonUtf8Path(relative_path.to_path_buf()))?;
+
+        let file_type = entry.file_type();
+        if file_type.is_dir() {
+            tree.directories.push(ImportedDirectory { path: posix_path });
+            continue;
+        }
+
+        if file_type.is_symlink() {
+            let target = fs::read_link(absolute_path)
+                .map_err(|source| ImportError::Io { path: absolute_path.to_path_buf(), source })?;
+            let target_text = target
+                .to_str()
+                .ok_or_else(|| ImportError::NonUtf8Path(target.clone()))?
+                .to_owned();
+            let mode = platform_mode(absolute_path, true)?;
+            let artifact = ExactArtifactProcedure {
+                procedure_id: ProcedureId::new(),
+                blob: px_repo_model::identity::BlobHash::of_raw_bytes(b""),
+                mode,
+                encoding: "binary".to_owned(),
+                is_symlink: true,
+                symlink_target: Some(target_text),
+                original_path: posix_path,
+                line_endings: LineEndings::NotApplicable,
+            };
+            tree.files.push(ImportedFile { artifact, blob: Blob { content: Vec::new() } });
+            continue;
+        }
+
+        if file_type.is_file() {
+            let content = fs::read(absolute_path)
+                .map_err(|source| ImportError::Io { path: absolute_path.to_path_buf(), source })?;
+            let blob = Blob { content };
+            let blob_hash = blob.hash();
+            let encoding = detect_encoding(&blob.content);
+            let line_endings = detect_line_endings(&blob.content, &encoding);
+            let mode = platform_mode(absolute_path, is_executable(absolute_path)?)?;
+            let artifact = ExactArtifactProcedure {
+                procedure_id: ProcedureId::new(),
+                blob: blob_hash,
+                mode,
+                encoding,
+                is_symlink: false,
+                symlink_target: None,
+                original_path: posix_path,
+                line_endings,
+            };
+            tree.files.push(ImportedFile { artifact, blob });
+        }
+    }
+
+    tree.canonicalize();
+    Ok(tree)
+}
+
+/// Convert a native relative path into a POSIX-style (`/`-separated) UTF-8
+/// string, per px-bundle-format.md §2's "all paths are POSIX-style
+/// regardless of host OS" rule. Returns `None` if any component is not
+/// valid UTF-8 (out of M1 scope, exact-artifact-procedure.md §3).
+fn to_posix_relative_path(path: &Path) -> Option<String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => parts.push(part.to_str()?.to_owned()),
+            _ => return None,
+        }
+    }
+    Some(parts.join("/"))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> Result<bool, ImportError> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|source| ImportError::Io { path: path.to_path_buf(), source })?;
+    Ok(metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> Result<bool, ImportError> {
+    // exact-artifact-procedure.md §3: "On platforms without POSIX permission
+    // bits (Windows), the importer MUST synthesize a canonical value...
+    // executable-by-convention, e.g. .exe/.bat/shebang-detected files."
+    let _ = path;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    Ok(matches!(ext.as_deref(), Some("exe") | Some("bat") | Some("cmd") | Some("sh") | Some("ps1")))
+}
+
+#[cfg(unix)]
+fn platform_mode(path: &Path, _is_executable_hint: bool) -> Result<String, ImportError> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|source| ImportError::Io { path: path.to_path_buf(), source })?;
+    let mode_bits = metadata.permissions().mode() & 0o777;
+    Ok(format!("{:04o}", mode_bits))
+}
+
+#[cfg(not(unix))]
+fn platform_mode(_path: &Path, is_executable_hint: bool) -> Result<String, ImportError> {
+    // exact-artifact-procedure.md §3: synthesize 0644/0755 canonically.
+    Ok(if is_executable_hint { "0755".to_owned() } else { "0644".to_owned() })
+}
+
+/// Detect whether content is valid UTF-8 text or must be treated as binary.
+/// exact-artifact-procedure.md §3: "if bytes are not valid UTF-8, `encoding`
+/// MUST be `binary`."
+fn detect_encoding(content: &[u8]) -> String {
+    if std::str::from_utf8(content).is_ok() {
+        "utf-8".to_owned()
+    } else {
+        "binary".to_owned()
+    }
+}
+
+/// Detect line-ending style for text content. Binary content is always
+/// `n/a` (exact-artifact-procedure.md §3, matching `ExactArtifactProcedure`'s
+/// own `validate()` invariant that binary encoding pairs with `NotApplicable`).
+fn detect_line_endings(content: &[u8], encoding: &str) -> LineEndings {
+    if encoding == "binary" {
+        return LineEndings::NotApplicable;
+    }
+    let mut has_crlf = false;
+    let mut has_lone_lf = false;
+    let mut i = 0;
+    while i < content.len() {
+        if content[i] == b'\n' {
+            if i > 0 && content[i - 1] == b'\r' {
+                has_crlf = true;
+            } else {
+                has_lone_lf = true;
+            }
+        }
+        i += 1;
+    }
+    match (has_crlf, has_lone_lf) {
+        (true, true) => LineEndings::Mixed,
+        (true, false) => LineEndings::Crlf,
+        (false, true) => LineEndings::Lf,
+        // No newlines at all (e.g. a single-line file with no trailing
+        // newline, or an empty file): there is no line-ending evidence in
+        // the content, but this is still text content, so
+        // `ExactArtifactProcedure::validate()` requires a non-`NotApplicable`
+        // value. Default to `Lf` (POSIX convention) rather than inventing a
+        // fifth variant not present in the schema.
+        (false, false) => LineEndings::Lf,
+    }
+}

--- a/crates/px-adapter-exact/src/lib.rs
+++ b/crates/px-adapter-exact/src/lib.rs
@@ -1,0 +1,30 @@
+//! `px-adapter-exact`: the M1 exact-artifact adapter (design-spec §6 "exact
+//! adapter", exact-artifact-procedure.md §5). Implements the recursive
+//! folder importer and deterministic materializer specified there:
+//!
+//! - [`import_tree`] walks a real filesystem directory and produces one
+//!   [`px_repo_model::exact_artifact::ExactArtifactProcedure`] per regular
+//!   file/symlink, plus the raw content [`Blob`](px_repo_model::schema::Blob)
+//!   for each non-symlink file, matching graph-schema.md §2.6/§2.9/§2.10.
+//! - [`materialize_tree`] writes an [`ImportedTree`] back to a filesystem
+//!   root, satisfying the exact-import law from exact-artifact-procedure.md
+//!   §5: `write(read(S)) = S`.
+//!
+//! Scope (M1, per the epic task and M0's own explicit boundary notes):
+//! regular files, directories (including empty ones) and symlinks with
+//! **UTF-8-representable relative paths**. Non-UTF-8 filenames and the exact
+//! `.px` source-text grammar are both explicitly out of scope per
+//! exact-artifact-procedure.md §3's `original_path` field note ("this
+//! document does NOT resolve how a UTF-8-only `.px` text format represents a
+//! non-UTF-8 filename byte-for-byte... flagged here as an open item for the
+//! follow-on implementation") — this crate is that follow-on implementation
+//! and inherits the same explicitly-named scope boundary rather than
+//! guessing an unverified encoding scheme.
+
+pub mod importer;
+pub mod materializer;
+pub mod tree;
+
+pub use importer::{import_tree, ImportError};
+pub use materializer::{materialize_tree, MaterializeError};
+pub use tree::{ImportedDirectory, ImportedFile, ImportedTree};

--- a/crates/px-adapter-exact/src/materializer.rs
+++ b/crates/px-adapter-exact/src/materializer.rs
@@ -1,0 +1,150 @@
+//! Deterministic materializer (M1 exit criterion, exact-artifact-procedure.md
+//! §5 "exact import law": `write` half of `write(read(S)) = S`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::tree::ImportedTree;
+
+#[derive(Debug, thiserror::Error)]
+pub enum MaterializeError {
+    #[error("materialization root {0:?} must be an existing empty directory or not yet exist")]
+    RootNotUsable(PathBuf),
+    #[error("path {path:?} would escape the declared materialization root (design-spec §13.2 / conformance test 4: \"materialization cannot write outside its declared root\")")]
+    PathEscapesRoot { path: String },
+    #[error("io error at {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[cfg(unix)]
+    #[error("failed to create symlink at {path:?} -> {target:?}: {source}")]
+    Symlink {
+        path: PathBuf,
+        target: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("symlink materialization is not supported on this platform for path {0:?}")]
+    SymlinkUnsupportedPlatform(PathBuf),
+}
+
+/// Materialize an [`ImportedTree`] to `root` on disk.
+///
+/// `root` MUST NOT already contain content that would be silently
+/// overwritten in a way that hides pre-existing files not part of this
+/// tree — this function creates `root` if absent, and requires it be an
+/// empty directory if it already exists, matching conformance test 4's
+/// "materialization cannot write outside its declared root" as the
+/// strictest interpretation available without a full capability/workspace
+/// system (M2 scope): the declared root is exactly this parameter, and nothing
+/// this function writes may resolve (via `..` or symlink components in
+/// `path`) outside of it.
+pub fn materialize_tree(tree: &ImportedTree, root: &Path) -> Result<(), MaterializeError> {
+    if root.exists() {
+        let mut entries = fs::read_dir(root)
+            .map_err(|source| MaterializeError::Io { path: root.to_path_buf(), source })?;
+        if entries.next().is_some() {
+            return Err(MaterializeError::RootNotUsable(root.to_path_buf()));
+        }
+    } else {
+        fs::create_dir_all(root)
+            .map_err(|source| MaterializeError::Io { path: root.to_path_buf(), source })?;
+    }
+
+    for directory in &tree.directories {
+        let target = resolve_within_root(root, &directory.path)?;
+        fs::create_dir_all(&target)
+            .map_err(|source| MaterializeError::Io { path: target, source })?;
+    }
+
+    for file in &tree.files {
+        let posix_path = &file.artifact.original_path;
+        let target = resolve_within_root(root, posix_path)?;
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|source| MaterializeError::Io { path: parent.to_path_buf(), source })?;
+        }
+
+        if file.artifact.is_symlink {
+            let link_target = file
+                .artifact
+                .symlink_target
+                .as_ref()
+                .expect("ExactArtifactProcedure::validate() requires a symlink_target when is_symlink is true");
+            create_symlink(link_target, &target)?;
+        } else {
+            fs::write(&target, &file.blob.content)
+                .map_err(|source| MaterializeError::Io { path: target.clone(), source })?;
+            apply_mode(&target, &file.artifact.mode)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve a POSIX-style relative path against `root`, rejecting anything
+/// that would escape it (`..` components, absolute paths). This is the
+/// concrete enforcement of conformance test 4.
+fn resolve_within_root(root: &Path, posix_relative_path: &str) -> Result<PathBuf, MaterializeError> {
+    if posix_relative_path.is_empty() || posix_relative_path.starts_with('/') {
+        return Err(MaterializeError::PathEscapesRoot { path: posix_relative_path.to_owned() });
+    }
+    let mut target = root.to_path_buf();
+    for part in posix_relative_path.split('/') {
+        if part.is_empty() || part == "." || part == ".." {
+            return Err(MaterializeError::PathEscapesRoot { path: posix_relative_path.to_owned() });
+        }
+        target.push(part);
+    }
+    Ok(target)
+}
+
+#[cfg(unix)]
+fn create_symlink(link_target: &str, at: &Path) -> Result<(), MaterializeError> {
+    std::os::unix::fs::symlink(link_target, at).map_err(|source| MaterializeError::Symlink {
+        path: at.to_path_buf(),
+        target: link_target.to_owned(),
+        source,
+    })
+}
+
+#[cfg(windows)]
+fn create_symlink(link_target: &str, at: &Path) -> Result<(), MaterializeError> {
+    // Creating real Windows symlinks requires elevated privileges/Developer
+    // Mode in the general case, so this cannot be implemented as a plain
+    // file-write fallback without silently losing the "this was a symlink"
+    // fact (which would violate the exact-import law). Rather than fabricate
+    // a fake symlink representation (C-NOSTUB-001), materialization of
+    // symlinks reports itself unsupported on this platform; the round-trip
+    // test corpus for this crate is exercised on the platforms that support
+    // real symlink creation, matching the M0 boundary precedent of scoping
+    // explicitly rather than inventing an unverified behavior.
+    let _ = link_target;
+    Err(MaterializeError::SymlinkUnsupportedPlatform(at.to_path_buf()))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_symlink(link_target: &str, at: &Path) -> Result<(), MaterializeError> {
+    let _ = link_target;
+    Err(MaterializeError::SymlinkUnsupportedPlatform(at.to_path_buf()))
+}
+
+#[cfg(unix)]
+fn apply_mode(path: &Path, mode: &str) -> Result<(), MaterializeError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode_bits = u32::from_str_radix(mode, 8).unwrap_or(0o644);
+    let permissions = fs::Permissions::from_mode(mode_bits);
+    fs::set_permissions(path, permissions)
+        .map_err(|source| MaterializeError::Io { path: path.to_path_buf(), source })
+}
+
+#[cfg(not(unix))]
+fn apply_mode(_path: &Path, _mode: &str) -> Result<(), MaterializeError> {
+    // exact-artifact-procedure.md §3 notes mode is synthesized/canonical on
+    // platforms without POSIX permission bits; there is nothing to apply
+    // back on Windows (no POSIX permission bit API), matching the same
+    // asymmetry the importer already documents for `platform_mode`.
+    Ok(())
+}

--- a/crates/px-adapter-exact/src/tree.rs
+++ b/crates/px-adapter-exact/src/tree.rs
@@ -1,0 +1,61 @@
+//! In-memory representation of an imported filesystem tree (M1 scope).
+//!
+//! This is the graph-shaped intermediate produced by [`crate::import_tree`]
+//! and consumed by [`crate::materialize_tree`]. It is deliberately NOT a
+//! PluresDB-persisted graph (that is M2 scope, design-spec §17) — this crate
+//! owns only the exact-adapter's `read`/`write` functions (design-spec §6),
+//! operating on an in-memory value that already has the shape of the M0
+//! schema types (`ExactArtifactProcedure`, `Blob`).
+
+use px_repo_model::exact_artifact::ExactArtifactProcedure;
+use px_repo_model::schema::Blob;
+
+/// One imported directory (graph-schema.md §2.6 does not model directories
+/// as their own entity kind — a directory's existence is recorded here only
+/// so an exact re-materialization can recreate EMPTY directories, which
+/// would otherwise be silently lost since they own no artifact/blob of
+/// their own).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportedDirectory {
+    /// POSIX-style path relative to the import root (`""` for the root
+    /// itself is never recorded; only non-root directories appear here).
+    pub path: String,
+}
+
+/// One imported regular file or symlink.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportedFile {
+    /// The `ExactArtifactProcedure` metadata record for this artifact
+    /// (exact-artifact-procedure.md §3). `artifact.original_path` is the
+    /// same POSIX-style relative path used to key this entry.
+    pub artifact: ExactArtifactProcedure,
+    /// Raw file content. For a symlink, this is empty — a symlink's
+    /// identity-relevant payload is `artifact.symlink_target`, not file
+    /// content (exact-artifact-procedure.md §3: "an exact import preserves
+    /// the symlink itself"; the target it points to is not itself walked
+    /// or dereferenced by this importer).
+    pub blob: Blob,
+}
+
+/// A full imported filesystem tree: every directory and every file/symlink,
+/// keyed by their POSIX-style path relative to the import root.
+///
+/// Entries are stored sorted by path (byte-wise ascending, matching
+/// ADR-0040 §4's `materialization_root` sort rule) so that two imports of
+/// the same directory tree always produce identical in-memory ordering,
+/// independent of the host filesystem's directory-listing order.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ImportedTree {
+    pub directories: Vec<ImportedDirectory>,
+    pub files: Vec<ImportedFile>,
+}
+
+impl ImportedTree {
+    /// Sort `directories` and `files` by their path field, byte-wise
+    /// ascending on the UTF-8 path bytes (ADR-0040 §4 convention).
+    pub fn canonicalize(&mut self) {
+        self.directories.sort_by(|a, b| a.path.as_bytes().cmp(b.path.as_bytes()));
+        self.files
+            .sort_by(|a, b| a.artifact.original_path.as_bytes().cmp(b.artifact.original_path.as_bytes()));
+    }
+}

--- a/crates/px-adapter-exact/tests/round_trip.rs
+++ b/crates/px-adapter-exact/tests/round_trip.rs
@@ -1,0 +1,174 @@
+//! M1 exit-criterion test: import a real, non-trivial directory tree,
+//! materialize it back out, and diff against the original byte-for-byte.
+//!
+//! This directly exercises design-spec §19 conformance test 3 ("Exact
+//! folder import round-trips byte-for-byte") at the folder level (the M0
+//! `exact_artifact.rs` tests only cover the per-artifact metadata contract).
+
+use std::fs;
+use std::path::Path;
+
+use px_adapter_exact::{import_tree, materialize_tree};
+
+/// Build a real, non-trivial fixture directory tree under `root`:
+/// multiple files, nested directories, an empty directory, and a binary
+/// file (not valid UTF-8), matching the task's required fixture shape.
+fn build_fixture(root: &Path) {
+    fs::create_dir_all(root.join("src/nested")).unwrap();
+    fs::create_dir_all(root.join("empty-dir")).unwrap();
+
+    fs::write(root.join("README.md"), b"# Fixture\n\nSome text with LF endings.\n").unwrap();
+    fs::write(root.join("src/main.rs"), b"fn main() {\r\n    println!(\"hi\");\r\n}\r\n").unwrap();
+    fs::write(
+        root.join("src/nested/mixed.txt"),
+        b"line one\nline two\r\nline three\n",
+    )
+    .unwrap();
+
+    // A genuine binary file: not valid UTF-8 and containing NUL bytes /
+    // arbitrary byte values, e.g. a tiny fake "image" payload.
+    let binary_content: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0xFE, 0x80, 0x81, 0x00, 0x00, 0x01];
+    fs::write(root.join("src/nested/asset.bin"), &binary_content).unwrap();
+
+    // A no-trailing-newline single-line file (line-ending edge case).
+    fs::write(root.join("no-newline.txt"), b"no trailing newline here").unwrap();
+}
+
+/// Recursively collect every regular file's relative path + content under
+/// `root`, sorted, for a strict byte-for-byte comparison. Directories are
+/// compared separately via `collect_dirs`.
+fn collect_files(root: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(root).min_depth(1) {
+        let entry = entry.unwrap();
+        if entry.file_type().is_file() {
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace('\\', "/");
+            let content = fs::read(entry.path()).unwrap();
+            out.push((relative, content));
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+fn collect_dirs(root: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(root).min_depth(1) {
+        let entry = entry.unwrap();
+        if entry.file_type().is_dir() {
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace('\\', "/");
+            out.push(relative);
+        }
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn round_trip_import_then_materialize_is_byte_identical() {
+    let source_dir = tempfile::tempdir().unwrap();
+    build_fixture(source_dir.path());
+
+    let tree = import_tree(source_dir.path()).expect("import must succeed on a well-formed fixture");
+
+    // Every imported artifact must pass the M0 field-level validation
+    // contract (mode/encoding/line-ending invariants).
+    for file in &tree.files {
+        file.artifact
+            .validate()
+            .expect("every imported ExactArtifactProcedure must satisfy the M0 validate() contract");
+    }
+
+    let dest_dir = tempfile::tempdir().unwrap();
+    // materialize_tree requires the root to not already exist or be empty;
+    // remove the auto-created tempdir and let materialize_tree recreate it.
+    fs::remove_dir(dest_dir.path()).unwrap();
+    materialize_tree(&tree, dest_dir.path()).expect("materialization must succeed");
+
+    let original_files = collect_files(source_dir.path());
+    let materialized_files = collect_files(dest_dir.path());
+    assert_eq!(
+        original_files, materialized_files,
+        "materialized file paths and byte content must exactly match the original fixture"
+    );
+
+    let original_dirs = collect_dirs(source_dir.path());
+    let materialized_dirs = collect_dirs(dest_dir.path());
+    assert_eq!(
+        original_dirs, materialized_dirs,
+        "materialized directory structure (including the empty directory) must exactly match the original"
+    );
+}
+
+#[test]
+fn re_importing_a_materialized_tree_yields_identical_blob_hashes() {
+    // exact-artifact-procedure.md §5 "stable projection law": read(write(G))
+    // is equivalent to G for the exact adapter. Concretely: re-importing a
+    // materialized tree must yield the same set of (path, blob_hash) pairs.
+    let source_dir = tempfile::tempdir().unwrap();
+    build_fixture(source_dir.path());
+
+    let original_tree = import_tree(source_dir.path()).unwrap();
+
+    let dest_dir = tempfile::tempdir().unwrap();
+    fs::remove_dir(dest_dir.path()).unwrap();
+    materialize_tree(&original_tree, dest_dir.path()).unwrap();
+
+    let reimported_tree = import_tree(dest_dir.path()).unwrap();
+
+    let mut original_hashes: Vec<(String, String)> = original_tree
+        .files
+        .iter()
+        .map(|f| (f.artifact.original_path.clone(), f.artifact.blob.to_canonical_text()))
+        .collect();
+    let mut reimported_hashes: Vec<(String, String)> = reimported_tree
+        .files
+        .iter()
+        .map(|f| (f.artifact.original_path.clone(), f.artifact.blob.to_canonical_text()))
+        .collect();
+    original_hashes.sort();
+    reimported_hashes.sort();
+
+    assert_eq!(original_hashes, reimported_hashes);
+}
+
+#[test]
+fn materialize_rejects_paths_that_would_escape_the_declared_root() {
+    use px_adapter_exact::{materialize_tree, ImportedFile, ImportedTree};
+    use px_repo_model::exact_artifact::{ExactArtifactProcedure, LineEndings};
+    use px_repo_model::identity::{BlobHash, ProcedureId};
+    use px_repo_model::schema::Blob;
+
+    let content = b"escape attempt".to_vec();
+    let artifact = ExactArtifactProcedure {
+        procedure_id: ProcedureId::new(),
+        blob: BlobHash::of_raw_bytes(&content),
+        mode: "0644".to_owned(),
+        encoding: "utf-8".to_owned(),
+        is_symlink: false,
+        symlink_target: None,
+        original_path: "../escaped.txt".to_owned(),
+        line_endings: LineEndings::Lf,
+    };
+    let malicious_tree = ImportedTree {
+        directories: Vec::new(),
+        files: vec![ImportedFile { artifact, blob: Blob { content } }],
+    };
+
+    let dest_dir = tempfile::tempdir().unwrap();
+    fs::remove_dir(dest_dir.path()).unwrap();
+    let result = materialize_tree(&malicious_tree, dest_dir.path());
+    assert!(result.is_err(), "a '..'-containing path must be rejected, not written outside the root");
+}


### PR DESCRIPTION
## Summary
Implements M1 ("exact repository importer") of epic `pares-radix:procedure-graph-repository-substrate`, building on merged M0 (PR#599, `px-repo-model` crate: ADR-0040 identity/hashing, graph schema, `ExactArtifactProcedure`).

New crate `crates/px-adapter-exact`:
- `import_tree(root)` — recursive filesystem walk producing one `ExactArtifactProcedure` (+ raw content `Blob` for non-symlinks) per regular file/symlink, following the exact-artifact-procedure.md field contract: blob hash over raw bytes, POSIX mode (real on Unix, synthesized 0644/0755 on Windows per the doc's explicit instruction), UTF-8/binary encoding detection, LF/CRLF/mixed line-ending detection, symlink target captured without dereferencing, POSIX-style relative paths, no timestamp field.
- `materialize_tree(tree, root)` — deterministic graph-to-filesystem writer. Rejects any path that would escape the declared root (`..`/absolute components), directly implementing design-spec conformance test 4.
- `ImportedTree`/`ImportedFile`/`ImportedDirectory` — in-memory graph-shaped intermediate (directories recorded explicitly so empty dirs survive round-trip; PluresDB persistence is M2 scope, out of scope here).

## M1 exit-criterion test
`tests/round_trip.rs` builds a real, non-trivial fixture (nested dirs, an empty dir, LF/CRLF/mixed-line-ending text files, a genuine binary file with NUL/high bytes, a no-trailing-newline file), imports it, materializes it to a fresh directory, and asserts the materialized file set + directory structure is byte-for-byte identical to the original — this is design-spec §19 conformance test 3 ("exact folder import round-trips byte-for-byte") at the folder level, satisfying the M1 exit criterion literally.

A second test re-imports the materialized tree and confirms identical per-path blob hashes (exact-artifact-procedure.md §5's "stable projection law": `read(write(G)) ≡ G`). A third test proves `materialize_tree` refuses a `..`-containing path rather than writing outside its root.

## Scope notes (explicit, per instructions)
- **UTF-8-representable relative paths only.** Non-UTF-8 filenames and the `.px` source-text grammar remain out of scope, matching exact-artifact-procedure.md §3's own explicitly-flagged open item (not silently resolved with an invented encoding scheme, per C-NOSTUB-001).
- **Windows symlink materialization is not implemented.** Creating real Windows symlinks generally requires elevated privileges/Developer Mode; rather than fabricate a fake symlink representation, `materialize_tree` returns `SymlinkUnsupportedPlatform` on Windows for symlink entries. The importer still faithfully records `is_symlink`/`symlink_target` on symlink-capable platforms (verified logically; the round-trip test's own fixture doesn't include a symlink since CI here runs on Windows — noting this plainly rather than silently skipping the case).
- Directory-empty preservation, mode/encoding/line-ending detection, and the escape-guard are all exercised for real, not stubbed.

## Validation
- `cargo build --workspace` — clean (5m37s, all crates including `src-tauri`)
- `cargo test -p px-adapter-exact` — 3/3 pass
- `cargo clippy -p px-adapter-exact -p px-repo-model --all-targets -- -D warnings` — clean

## Follow-on (M2+)
PluresDB persistence of the imported graph, Merkle-root verification wiring (`px-repo-model::merkle` already exists from M0 but isn't wired to this importer's output yet — natural next actionable step), and Unix-CI coverage of the symlink path are explicitly left for the next milestone/PR rather than guessed at here.
