### PR TITLE
feat(graph): persist procedure graph in PluresDB

### DIFF
--- a/.praxis/decisions/ADR-0041-procedure-graph-pluresdb-storage.md
+++ b/.praxis/decisions/ADR-0041-procedure-graph-pluresdb-storage.md
@@ -1,0 +1,106 @@
+# ADR-0041: Procedure graph PluresDB storage schema
+
+**Status:** Accepted
+**Date:** 2026-07-31
+**Epic:** `pares-radix:procedure-graph-repository-substrate`, M2
+
+## Context
+
+M0 defined the procedure graph's Rust domain model and canonical BLAKE3
+identity rules in ADR-0040 (`px-repo-model`). M1 added exact artifact import
+and materialization. M2 needs durable graph persistence and a query surface.
+C-PLURES-003/004 require persistent state to use PluresDB rather than custom
+files, maps, or a second graph store. C-DEV-001 requires pure query semantics
+to be expressed in `.px`, leaving Rust as the PluresDB IO boundary.
+
+PluresDB's `CrdtStore` provides a flat, CRDT-merged `NodeId -> JSON` keyspace;
+it has no native edge table. The graph therefore needs a typed record layout
+inside that keyspace without copying M0's domain schema.
+
+## Decision
+
+`crates/px-graph-store` persists all M2 graph state in a `pluresdb::CrdtStore`
+backed by `SledStorage` for durable deployments. The test-only constructor uses
+PluresDB's `MemoryStorage`; it is not an alternate application persistence
+implementation.
+
+### Nodes
+
+Node records use a storage key:
+
+```
+px_graph_node:v1:<NodeKey>
+```
+
+`NodeKey` is either:
+
+```
+repository:<stable externally-assigned repository name>
+procedure:<ProcedureId canonical UUIDv7>
+revision:<RevisionId canonical blake3:... text>
+```
+
+A repository key is a typed edge endpoint only: `Repository` has no
+content-derived identity or M0 Rust payload, so M2 deliberately does not
+invent a duplicate `Repository` storage struct. Procedure and revision keys
+address versioned `GraphNode` payloads.
+
+The JSON payload is:
+
+```json
+{
+  "schema_version": 1,
+  "key": "procedure:...",
+  "node": { "kind": "procedure", "value": "<px-repo-model Procedure>" }
+}
+```
+
+The `value` is serialized directly from `px_repo_model::schema::Procedure` or
+`RevisionContent`. No storage-only copy of their fields exists. Unsupported
+M0 entities are intentionally absent from M2 rather than represented by empty
+or fake records.
+
+### Edges
+
+An edge is an independent PluresDB record with deterministic key:
+
+```
+px_graph_edge:v1:<edge kind>:<from NodeKey>:<to NodeKey>
+```
+
+Its payload is `EdgeRecord { from, kind, to }`. Deterministic keys make
+repeated writes of the same relation idempotent under `CrdtStore::put`.
+M2 defines `repository_contains_procedure`, `revision_parent_of`, and
+`revision_includes_procedure_revision`; `put_revision` derives and persists
+its parent → child relations from `RevisionContent.parents`.
+
+### Hashing and historical queries
+
+`GraphStore::current_procedure_root` gathers persisted `Procedure` records and
+delegates to `px_repo_model::merkle::procedure_root`. Thus sorting, canonical
+JSON encoding, and BLAKE3 hashing remain exactly those specified by ADR-0040;
+M2 introduces no parallel hash implementation.
+
+`GraphStore::merkle_root_at_revision(RevisionId)` returns the immutable
+`RevisionContent.procedure_root` stored under that content-addressed revision.
+It intentionally does not recompute current state, which preserves the stated
+point-in-time semantics.
+
+### Query logic
+
+`praxis/procedures/procedure-graph-queries.px` owns direct-child selection and
+historical-root decision semantics. Rust scans/deserializes PluresDB records
+and applies those declared rules; it contains no separate persistence model or
+custom graph index.
+
+## Consequences
+
+- PluresDB is the only M2 persistence substrate.
+- M2 can read nodes, query direct children, recompute the current procedure
+  root, and return a revision's historical root.
+- The flat edge scan is correct and simple for this milestone. M3 may add a
+  PluresDB-native secondary-index/projection strategy after query-volume
+  evidence exists, without changing node identities or hash rules.
+- M3 should extend the typed node/edge vocabulary to the remaining graph
+  entities and wire persisted procedure revisions/artifact relationships into
+  the repository import/materialization workflows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5638,6 +5638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "px-graph-store"
+version = "0.1.0"
+dependencies = [
+ "pluresdb 3.10.3",
+ "px-repo-model",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "px-repo-model"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/px-repo-model",
     "crates/px-adapter-exact",
+    "crates/px-graph-store",
     "crates/radix-core",
     "crates/mcp-client",
     "crates/privacy",

--- a/crates/px-graph-store/Cargo.toml
+++ b/crates/px-graph-store/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "px-graph-store"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "PluresDB-backed procedure graph persistence and queries."
+
+[dependencies]
+px-repo-model = { path = "../px-repo-model" }
+pluresdb = { git = "https://github.com/plures/pluresdb", rev = "2af92b1923e11e41c9103ad8f14900b179d839f6" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/px-graph-store/src/edge.rs
+++ b/crates/px-graph-store/src/edge.rs
@@ -1,0 +1,52 @@
+//! Explicit graph edges persisted as PluresDB records.
+
+use serde::{Deserialize, Serialize};
+
+use crate::NodeKey;
+
+/// Relationships needed by the M2 graph query surface. The names and
+/// direction match `graph-schema.md`: a `RevisionParentOf` edge is parent →
+/// child, and `RepositoryContainsProcedure` is repository → procedure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeKind {
+    RepositoryContainsProcedure,
+    RevisionParentOf,
+    RevisionIncludesProcedureRevision,
+}
+
+impl EdgeKind {
+    fn storage_name(self) -> &'static str {
+        match self {
+            Self::RepositoryContainsProcedure => "repository_contains_procedure",
+            Self::RevisionParentOf => "revision_parent_of",
+            Self::RevisionIncludesProcedureRevision => "revision_includes_procedure_revision",
+        }
+    }
+}
+
+/// A directed relationship between two typed graph keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeRecord {
+    pub from: NodeKey,
+    pub kind: EdgeKind,
+    pub to: NodeKey,
+}
+
+impl EdgeRecord {
+    pub fn new(from: NodeKey, kind: EdgeKind, to: NodeKey) -> Self {
+        Self { from, kind, to }
+    }
+
+    /// A deterministic PluresDB key makes edge writes idempotent. Node keys
+    /// have fixed prefixes and canonical UUID/BLAKE3 suffixes, so this tuple
+    /// encoding is unambiguous for the M2 node vocabulary.
+    pub(crate) fn storage_key(&self) -> String {
+        format!(
+            "px_graph_edge:v1:{}:{}:{}",
+            self.kind.storage_name(),
+            self.from.as_str(),
+            self.to.as_str()
+        )
+    }
+}

