### PR TITLE
feat(px-graph-store,px-adapter-exact): M3 - persist procedure graph, wire import/materialize through PluresDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5592,6 +5592,7 @@ checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 name = "px-adapter-exact"
 version = "0.1.0"
 dependencies = [
+ "px-graph-store",
  "px-repo-model",
  "tempfile",
  "thiserror 2.0.19",

--- a/crates/px-adapter-exact/Cargo.toml
+++ b/crates/px-adapter-exact/Cargo.toml
@@ -8,6 +8,7 @@ description = "M1 exact-artifact adapter: recursive filesystem importer and dete
 
 [dependencies]
 px-repo-model = { path = "../px-repo-model" }
+px-graph-store = { path = "../px-graph-store" }
 walkdir = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/px-adapter-exact/src/lib.rs
+++ b/crates/px-adapter-exact/src/lib.rs
@@ -23,8 +23,10 @@
 
 pub mod importer;
 pub mod materializer;
+pub mod persistence;
 pub mod tree;
 
 pub use importer::{import_tree, ImportError};
 pub use materializer::{materialize_tree, MaterializeError};
+pub use persistence::{materialize_from_store, persist_imported_tree, PersistError};
 pub use tree::{ImportedDirectory, ImportedFile, ImportedTree};

--- a/crates/px-adapter-exact/src/persistence.rs
+++ b/crates/px-adapter-exact/src/persistence.rs
@@ -1,0 +1,180 @@
+//! M3: wires the M1 import/materialize flow into the M2 PluresDB-backed
+//! `px-graph-store`, per PR #601's own follow-up note ("wire
+//! ProcedureRevision/artifact/ref/logical-change persistence into
+//! import/materialization flows").
+//!
+//! `import_tree`/`materialize_tree` (this crate's M1 exit criterion) operate
+//! on the in-memory [`crate::tree::ImportedTree`]. This module is the
+//! missing link: [`persist_imported_tree`] writes that in-memory tree into a
+//! real [`px_graph_store::GraphStore`] using the exact relationships
+//! `exact-artifact-procedure.md` §2 specifies (`Procedure` +
+//! `ExactArtifactProcedure` + `Artifact` + `ProcedureRevision`, plus the
+//! `Repository CONTAINS Procedure` edge from graph-schema.md §2.6), and
+//! [`materialize_from_store`] reads that same graph back out into a fresh
+//! `ImportedTree` so it can be handed to the existing [`crate::materialize_tree`]
+//! — proving the graph substrate, not just the in-memory value, is what
+//! round-trips.
+
+use px_graph_store::{EdgeKind, EdgeRecord, GraphStore, GraphStoreError, NodeKey};
+use px_repo_model::identity::ProcedureId;
+use px_repo_model::schema::{
+    procedure_revision_hash, Artifact, Procedure, ProcedureKind, ProcedureRevisionContent,
+};
+
+use crate::tree::{ImportedDirectory, ImportedFile, ImportedTree};
+
+#[derive(Debug, thiserror::Error)]
+pub enum PersistError {
+    #[error(transparent)]
+    GraphStore(#[from] GraphStoreError),
+    #[error("canonical hashing failed while persisting a procedure revision: {0}")]
+    Canonical(#[from] px_repo_model::canonical::CanonicalError),
+}
+
+/// Persist every directory and file/symlink in `tree` into `store` under
+/// `repository_name`, following the exact `Procedure`/`ExactArtifactProcedure`
+/// /`Artifact`/`ProcedureRevision` relationship exact-artifact-procedure.md
+/// §2 defines. Idempotent: re-persisting the same `ImportedTree` writes the
+/// same content-addressed records again (`CrdtStore::put` semantics), so
+/// calling this twice for an unchanged tree is a no-op in effect.
+pub fn persist_imported_tree(
+    store: &GraphStore,
+    repository_name: &str,
+    tree: &ImportedTree,
+) -> Result<(), PersistError> {
+    for directory in &tree.directories {
+        store.put_empty_directory(repository_name, &directory.path)?;
+    }
+
+    for file in &tree.files {
+        persist_imported_file(store, repository_name, file)?;
+    }
+
+    Ok(())
+}
+
+fn persist_imported_file(
+    store: &GraphStore,
+    repository_name: &str,
+    file: &ImportedFile,
+) -> Result<(), PersistError> {
+    let procedure_id = file.artifact.procedure_id;
+
+    // The blob is only meaningful for non-symlinks (a symlink's payload is
+    // its target string, per the M1 importer's own doc comment); persisting
+    // an empty blob for a symlink would still be correct (its hash is the
+    // BLAKE3 of zero bytes) but is skipped as pointless duplicate writes of
+    // the same well-known empty-content hash across every symlink.
+    if !file.artifact.is_symlink {
+        store.put_blob(file.blob.clone())?;
+    }
+
+    store.put_exact_artifact(file.artifact.clone())?;
+
+    store.put_artifact(Artifact {
+        owning_procedure: procedure_id,
+        blob: file.artifact.blob,
+        mode: file.artifact.mode.clone(),
+        encoding: file.artifact.encoding.clone(),
+        is_symlink: file.artifact.is_symlink,
+        symlink_target: file.artifact.symlink_target.clone(),
+    })?;
+
+    // exact-artifact-procedure.md §2: the ProcedureRevision's source_text is
+    // "the canonical .px serialization of the ExactArtifactProcedure fields"
+    // (not the raw file content, which lives in the Blob/Artifact). This
+    // crate does not implement the full `.px` grammar (out of scope per this
+    // crate's own doc comment), so it uses the same canonical-JSON encoding
+    // `px-repo-model` already defines and hashes everything else with
+    // (ADR-0040 §2) as the deterministic structured-metadata serialization;
+    // this is a real, well-defined encoding, not a placeholder string.
+    let source_text = px_repo_model::canonical::to_canonical_bytes(&file.artifact)
+        .map(|bytes| String::from_utf8(bytes).expect("canonical JSON is always valid UTF-8"))?;
+
+    let revision_content = ProcedureRevisionContent {
+        procedure_id,
+        source_text,
+        capability_grants: vec![],
+        residuals: vec![],
+    };
+    let revision_hash = procedure_revision_hash(&revision_content)?;
+    store.put_procedure_revision(revision_hash, revision_content)?;
+
+    let name = file_name(&file.artifact.original_path);
+    let procedure = Procedure {
+        id: procedure_id,
+        kind: ProcedureKind::ExactArtifact,
+        name,
+        path: file.artifact.original_path.clone(),
+        current_revision: revision_hash,
+    };
+    store.put_procedure(procedure)?;
+
+    store.put_edge(EdgeRecord::new(
+        NodeKey::repository(repository_name),
+        EdgeKind::RepositoryContainsProcedure,
+        NodeKey::procedure(procedure_id),
+    ))?;
+
+    Ok(())
+}
+
+fn file_name(posix_path: &str) -> String {
+    posix_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(posix_path)
+        .to_owned()
+}
+
+/// Reconstruct an [`ImportedTree`] entirely from what is persisted in
+/// `store` under `repository_name` — no reference to the original
+/// filesystem or the in-memory tree that was persisted. This is the
+/// substrate-backed half of the M1 round-trip guarantee: the result is
+/// handed to [`crate::materialize_tree`] the same way a freshly imported
+/// `ImportedTree` would be.
+pub fn materialize_from_store(
+    store: &GraphStore,
+    repository_name: &str,
+) -> Result<ImportedTree, PersistError> {
+    let mut tree = ImportedTree::default();
+
+    for path in store.get_empty_directories(repository_name)? {
+        tree.directories.push(ImportedDirectory { path });
+    }
+
+    let procedure_keys = store.get_children(
+        &NodeKey::repository(repository_name),
+        EdgeKind::RepositoryContainsProcedure,
+    )?;
+    for key in procedure_keys {
+        let procedure_id = procedure_id_from_key(&key);
+        let Some(artifact) = store.get_exact_artifact(procedure_id)? else {
+            continue;
+        };
+        let blob = if artifact.is_symlink {
+            px_repo_model::schema::Blob { content: Vec::new() }
+        } else {
+            store
+                .get_blob(artifact.blob)?
+                .expect("a persisted non-symlink ExactArtifactProcedure always has its blob persisted alongside it")
+        };
+        tree.files.push(ImportedFile { artifact, blob });
+    }
+
+    tree.canonicalize();
+    Ok(tree)
+}
+
+/// Recover the `ProcedureId` a `procedure:<uuid>` `NodeKey` addresses. This
+/// mirrors `NodeKey::procedure`'s own encoding rather than adding a second
+/// parsing rule to `px-graph-store`'s public API, since only this crate's
+/// reconstruction path needs to walk node keys back into typed ids.
+fn procedure_id_from_key(key: &NodeKey) -> ProcedureId {
+    let text = key
+        .as_str()
+        .strip_prefix("procedure:")
+        .expect("get_children(RepositoryContainsProcedure) only ever returns procedure: keys");
+    ProcedureId::parse_canonical_text(text)
+        .expect("NodeKey::procedure always encodes a valid canonical ProcedureId")
+}

--- a/crates/px-adapter-exact/tests/persisted_round_trip.rs
+++ b/crates/px-adapter-exact/tests/persisted_round_trip.rs
@@ -1,0 +1,195 @@
+//! M3 end-to-end test: import a real fixture repo via `px-adapter-exact`,
+//! persist it into a real PluresDB-backed `px-graph-store`, verify it is
+//! queryable from the store (nodes, children, Merkle root), and prove the
+//! full `import -> persist -> materialize` path is byte-identical to the
+//! M1 in-memory round trip guarantee — but now going through the persisted
+//! store rather than reusing the original in-memory `ImportedTree`.
+
+use std::fs;
+use std::path::Path;
+
+use px_adapter_exact::{import_tree, materialize_from_store, materialize_tree, persist_imported_tree};
+use px_graph_store::{EdgeKind, GraphStore, NodeKey};
+use px_repo_model::schema::ProcedureKind;
+
+const REPOSITORY_NAME: &str = "e2e-fixture-repo";
+
+fn build_fixture(root: &Path) {
+    fs::create_dir_all(root.join("src/nested")).unwrap();
+    fs::create_dir_all(root.join("empty-dir")).unwrap();
+
+    fs::write(root.join("README.md"), b"# Fixture\n\nSome text with LF endings.\n").unwrap();
+    fs::write(
+        root.join("src/main.rs"),
+        b"fn main() {\r\n    println!(\"hi\");\r\n}\r\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/nested/mixed.txt"),
+        b"line one\nline two\r\nline three\n",
+    )
+    .unwrap();
+
+    let binary_content: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0xFE, 0x80, 0x81, 0x00, 0x00,
+        0x01,
+    ];
+    fs::write(root.join("src/nested/asset.bin"), &binary_content).unwrap();
+    fs::write(root.join("no-newline.txt"), b"no trailing newline here").unwrap();
+}
+
+fn collect_files(root: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(root).min_depth(1) {
+        let entry = entry.unwrap();
+        if entry.file_type().is_file() {
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace('\\', "/");
+            out.push((relative, fs::read(entry.path()).unwrap()));
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+fn collect_dirs(root: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(root).min_depth(1) {
+        let entry = entry.unwrap();
+        if entry.file_type().is_dir() {
+            out.push(
+                entry
+                    .path()
+                    .strip_prefix(root)
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .replace('\\', "/"),
+            );
+        }
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn import_persist_materialize_round_trips_through_pluresdb_byte_identical() {
+    let source_dir = tempfile::tempdir().unwrap();
+    build_fixture(source_dir.path());
+
+    // --- import (M1) ---
+    let tree = import_tree(source_dir.path()).expect("import must succeed on a well-formed fixture");
+    assert_eq!(tree.files.len(), 5, "fixture has 5 real files");
+    assert_eq!(tree.directories.len(), 3, "fixture has 3 non-root directories, one empty");
+
+    // --- persist (M3): a real, durable PluresDB/Sled-backed store ---
+    let db_dir = tempfile::tempdir().unwrap();
+    {
+        let store = GraphStore::open(db_dir.path()).expect("open durable PluresDB store");
+        persist_imported_tree(&store, REPOSITORY_NAME, &tree).expect("persist imported tree");
+    }
+
+    // Re-open to prove durability across a fresh process-local `CrdtStore`
+    // instance, exactly like px-graph-store's own M2 durability test does.
+    let store = GraphStore::open(db_dir.path()).expect("re-open durable PluresDB store");
+
+    // --- verify queryability: nodes ---
+    let procedure_keys = store
+        .get_children(
+            &NodeKey::repository(REPOSITORY_NAME),
+            EdgeKind::RepositoryContainsProcedure,
+        )
+        .expect("query repository -> procedure children");
+    assert_eq!(procedure_keys.len(), 5, "one Procedure per imported file");
+
+    for file in &tree.files {
+        let procedure = store
+            .get_procedure(file.artifact.procedure_id)
+            .expect("query procedure")
+            .expect("every imported file's Procedure must be persisted and queryable");
+        assert_eq!(procedure.kind, ProcedureKind::ExactArtifact);
+        assert_eq!(procedure.path, file.artifact.original_path);
+
+        let stored_artifact = store
+            .get_exact_artifact(file.artifact.procedure_id)
+            .expect("query exact artifact")
+            .expect("every imported file's ExactArtifactProcedure must be persisted");
+        assert_eq!(&stored_artifact, &file.artifact);
+
+        let stored_procedure_revision = store
+            .get_procedure_revision(procedure.current_revision)
+            .expect("query procedure revision")
+            .expect("the Procedure's current_revision must be a persisted ProcedureRevision");
+        assert_eq!(stored_procedure_revision.procedure_id, file.artifact.procedure_id);
+
+        if !file.artifact.is_symlink {
+            let stored_blob = store
+                .get_blob(file.artifact.blob)
+                .expect("query blob")
+                .expect("every non-symlink file's Blob must be persisted under its BlobHash");
+            assert_eq!(stored_blob.content, file.blob.content);
+        }
+    }
+
+    // --- verify queryability: current procedure Merkle root ---
+    // The persisted graph's current_procedure_root must reproduce exactly
+    // the same root as computing it directly from the in-memory tree's
+    // procedures (ADR-0040 §4 / px_repo_model::merkle::procedure_root),
+    // proving px-graph-store did not silently drop or alter any procedure
+    // during persistence.
+    let expected_root = px_repo_model::merkle::procedure_root(
+        tree.files
+            .iter()
+            .map(|f| (f.artifact.procedure_id, {
+                let content = px_repo_model::schema::ProcedureRevisionContent {
+                    procedure_id: f.artifact.procedure_id,
+                    source_text: String::from_utf8(
+                        px_repo_model::canonical::to_canonical_bytes(&f.artifact).unwrap(),
+                    )
+                    .unwrap(),
+                    capability_grants: vec![],
+                    residuals: vec![],
+                };
+                px_repo_model::schema::procedure_revision_hash(&content).unwrap()
+            }))
+            .collect(),
+    )
+    .unwrap();
+    let persisted_root = store
+        .current_procedure_root()
+        .expect("compute current procedure root from persisted store");
+    assert_eq!(
+        persisted_root, expected_root,
+        "persisted graph's Merkle root must match the root computed directly from the imported tree"
+    );
+
+    // --- reconstruct and materialize purely from the persisted store ---
+    let reconstructed_tree = materialize_from_store(&store, REPOSITORY_NAME)
+        .expect("reconstruct ImportedTree entirely from the persisted graph");
+    assert_eq!(reconstructed_tree.files.len(), tree.files.len());
+    assert_eq!(reconstructed_tree.directories.len(), tree.directories.len());
+
+    let dest_dir = tempfile::tempdir().unwrap();
+    fs::remove_dir(dest_dir.path()).unwrap();
+    materialize_tree(&reconstructed_tree, dest_dir.path())
+        .expect("materialize the store-reconstructed tree back to a real filesystem");
+
+    let original_files = collect_files(source_dir.path());
+    let materialized_files = collect_files(dest_dir.path());
+    assert_eq!(
+        original_files, materialized_files,
+        "import -> persist -> materialize must be byte-identical to the original fixture"
+    );
+
+    let original_dirs = collect_dirs(source_dir.path());
+    let materialized_dirs = collect_dirs(dest_dir.path());
+    assert_eq!(
+        original_dirs, materialized_dirs,
+        "the persisted empty directory must materialize back, matching the original tree exactly"
+    );
+}

--- a/crates/px-graph-store/src/edge.rs
+++ b/crates/px-graph-store/src/edge.rs
@@ -13,6 +13,12 @@ pub enum EdgeKind {
     RepositoryContainsProcedure,
     RevisionParentOf,
     RevisionIncludesProcedureRevision,
+    RepositoryHasRef,
+    RefPointsToRevision,
+    ProcedureProducesArtifact,
+    ArtifactUsesBlob,
+    RevisionRecordsLogicalChange,
+    RepositoryContainsEmptyDirectory,
 }
 
 impl EdgeKind {
@@ -21,6 +27,12 @@ impl EdgeKind {
             Self::RepositoryContainsProcedure => "repository_contains_procedure",
             Self::RevisionParentOf => "revision_parent_of",
             Self::RevisionIncludesProcedureRevision => "revision_includes_procedure_revision",
+            Self::RepositoryHasRef => "repository_has_ref",
+            Self::RefPointsToRevision => "ref_points_to_revision",
+            Self::ProcedureProducesArtifact => "procedure_produces_artifact",
+            Self::ArtifactUsesBlob => "artifact_uses_blob",
+            Self::RevisionRecordsLogicalChange => "revision_records_logical_change",
+            Self::RepositoryContainsEmptyDirectory => "repository_contains_empty_directory",
         }
     }
 }

--- a/crates/px-graph-store/src/lib.rs
+++ b/crates/px-graph-store/src/lib.rs
@@ -12,5 +12,5 @@ mod store;
 
 pub use edge::{EdgeKind, EdgeRecord};
 pub use error::GraphStoreError;
-pub use node::{GraphNode, GraphNodeKind, NodeKey};
+pub use node::{BlobRecord, EmptyDirectoryRecord, GraphNode, GraphNodeKind, NodeKey};
 pub use store::GraphStore;

--- a/crates/px-graph-store/src/node.rs
+++ b/crates/px-graph-store/src/node.rs
@@ -3,9 +3,33 @@
 //! The payload types are the `px-repo-model` types themselves. The envelope
 //! adds only a type discriminator required by storage and query dispatch; it
 //! does not duplicate any domain schema fields.
+//!
+//! M3 extends the vocabulary to the remaining M0 graph entities the M2
+//! follow-up note named: `ProcedureRevision` detail records, `Artifact`,
+//! `Ref`, and `LogicalChange` (graph-schema.md §2.3/§2.5/§2.7/§2.9), plus the
+//! `ExactArtifactProcedure` metadata record the M1 adapter produces
+//! (graph-schema.md §2.6's `exact_artifact` `ProcedureKind`). All payload
+//! types are reused verbatim from `px_repo_model`; no parallel schema is
+//! introduced for any M0-named entity.
+//!
+//! Two node kinds are NOT M0 domain entities and are called out as such:
+//! `Blob` (raw file bytes; graph-schema.md §2.10 defines a `Blob` entity but
+//! only for its content-derived identity, not a Rust storage struct - this
+//! crate is the first thing that needs to actually keep the bytes somewhere,
+//! so `BlobRecord` exists solely as the PluresDB-side byte container) and
+//! `EmptyDirectory` (directories are explicitly out of the M0 schema per
+//! `px-adapter-exact`'s own `ImportedDirectory` doc comment - this crate
+//! persists the same "must remember this dir existed" bookkeeping fact the
+//! M1 in-memory `ImportedTree` already carries, so a round trip through
+//! PluresDB does not silently drop empty directories).
 
-use px_repo_model::identity::{ProcedureId, RevisionId};
-use px_repo_model::schema::{Procedure, RevisionContent};
+use px_repo_model::exact_artifact::ExactArtifactProcedure;
+use px_repo_model::identity::{
+    BlobHash, LogicalChangeId, ProcedureId, ProcedureRevisionHash, RevisionId,
+};
+use px_repo_model::schema::{
+    Artifact, LogicalChange, Procedure, ProcedureRevisionContent, Ref, RevisionContent,
+};
 use serde::{Deserialize, Serialize};
 
 /// Stable graph key, deliberately distinct from PluresDB's raw node key so
@@ -30,6 +54,78 @@ impl NodeKey {
         Self(format!("revision:{}", id.to_canonical_text()))
     }
 
+    /// Addresses a `ProcedureRevision` detail record (graph-schema.md §2.7)
+    /// by its own content-derived `ProcedureRevisionHash`, distinct from the
+    /// `revision:` key above, which addresses the M0 `Revision` entity
+    /// (graph-schema.md §2.2) - the two are different entities that share
+    /// only a similar English name.
+    pub fn procedure_revision(hash: ProcedureRevisionHash) -> Self {
+        Self(format!("procedure_revision:{}", hash.to_canonical_text()))
+    }
+
+    /// Addresses an `Artifact` projection-facing record (graph-schema.md
+    /// §2.9). An `Artifact` has no identity of its own - it is identified by
+    /// the combination of its owning `Procedure` and the `Blob` it
+    /// references (§2.9: "identified by the combination of its owning
+    /// `Procedure` and its `PROJECTS_TO Path` relationship") - so the key is
+    /// composed from both rather than invented as a new identity.
+    pub fn artifact(owning_procedure: ProcedureId, blob: BlobHash) -> Self {
+        Self(format!(
+            "artifact:{}:{}",
+            owning_procedure.to_canonical_text(),
+            blob.to_canonical_text()
+        ))
+    }
+
+    /// Addresses an M1 `ExactArtifactProcedure` record (distinct from the
+    /// `Artifact` projection record above; graph-schema.md §2.6's
+    /// `exact_artifact` `ProcedureKind` names the exact-artifact adapter's
+    /// full metadata as the procedure's own detail, not the separate
+    /// rendering-facing `Artifact` entity in §2.9).
+    pub fn exact_artifact(procedure_id: ProcedureId) -> Self {
+        Self(format!("exact_artifact:{}", procedure_id.to_canonical_text()))
+    }
+
+    /// Addresses a `LogicalChange` entity (graph-schema.md §2.3) by its
+    /// assigned `LogicalChangeId`.
+    pub fn logical_change(id: LogicalChangeId) -> Self {
+        Self(format!("logical_change:{}", id.to_canonical_text()))
+    }
+
+    /// Addresses a `Ref` (graph-schema.md §2.5): a `Ref` has no identity of
+    /// its own, only a mutable `name` scoped to the repository that owns it
+    /// (`Repository HAS_REF Ref`, §2.5), so the key includes both.
+    pub fn reference(repository_name: impl AsRef<str>, ref_name: impl AsRef<str>) -> Self {
+        Self(format!(
+            "ref:{}:{}",
+            repository_name.as_ref(),
+            ref_name.as_ref()
+        ))
+    }
+
+    /// Addresses the raw byte payload a `Blob` entity's `BlobHash` refers to
+    /// (graph-schema.md §2.10). `Blob` itself has no Rust storage struct in
+    /// `px-repo-model` beyond its hash function; this is the PluresDB-side
+    /// byte container the M1 import/materialize flow actually needs so a
+    /// persisted graph can be materialized back without the original
+    /// filesystem tree still being present on disk.
+    pub fn blob(hash: BlobHash) -> Self {
+        Self(format!("blob:{}", hash.to_canonical_text()))
+    }
+
+    /// Addresses an M1-imported empty directory bookkeeping record
+    /// (`px_adapter_exact::ImportedDirectory`'s doc comment: directories are
+    /// not an M0 graph entity, but must still be remembered so a
+    /// materialize-after-persist round trip does not silently drop them),
+    /// scoped to the repository that owns the imported tree.
+    pub fn empty_directory(repository_name: impl AsRef<str>, path: impl AsRef<str>) -> Self {
+        Self(format!(
+            "empty_directory:{}:{}",
+            repository_name.as_ref(),
+            path.as_ref()
+        ))
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -46,15 +142,49 @@ impl std::fmt::Display for NodeKey {
 pub enum GraphNodeKind {
     Procedure,
     Revision,
+    ProcedureRevision,
+    Artifact,
+    ExactArtifact,
+    LogicalChange,
+    Ref,
+    Blob,
+    EmptyDirectory,
 }
 
-/// A graph node. The procedure/revision content is never copied into a new
-/// storage-specific struct; it is stored and recovered verbatim.
+/// PluresDB-side raw byte container for a `Blob` entity (graph-schema.md
+/// §2.10). Not an M0 Rust type - `px_repo_model::schema::Blob` already
+/// exists and is reused verbatim as the payload; this wrapper exists only so
+/// the node envelope can carry the same self-consistency check every other
+/// stored node gets (the caller-supplied key must match the recomputed
+/// content hash), never a second definition of what a blob's identity is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlobRecord {
+    pub content: Vec<u8>,
+}
+
+/// M1's `ImportedDirectory` bookkeeping fact, persisted so the graph
+/// substrate can materialize an empty directory back even after the
+/// original in-memory `ImportedTree` is gone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmptyDirectoryRecord {
+    pub repository_name: String,
+    pub path: String,
+}
+
+/// A graph node. The procedure/revision/etc. content is never copied into a
+/// new storage-specific struct; it is stored and recovered verbatim.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum GraphNode {
     Procedure(Procedure),
     Revision(RevisionContent),
+    ProcedureRevision(ProcedureRevisionContent),
+    Artifact(Artifact),
+    ExactArtifact(ExactArtifactProcedure),
+    LogicalChange(LogicalChange),
+    Ref(Ref),
+    Blob(BlobRecord),
+    EmptyDirectory(EmptyDirectoryRecord),
 }
 
 impl GraphNode {
@@ -62,6 +192,13 @@ impl GraphNode {
         match self {
             Self::Procedure(_) => GraphNodeKind::Procedure,
             Self::Revision(_) => GraphNodeKind::Revision,
+            Self::ProcedureRevision(_) => GraphNodeKind::ProcedureRevision,
+            Self::Artifact(_) => GraphNodeKind::Artifact,
+            Self::ExactArtifact(_) => GraphNodeKind::ExactArtifact,
+            Self::LogicalChange(_) => GraphNodeKind::LogicalChange,
+            Self::Ref(_) => GraphNodeKind::Ref,
+            Self::Blob(_) => GraphNodeKind::Blob,
+            Self::EmptyDirectory(_) => GraphNodeKind::EmptyDirectory,
         }
     }
 }

--- a/crates/px-graph-store/src/store.rs
+++ b/crates/px-graph-store/src/store.rs
@@ -4,13 +4,14 @@ use std::path::Path;
 use std::sync::Arc;
 
 use pluresdb::{CrdtStore, MemoryStorage, SledStorage, StorageEngine};
-use px_repo_model::identity::{ContentHash, ProcedureId, RevisionId};
+use px_repo_model::exact_artifact::ExactArtifactProcedure;
+use px_repo_model::identity::{BlobHash, ContentHash, LogicalChangeId, ProcedureId, ProcedureRevisionHash, RevisionId};
 use px_repo_model::merkle::procedure_root;
-use px_repo_model::schema::{Procedure, RevisionContent};
+use px_repo_model::schema::{Artifact, Blob, LogicalChange, Procedure, ProcedureRevisionContent, Ref, RevisionContent};
 
 use crate::edge::{EdgeKind, EdgeRecord};
 use crate::error::GraphStoreError;
-use crate::node::{GraphNode, NodeKey, StoredNode};
+use crate::node::{BlobRecord, EmptyDirectoryRecord, GraphNode, NodeKey, StoredNode};
 
 const ACTOR_ID: &str = "px-graph-store";
 const NODE_PREFIX: &str = "px_graph_node:v1:";
@@ -72,6 +73,91 @@ impl GraphStore {
         )
     }
 
+    /// Persists a `ProcedureRevision` detail record (graph-schema.md §2.7)
+    /// under its own content-derived `ProcedureRevisionHash`. This is
+    /// distinct from `put_revision`, which persists the M0 `Revision` entity
+    /// (§2.2); a `Procedure`'s `current_revision` field points at records
+    /// stored via this method.
+    pub fn put_procedure_revision(
+        &self,
+        hash: ProcedureRevisionHash,
+        content: ProcedureRevisionContent,
+    ) -> Result<(), GraphStoreError> {
+        self.put_node(
+            NodeKey::procedure_revision(hash),
+            GraphNode::ProcedureRevision(content),
+        )
+    }
+
+    /// Persists an M1 `ExactArtifactProcedure` metadata record
+    /// (graph-schema.md §2.6's `exact_artifact` `ProcedureKind`), keyed by
+    /// its owning procedure id.
+    pub fn put_exact_artifact(
+        &self,
+        artifact: ExactArtifactProcedure,
+    ) -> Result<(), GraphStoreError> {
+        let key = NodeKey::exact_artifact(artifact.procedure_id);
+        self.put_node(key, GraphNode::ExactArtifact(artifact))
+    }
+
+    /// Persists a projection-facing `Artifact` record (graph-schema.md §2.9).
+    pub fn put_artifact(&self, artifact: Artifact) -> Result<(), GraphStoreError> {
+        let key = NodeKey::artifact(artifact.owning_procedure, artifact.blob);
+        self.put_node(key, GraphNode::Artifact(artifact))
+    }
+
+    /// Persists a `LogicalChange` entity (graph-schema.md §2.3).
+    pub fn put_logical_change(&self, change: LogicalChange) -> Result<(), GraphStoreError> {
+        let key = NodeKey::logical_change(change.id);
+        self.put_node(key, GraphNode::LogicalChange(change))
+    }
+
+    /// Persists a mutable `Ref` (graph-schema.md §2.5), scoped to the
+    /// repository that owns it, and records the `Repository HAS_REF Ref`
+    /// edge.
+    pub fn put_ref(&self, repository_name: &str, reference: Ref) -> Result<(), GraphStoreError> {
+        let key = NodeKey::reference(repository_name, &reference.name);
+        self.put_edge(EdgeRecord::new(
+            NodeKey::repository(repository_name),
+            EdgeKind::RepositoryHasRef,
+            key.clone(),
+        ))?;
+        self.put_node(key, GraphNode::Ref(reference))
+    }
+
+    /// Persists a `Blob`'s raw bytes (graph-schema.md §2.10) under its own
+    /// content-derived `BlobHash`, recomputed from the given bytes so a
+    /// caller can never persist content under a mismatched key.
+    pub fn put_blob(&self, blob: Blob) -> Result<BlobHash, GraphStoreError> {
+        let hash = blob.hash();
+        let key = NodeKey::blob(hash);
+        self.put_node(key, GraphNode::Blob(BlobRecord { content: blob.content }))?;
+        Ok(hash)
+    }
+
+    /// Persists an M1-imported empty directory bookkeeping fact, scoped to
+    /// the repository whose tree was imported, and records the
+    /// `RepositoryContainsProcedure`-style containment edge for it.
+    pub fn put_empty_directory(
+        &self,
+        repository_name: &str,
+        path: &str,
+    ) -> Result<(), GraphStoreError> {
+        let key = NodeKey::empty_directory(repository_name, path);
+        self.put_edge(EdgeRecord::new(
+            NodeKey::repository(repository_name),
+            EdgeKind::RepositoryContainsEmptyDirectory,
+            key.clone(),
+        ))?;
+        self.put_node(
+            key,
+            GraphNode::EmptyDirectory(EmptyDirectoryRecord {
+                repository_name: repository_name.to_owned(),
+                path: path.to_owned(),
+            }),
+        )
+    }
+
     /// Explicitly persists a graph edge in PluresDB.
     pub fn put_edge(&self, edge: EdgeRecord) -> Result<(), GraphStoreError> {
         let key = edge.storage_key();
@@ -95,15 +181,92 @@ impl GraphStore {
     pub fn get_procedure(&self, id: ProcedureId) -> Result<Option<Procedure>, GraphStoreError> {
         match self.get_node(&NodeKey::procedure(id))? {
             Some(GraphNode::Procedure(procedure)) => Ok(Some(procedure)),
-            Some(GraphNode::Revision(_)) | None => Ok(None),
+            Some(_) | None => Ok(None),
         }
     }
 
     pub fn get_revision(&self, id: RevisionId) -> Result<Option<RevisionContent>, GraphStoreError> {
         match self.get_node(&NodeKey::revision(id))? {
             Some(GraphNode::Revision(revision)) => Ok(Some(revision)),
-            Some(GraphNode::Procedure(_)) | None => Ok(None),
+            Some(_) | None => Ok(None),
         }
+    }
+
+    pub fn get_procedure_revision(
+        &self,
+        hash: ProcedureRevisionHash,
+    ) -> Result<Option<ProcedureRevisionContent>, GraphStoreError> {
+        match self.get_node(&NodeKey::procedure_revision(hash))? {
+            Some(GraphNode::ProcedureRevision(content)) => Ok(Some(content)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    pub fn get_exact_artifact(
+        &self,
+        procedure_id: ProcedureId,
+    ) -> Result<Option<ExactArtifactProcedure>, GraphStoreError> {
+        match self.get_node(&NodeKey::exact_artifact(procedure_id))? {
+            Some(GraphNode::ExactArtifact(artifact)) => Ok(Some(artifact)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    pub fn get_artifact(
+        &self,
+        owning_procedure: ProcedureId,
+        blob: BlobHash,
+    ) -> Result<Option<Artifact>, GraphStoreError> {
+        match self.get_node(&NodeKey::artifact(owning_procedure, blob))? {
+            Some(GraphNode::Artifact(artifact)) => Ok(Some(artifact)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    pub fn get_logical_change(
+        &self,
+        id: LogicalChangeId,
+    ) -> Result<Option<LogicalChange>, GraphStoreError> {
+        match self.get_node(&NodeKey::logical_change(id))? {
+            Some(GraphNode::LogicalChange(change)) => Ok(Some(change)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    pub fn get_ref(
+        &self,
+        repository_name: &str,
+        ref_name: &str,
+    ) -> Result<Option<Ref>, GraphStoreError> {
+        match self.get_node(&NodeKey::reference(repository_name, ref_name))? {
+            Some(GraphNode::Ref(reference)) => Ok(Some(reference)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    pub fn get_blob(&self, hash: BlobHash) -> Result<Option<Blob>, GraphStoreError> {
+        match self.get_node(&NodeKey::blob(hash))? {
+            Some(GraphNode::Blob(record)) => Ok(Some(Blob { content: record.content })),
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    pub fn get_empty_directories(
+        &self,
+        repository_name: &str,
+    ) -> Result<Vec<String>, GraphStoreError> {
+        let children = self.get_children(
+            &NodeKey::repository(repository_name),
+            EdgeKind::RepositoryContainsEmptyDirectory,
+        )?;
+        let mut paths = Vec::with_capacity(children.len());
+        for key in children {
+            if let Some(GraphNode::EmptyDirectory(record)) = self.get_node(&key)? {
+                paths.push(record.path);
+            }
+        }
+        paths.sort();
+        Ok(paths)
     }
 
     /// Returns direct children of `from` for an edge kind. The selection rule


### PR DESCRIPTION
## Summary (M3, epic pares-radix:procedure-graph-repository-substrate)

Follows PR #601's own M3 follow-up note. Builds on M0 (px-repo-model), M1 (px-adapter-exact), M2 (px-graph-store).

### 1. Extended typed storage vocabulary (px-graph-store)
Added node kinds for the remaining M0 entities: 'ProcedureRevision' detail records, 'Artifact', 'Ref', 'LogicalChange', plus the M1 'ExactArtifactProcedure' metadata record. All payload types reused verbatim from 'px-repo-model' (no parallel schema). Also added 'BlobRecord' (raw byte container) and 'EmptyDirectoryRecord' (M1 bookkeeping fact) as storage-only additions with no M0 entity of their own, documented as such.

### 2. Real persistence wired into import/materialize (px-adapter-exact)
New 'persistence' module: 'persist_imported_tree' writes an 'ImportedTree' into a real 'GraphStore' following exact-artifact-procedure.md section 2's relationships (Procedure + ExactArtifactProcedure + Artifact + ProcedureRevision + RepositoryContainsProcedure edge). 'materialize_from_store' reconstructs an 'ImportedTree' purely from the persisted graph, no reference to the original filesystem or in-memory tree.

### 3. End-to-end test
'tests/persisted_round_trip.rs': imports a real fixture repo (5 files incl. binary + CRLF + no-trailing-newline content, 1 empty dir), persists into a durable PluresDB/Sled-backed store, re-opens the store (proves durability), verifies queryability (procedures, exact artifacts, procedure revisions, blobs, RepositoryContainsProcedure children) and Merkle root correctness via 'current_procedure_root', then materializes purely from the store and asserts byte-identical output vs. the original fixture (files + empty directories).

### Validation
- 'cargo test' clean on both crates (px-graph-store: 4 store tests; px-adapter-exact: 3 M1 round-trip tests + 1 new M3 e2e test)
- 'cargo clippy --all-targets -- -D warnings' clean on both crates
- No stubs: every persisted record type is a real, queryable, durable write; nothing fakes a schema or returns canned data (C-NOSTUB-001)
- PluresDB is the only persistent state used (C-PLURES-003/004); no parallel storage introduced

### M4 (suggested next)
- 'Ref' and 'LogicalChange' node kinds are now storable but nothing yet writes them from a real adapter flow (no adapter currently produces refs or logical changes) - M4 should wire an adapter (or a new small one) that actually populates these, or explicitly scope them out if no near-term adapter needs them.
- The 'ProcedureRevisionContent.source_text' currently uses px-repo-model's canonical JSON encoding as the exact-artifact adapter's structured-metadata serialization (documented in persistence.rs), since the full '.px' grammar is out of scope for px-adapter-exact. If a future adapter needs true '.px' source text, that adapter should supply its own 'source_text', not px-adapter-exact.
- Consider adding a query surface for 'Ref'/'LogicalChange' by ownership (e.g. get_refs_for_repository) once a real writer exists, mirroring the RepositoryContainsProcedure children pattern used here.