--- a/crates/px-graph-store/src/error.rs
+++ b/crates/px-graph-store/src/error.rs
@@ -1,0 +1,24 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GraphStoreError {
+    #[error("could not open PluresDB storage at {path}: {message}")]
+    Open { path: String, message: String },
+
+    #[error("could not serialize record {key}: {source}")]
+    Serialize {
+        key: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("persisted record {key} is invalid: {source}")]
+    Deserialize {
+        key: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("canonical graph hash failed: {0}")]
+    Canonical(#[from] px_repo_model::canonical::CanonicalError),
+}

--- a/crates/px-graph-store/src/lib.rs
+++ b/crates/px-graph-store/src/lib.rs
@@ -1,0 +1,16 @@
+//! PluresDB persistence for the procedure-graph repository substrate.
+//!
+//! `px-repo-model` owns the graph's domain types and canonical BLAKE3
+//! hashing. This crate owns only the PluresDB IO boundary: it stores typed
+//! node envelopes and explicit edge records, and exposes read APIs over those
+//! persisted records. See ADR-0041 for the storage schema.
+
+mod edge;
+mod error;
+mod node;
+mod store;
+
+pub use edge::{EdgeKind, EdgeRecord};
+pub use error::GraphStoreError;
+pub use node::{GraphNode, GraphNodeKind, NodeKey};
+pub use store::GraphStore;

--- a/crates/px-graph-store/src/node.rs
+++ b/crates/px-graph-store/src/node.rs
@@ -1,0 +1,87 @@
+//! Typed graph node envelopes persisted in the flat PluresDB node keyspace.
+//!
+//! The payload types are the `px-repo-model` types themselves. The envelope
+//! adds only a type discriminator required by storage and query dispatch; it
+//! does not duplicate any domain schema fields.
+
+use px_repo_model::identity::{ProcedureId, RevisionId};
+use px_repo_model::schema::{Procedure, RevisionContent};
+use serde::{Deserialize, Serialize};
+
+/// Stable graph key, deliberately distinct from PluresDB's raw node key so
+/// domain identity and storage namespace cannot be conflated.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct NodeKey(String);
+
+impl NodeKey {
+    /// Addresses the schema's externally named repository root. Repositories
+    /// intentionally have no content-derived graph identity (graph-schema
+    /// §2.1), so this is an edge endpoint rather than a stored `GraphNode`.
+    pub fn repository(name: impl AsRef<str>) -> Self {
+        Self(format!("repository:{}", name.as_ref()))
+    }
+
+    pub fn procedure(id: ProcedureId) -> Self {
+        Self(format!("procedure:{}", id.to_canonical_text()))
+    }
+
+    pub fn revision(id: RevisionId) -> Self {
+        Self(format!("revision:{}", id.to_canonical_text()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for NodeKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphNodeKind {
+    Procedure,
+    Revision,
+}
+
+/// A graph node. The procedure/revision content is never copied into a new
+/// storage-specific struct; it is stored and recovered verbatim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum GraphNode {
+    Procedure(Procedure),
+    Revision(RevisionContent),
+}
+
+impl GraphNode {
+    pub fn kind(&self) -> GraphNodeKind {
+        match self {
+            Self::Procedure(_) => GraphNodeKind::Procedure,
+            Self::Revision(_) => GraphNodeKind::Revision,
+        }
+    }
+}
+
+/// Versioned node record stored as the PluresDB `NodeData` JSON payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct StoredNode {
+    pub schema_version: u8,
+    pub key: NodeKey,
+    pub node: GraphNode,
+}
+
+impl StoredNode {
+    pub(crate) const SCHEMA_VERSION: u8 = 1;
+
+    pub(crate) fn new(key: NodeKey, node: GraphNode) -> Self {
+        Self {
+            schema_version: Self::SCHEMA_VERSION,
+            key,
+            node,
+        }
+    }
+}

--- a/crates/px-graph-store/src/store.rs
+++ b/crates/px-graph-store/src/store.rs
@@ -1,0 +1,195 @@
+//! PluresDB IO boundary and graph read API.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use pluresdb::{CrdtStore, MemoryStorage, SledStorage, StorageEngine};
+use px_repo_model::identity::{ContentHash, ProcedureId, RevisionId};
+use px_repo_model::merkle::procedure_root;
+use px_repo_model::schema::{Procedure, RevisionContent};
+
+use crate::edge::{EdgeKind, EdgeRecord};
+use crate::error::GraphStoreError;
+use crate::node::{GraphNode, NodeKey, StoredNode};
+
+const ACTOR_ID: &str = "px-graph-store";
+const NODE_PREFIX: &str = "px_graph_node:v1:";
+
+/// Procedure graph persistence backed exclusively by PluresDB.
+pub struct GraphStore {
+    store: CrdtStore,
+}
+
+impl GraphStore {
+    /// Opens durable PluresDB/Sled storage. `SledStorage` is PluresDB's
+    /// persistence engine; this crate does not create its own data files.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, GraphStoreError> {
+        let display_path = path.as_ref().display().to_string();
+        let storage: Arc<dyn StorageEngine> = Arc::new(SledStorage::open(path).map_err(
+            |error| GraphStoreError::Open {
+                path: display_path,
+                message: error.to_string(),
+            },
+        )?);
+        Ok(Self {
+            store: CrdtStore::default().with_persistence(storage),
+        })
+    }
+
+    /// Uses PluresDB's in-memory storage engine. This exists solely for tests;
+    /// production persistence uses [`Self::open`].
+    pub fn in_memory() -> Self {
+        let storage: Arc<dyn StorageEngine> = Arc::new(MemoryStorage::default());
+        Self {
+            store: CrdtStore::default().with_persistence(storage),
+        }
+    }
+
+    /// Persists one procedure and its current revision relation as a typed
+    /// PluresDB node. The caller persists revision content separately.
+    pub fn put_procedure(&self, procedure: Procedure) -> Result<(), GraphStoreError> {
+        let key = NodeKey::procedure(procedure.id);
+        self.put_node(key, GraphNode::Procedure(procedure))
+    }
+
+    /// Persists revision content under its already canonical, content-derived
+    /// `RevisionId`. It additionally persists each parent → revision edge.
+    pub fn put_revision(
+        &self,
+        revision_id: RevisionId,
+        revision: RevisionContent,
+    ) -> Result<(), GraphStoreError> {
+        for parent in &revision.parents {
+            self.put_edge(EdgeRecord::new(
+                NodeKey::revision(*parent),
+                EdgeKind::RevisionParentOf,
+                NodeKey::revision(revision_id),
+            ))?;
+        }
+        self.put_node(
+            NodeKey::revision(revision_id),
+            GraphNode::Revision(revision),
+        )
+    }
+
+    /// Explicitly persists a graph edge in PluresDB.
+    pub fn put_edge(&self, edge: EdgeRecord) -> Result<(), GraphStoreError> {
+        let key = edge.storage_key();
+        let value = serde_json::to_value(edge).map_err(|source| GraphStoreError::Serialize {
+            key: key.clone(),
+            source,
+        })?;
+        self.store.put(&key, ACTOR_ID, value);
+        Ok(())
+    }
+
+    /// Gets a typed graph node by its domain key from PluresDB.
+    pub fn get_node(&self, key: &NodeKey) -> Result<Option<GraphNode>, GraphStoreError> {
+        let storage_key = node_storage_key(key);
+        self.store
+            .get(&storage_key)
+            .map(|record| decode_node(&storage_key, record.data).map(|stored| stored.node))
+            .transpose()
+    }
+
+    pub fn get_procedure(&self, id: ProcedureId) -> Result<Option<Procedure>, GraphStoreError> {
+        match self.get_node(&NodeKey::procedure(id))? {
+            Some(GraphNode::Procedure(procedure)) => Ok(Some(procedure)),
+            Some(GraphNode::Revision(_)) | None => Ok(None),
+        }
+    }
+
+    pub fn get_revision(&self, id: RevisionId) -> Result<Option<RevisionContent>, GraphStoreError> {
+        match self.get_node(&NodeKey::revision(id))? {
+            Some(GraphNode::Revision(revision)) => Ok(Some(revision)),
+            Some(GraphNode::Procedure(_)) | None => Ok(None),
+        }
+    }
+
+    /// Returns direct children of `from` for an edge kind. The selection rule
+    /// is specified in `praxis/procedures/procedure-graph-queries.px`; this
+    /// method performs only the PluresDB scan/deserialization required to
+    /// apply that rule to persisted edge records.
+    pub fn get_children(
+        &self,
+        from: &NodeKey,
+        kind: EdgeKind,
+    ) -> Result<Vec<NodeKey>, GraphStoreError> {
+        let mut children = self
+            .all_edges()?
+            .into_iter()
+            .filter(|edge| edge.from == *from && edge.kind == kind)
+            .map(|edge| edge.to)
+            .collect::<Vec<_>>();
+        children.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        Ok(children)
+    }
+
+    /// Gets the historical procedure root asserted in a persisted revision.
+    /// This is the M2 "at a point in time" query: it reads the immutable
+    /// revision's recorded root rather than recalculating from current state.
+    pub fn merkle_root_at_revision(
+        &self,
+        revision_id: RevisionId,
+    ) -> Result<Option<ContentHash>, GraphStoreError> {
+        Ok(self
+            .get_revision(revision_id)?
+            .map(|revision| revision.procedure_root))
+    }
+
+    /// Recomputes the current procedure root over procedures stored in
+    /// PluresDB, delegating all canonical ordering/encoding/BLAKE3 work to
+    /// M0's `px_repo_model::merkle::procedure_root`.
+    pub fn current_procedure_root(&self) -> Result<ContentHash, GraphStoreError> {
+        let mut entries = Vec::new();
+        for record in self.store.list() {
+            let key = record.id.to_string();
+            if !key.starts_with(NODE_PREFIX) {
+                continue;
+            }
+            let node = decode_node(&key, record.data)?;
+            if let GraphNode::Procedure(procedure) = node.node {
+                entries.push((procedure.id, procedure.current_revision));
+            }
+        }
+        procedure_root(entries).map_err(GraphStoreError::from)
+    }
+
+    fn put_node(&self, key: NodeKey, node: GraphNode) -> Result<(), GraphStoreError> {
+        let storage_key = node_storage_key(&key);
+        let value = serde_json::to_value(StoredNode::new(key, node)).map_err(|source| {
+            GraphStoreError::Serialize {
+                key: storage_key.clone(),
+                source,
+            }
+        })?;
+        self.store.put(&storage_key, ACTOR_ID, value);
+        Ok(())
+    }
+
+    fn all_edges(&self) -> Result<Vec<EdgeRecord>, GraphStoreError> {
+        self.store
+            .list()
+            .into_iter()
+            .filter_map(|record| {
+                let key = record.id.to_string();
+                key.starts_with("px_graph_edge:v1:").then(|| {
+                    serde_json::from_value(record.data)
+                        .map_err(|source| GraphStoreError::Deserialize { key, source })
+                })
+            })
+            .collect()
+    }
+}
+
+fn node_storage_key(key: &NodeKey) -> String {
+    format!("{NODE_PREFIX}{}", key.as_str())
+}
+
+fn decode_node(storage_key: &str, data: serde_json::Value) -> Result<StoredNode, GraphStoreError> {
+    let node = serde_json::from_value(data).map_err(|source| GraphStoreError::Deserialize {
+        key: storage_key.to_string(),
+        source,
+    })?;
+    Ok(node)
+}

--- a/crates/px-graph-store/tests/graph_store_tests.rs
+++ b/crates/px-graph-store/tests/graph_store_tests.rs
@@ -1,0 +1,137 @@
+use px_graph_store::{EdgeKind, EdgeRecord, GraphNode, GraphStore, NodeKey};
+use px_repo_model::identity::{ContentHash, ProcedureId, RenderingProfileHash};
+use px_repo_model::schema::{
+    procedure_revision_hash, revision_id, Procedure, ProcedureKind, ProcedureRevisionContent,
+    RevisionContent,
+};
+
+fn procedure(name: &str) -> (Procedure, ProcedureRevisionContent) {
+    let id = ProcedureId::new();
+    let content = ProcedureRevisionContent {
+        procedure_id: id,
+        source_text: format!("procedure {name}:\n  trigger: manual\n"),
+        capability_grants: vec![],
+        residuals: vec![],
+    };
+    let revision = procedure_revision_hash(&content).expect("valid canonical procedure content");
+    (
+        Procedure {
+            id,
+            kind: ProcedureKind::State,
+            name: name.to_string(),
+            path: format!("praxis/procedures/{name}.px"),
+            current_revision: revision,
+        },
+        content,
+    )
+}
+
+fn revision(
+    parents: Vec<px_repo_model::identity::RevisionId>,
+    root: ContentHash,
+) -> RevisionContent {
+    RevisionContent {
+        parents,
+        procedure_root: root,
+        entity_root: ContentHash::of_raw_bytes(b"entities"),
+        change_ids: vec![],
+        rendering_profile: RenderingProfileHash::of_raw_bytes(b"profile"),
+        materialization_root: ContentHash::of_raw_bytes(b"materialization"),
+        author: "test".to_string(),
+        timestamp: "2026-07-31T00:00:00Z".to_string(),
+        message: "test revision".to_string(),
+    }
+}
+
+#[test]
+fn persists_and_reads_a_graph_fixture_through_pluresdb() {
+    // A real durable PluresDB/Sled instance is opened twice; the second store
+    // proves the node was persisted by PluresDB rather than retained in a
+    // process-local collection.
+    let directory = tempfile::tempdir().unwrap();
+    let (procedure, _content) = procedure("persisted");
+    {
+        let store = GraphStore::open(directory.path()).unwrap();
+        store.put_procedure(procedure.clone()).unwrap();
+    }
+
+    let store = GraphStore::open(directory.path()).unwrap();
+    let key = NodeKey::procedure(procedure.id);
+    assert_eq!(
+        store.get_node(&key).unwrap(),
+        Some(GraphNode::Procedure(procedure.clone()))
+    );
+    assert_eq!(store.get_procedure(procedure.id).unwrap(), Some(procedure));
+}
+
+#[test]
+fn procedure_merkle_root_is_stable_and_independent_of_write_order() {
+    let (first, _) = procedure("first");
+    let (second, _) = procedure("second");
+
+    let left = GraphStore::in_memory();
+    left.put_procedure(first.clone()).unwrap();
+    left.put_procedure(second.clone()).unwrap();
+
+    let right = GraphStore::in_memory();
+    right.put_procedure(second.clone()).unwrap();
+    right.put_procedure(first.clone()).unwrap();
+
+    let root = left.current_procedure_root().unwrap();
+    assert_eq!(root, left.current_procedure_root().unwrap());
+    assert_eq!(root, right.current_procedure_root().unwrap());
+}
+
+#[test]
+fn query_children_and_historical_merkle_root_are_pluresdb_backed() {
+    let store = GraphStore::in_memory();
+    let (parent, _) = procedure("parent");
+    let (child, _) = procedure("child");
+    store.put_procedure(parent.clone()).unwrap();
+    store.put_procedure(child.clone()).unwrap();
+
+    store
+        .put_edge(EdgeRecord::new(
+            NodeKey::repository("test-repository"),
+            EdgeKind::RepositoryContainsProcedure,
+            NodeKey::procedure(child.id),
+        ))
+        .unwrap();
+    assert_eq!(
+        store
+            .get_children(
+                &NodeKey::repository("test-repository"),
+                EdgeKind::RepositoryContainsProcedure
+            )
+            .unwrap(),
+        vec![NodeKey::procedure(child.id)]
+    );
+
+    let frozen_root = ContentHash::of_raw_bytes(b"procedure-root-at-r1");
+    let revision = revision(vec![], frozen_root);
+    let revision_id = revision_id(&revision).unwrap();
+    store.put_revision(revision_id, revision).unwrap();
+    assert_eq!(
+        store.merkle_root_at_revision(revision_id).unwrap(),
+        Some(frozen_root)
+    );
+}
+
+#[test]
+fn revision_persistence_materializes_parent_to_child_edges() {
+    let store = GraphStore::in_memory();
+    let root = revision(vec![], ContentHash::of_raw_bytes(b"root"));
+    let root_id = revision_id(&root).unwrap();
+    store.put_revision(root_id, root).unwrap();
+
+    let child = revision(vec![root_id], ContentHash::of_raw_bytes(b"child"));
+    let child_id = revision_id(&child).unwrap();
+    store.put_revision(child_id, child).unwrap();
+
+    assert_eq!(
+        store
+            .get_children(&NodeKey::revision(root_id), EdgeKind::RevisionParentOf)
+            .unwrap(),
+        vec![NodeKey::revision(child_id)]
+    );
+}

--- a/praxis/procedures/procedure-graph-queries.px
+++ b/praxis/procedures/procedure-graph-queries.px
@@ -1,0 +1,31 @@
+# procedure-graph-queries.px
+#
+# Pure query semantics for M2's PluresDB-backed procedure graph. The Rust
+# GraphStore is the IO adapter: it fetches Typed Node and Edge records from
+# PluresDB, while this procedure defines which records comprise a query result.
+
+fact graph_query:
+  from: string
+  edge_kind: string
+
+constraint graph_query_requires_typed_edge:
+  require: graph_query.edge_kind != ""
+  severity: error
+  message: "Graph traversal must select a declared EdgeKind; untyped edges are not graph relationships."
+
+# Direct-children semantics: select edges of the requested kind that originate
+# at `from`, return their destination NodeKeys, sorted lexicographically. Rust
+# applies this exact rule after its PluresDB edge scan.
+procedure get_children:
+  trigger: manual
+  load_graph_edges {from: graph_query.from, kind: graph_query.edge_kind} -> $edges
+  sort_node_keys {edges: $edges} -> $children
+  return {children: $children}
+
+# Historical-root semantics: the root at a revision is the immutable
+# `RevisionContent.procedure_root` recorded under that RevisionId. It is not a
+# live recomputation over whatever procedures happen to be stored now.
+procedure get_merkle_root_at_revision:
+  trigger: manual
+  read_revision {revision_id: graph_query.from} -> $revision
+  return {procedure_root: $revision.procedure_root}


### PR DESCRIPTION
## M2: PluresDB procedure-graph substrate\n\n- Adds px-graph-store, a typed PluresDB/Sled persistence boundary that reuses px-repo-model Procedure and RevisionContent types.\n- Stores versioned node envelopes and deterministic directed edge records in PluresDB's flat CRDT keyspace.\n- Exposes real persisted reads for nodes, direct children, current canonical procedure Merkle roots, and historical revision roots.\n- Delegates all canonical ordering and BLAKE3 hashing to ADR-0040's px-repo-model::merkle::procedure_root; no parallel hashing implementation.\n- Adds ADR-0041 and .px query semantics for typed child selection and point-in-time root lookup.\n- Adds durable PluresDB/Sled round-trip, query, revision-edge, and Merkle determinism tests.\n\n## Validation\n\n- cargo fmt -p px-graph-store -- --check\n- cargo test -p px-graph-store\n- cargo clippy -p px-graph-store -- -D warnings\n- cargo test --workspace was also run: 899 tests passed; 14 pre-existing adix-core shell-executor tests fail on Windows because they invoke POSIX shell commands (sleep, cho -n, $MY_VAR). One separate pre-existing task-handoff test also fails with InvalidClaimToken. The M2 crate tests pass.\n\n## M3 follow-up\n\nExtend the typed storage vocabulary to remaining M0 graph entities and wire ProcedureRevision/artifact/ref/logical-change persistence into import/materialization flows. Add evidence-driven PluresDB-native indexes/projections only when graph query volume requires them.