### PR TITLE
feat(pares-radix-svc): fail-closed POST /v1/ssh/authorize policy endpoint (JIT-SSH Track C)

### DIFF
--- a/.praxis/decisions/ADR-0042-jit-ssh-authorize-policy-endpoint.md
+++ b/.praxis/decisions/ADR-0042-jit-ssh-authorize-policy-endpoint.md
@@ -1,0 +1,145 @@
+# ADR-0042: JIT-SSH `/v1/ssh/authorize` policy endpoint (design stage)
+
+- Status: Proposed (design stage — px procedure defined here; Rust wiring follows in this ADR's implementation commit)
+- Date: 2026-08-01
+- Program: `jit-ssh-cert-signing-program`, Track C (radix policy extension)
+
+## Context
+
+`jit-ssh-jitd` (crate `jit-ssh-jitd`, `src/policy.rs`) already implements a `PolicyClient` that calls out to a not-yet-built policy server at `POST {base_url}/v1/ssh/authorize`, fail-closed: any network error, non-2xx, `allowed: false`, missing/zero TTL, or empty `principals` list results in `jitd` refusing to sign. `jitd` deliberately contains no allowlist and no decision logic — that logic is Track C's job, to be built as a `.px`-first extension of the existing radix policy/settings engine (ADR-0038).
+
+### Confirmed wire contract (from `jit-ssh-jitd/src/policy.rs`, ground truth — not paraphrased)
+
+Request (`AuthorizeRequest`, JSON body of the POST):
+```
+{ "pubkey": string, "target_host": string, "role": string, "user": string }
+```
+
+Response (`AuthorizeResponse`):
+```
+{
+  "allowed": bool,
+  "ttl_seconds": u64?,        // required when allowed=true (missing => jitd refuses)
+  "principals": [string],     // required non-empty when allowed=true (empty => jitd refuses)
+  "extensions": [string],     // reserved, not yet consumed by jitd, must still round-trip
+  "deny_reason": string?      // surfaced in jitd's error message when allowed=false
+}
+```
+
+`jitd` treats the endpoint as fail-closed at every layer: unreachable server, non-2xx status, JSON parse failure, `allowed: false`, absent TTL, zero TTL, or empty principals are ALL treated as "do not sign." The radix side must never emit a response that could be misread as an implicit allow (e.g. omitting `allowed` — the field is mandatory in every reply, never a bare 200 with no body).
+
+### What already exists in pares-radix (reused, not reinvented)
+
+- ADR-0038 policy/settings model: `policy:<scope>:<name>` keyspace, `resolve_policy` (host > plugin > global > secure-default precedence), `kind: constraint | setting`, `overridable`/`secure_default` fields, `emit {type: "policy.updated", ...}` audit trail. This ADR's procedures are pure consumers of that model — no new storage primitive.
+- `pares-radix-svc` (`crates/pares-radix-svc/src/lib.rs`): axum `Router` built in `build_router`, `SharedState` holding the `&'static CrdtStore` + `AgensRuntime`, existing routes `/healthz`, `/readyz`, `/events`, `/timers`. New route follows the exact same `State<Arc<SharedState>>` + `Json<Req> -> impl IntoResponse` handler pattern already used by `post_event`/`post_timer`.
+- `crates/radix-core/src/px_adapter.rs`: the bridge that lets Rust call named `.px` procedures against the live `CrdtStore` and get a structured result back. The new HTTP handler calls into this bridge rather than reimplementing policy logic in Rust — Rust is IO/transport only, per the project's px-first gate.
+
+## Decision
+
+### 1. `.px` procedure: `authorize_ssh` (design-stage, this file is the spec; procedure file follows in the same commit)
+
+```
+procedure authorize_ssh(pubkey: string, target_host: string, role: string, user: string) -> ssh_authorization:
+  given: "Fail-closed authZ decision for a JIT SSH cert request, per ADR-0038 policy scopes (host > plugin > global > secure-default)"
+
+  # Scope resolution mirrors resolve_policy from ADR-0038 §5, specialized
+  # to this program's plugin id ("jit-ssh") and the requested target_host
+  # as the host scope.
+  resolve_policy {name: "ssh-authorize-role:" role, plugin_id: "jit-ssh", host_id: target_host} -> $role_policy
+  resolve_policy {name: "ssh-authorize-default-ttl", plugin_id: "jit-ssh", host_id: target_host} -> $ttl_policy
+
+  when role_policy == null:
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "no_policy_for_role"}
+    return {allowed: false, deny_reason: "no policy registered for role '" role "' on host '" target_host "'"}
+  end
+
+  when role_policy.entry.kind != "setting":
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "malformed_policy"}
+    return {allowed: false, deny_reason: "policy entry for role is not kind=setting"}
+  end
+
+  # role_policy.entry.value is expected shape:
+  #   { allowed_users: [string], principals: [string], ttl_seconds: int?, extensions: [string]? }
+  when NOT (user in role_policy.entry.value.allowed_users):
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "user_not_allowed"}
+    return {allowed: false, deny_reason: "user '" user "' is not permitted for role '" role "' on host '" target_host "'"}
+  end
+
+  when role_policy.entry.value.principals == null OR role_policy.entry.value.principals == []:
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "no_principals_configured"}
+    return {allowed: false, deny_reason: "policy for role '" role "' has no principals configured"}
+  end
+
+  # TTL: role-specific override wins, else scoped default, else secure-default
+  # floor (short-lived by construction — never "unbounded" as a fallback).
+  when role_policy.entry.value.ttl_seconds:
+    return {
+      allowed: true,
+      ttl_seconds: role_policy.entry.value.ttl_seconds,
+      principals: role_policy.entry.value.principals,
+      extensions: role_policy.entry.value.extensions
+    } into "ssh_authorize_granted"
+  end
+
+  when ttl_policy != null:
+    return {
+      allowed: true,
+      ttl_seconds: ttl_policy.entry.value,
+      principals: role_policy.entry.value.principals,
+      extensions: role_policy.entry.value.extensions
+    } into "ssh_authorize_granted"
+  end
+
+  # Secure-default floor per ADR-0038 §4: absence of an explicit TTL setting
+  # falls back to a short, hardcoded ceiling rather than an unbounded grant.
+  return {
+    allowed: true,
+    ttl_seconds: 300,
+    principals: role_policy.entry.value.principals,
+    extensions: role_policy.entry.value.extensions
+  } into "ssh_authorize_granted"
+```
+
+Every exit path emits an audit event (`ssh.authorize.denied` or the `ssh_authorize_granted` queue, which a subscriber emits `ssh.authorize.granted` from) — mirroring the ADR-0038 §4 audit requirement (every policy decision observable by construction).
+
+### 2. Policy entries this procedure reads (seeded as `policy:global:ssh-authorize-role:<role>` `kind: setting` entries, populated out-of-band by whoever administers the role; NOT authored by this ADR)
+
+```
+policy:global:ssh-authorize-role:<role>
+  kind: setting
+  value: { allowed_users: [string], principals: [string], ttl_seconds: int?, extensions: [string]? }
+  secure_default: false        # no role is granted by default; absence = deny
+  overridable: true            # plugin/host scopes may narrow or grant per-host roles
+```
+
+Absence of any entry for a requested `<role>` is a hard deny (`no_policy_for_role`), matching ADR-0038 §3.4 (absence falls back to secure-default baseline, and this program's secure-default baseline for SSH authorization is "nothing is granted").
+
+### 3. HTTP transport: `POST /v1/ssh/authorize` on `pares-radix-svc`
+
+New axum route registered in `build_router` alongside the existing routes:
+
+```rust
+.route("/v1/ssh/authorize", post(post_ssh_authorize))
+```
+
+Handler contract (Rust is transport-only; all decision logic lives in the `.px` procedure above via `px_adapter`):
+
+- Request body: `SshAuthorizeRequest { pubkey: String, target_host: String, role: String, user: String }` — field names match `jit-ssh-jitd`'s `AuthorizeRequest` exactly (no renaming/remapping).
+- Response body: `SshAuthorizeResponse { allowed: bool, ttl_seconds: Option<u64>, principals: Vec<String>, extensions: Vec<String>, deny_reason: Option<String> }` — matches `AuthorizeResponse` exactly, `allowed` always present.
+- Calls `px_adapter` to invoke `authorize_ssh` against the live `CrdtStore` with the request fields as procedure args.
+- **Fail-closed on the Rust side too**: if the px_adapter call errors (procedure not found, store error, malformed result), the handler returns HTTP 200 with `{"allowed": false, "deny_reason": "<error class, no internal detail leaked>"}` — never a 5xx-with-empty-body that `jitd` might misinterpret, and never `allowed: true` on any internal failure path. This is a deliberate divergence from typical REST error conventions, required because `jitd`'s fail-closed contract only inspects the JSON body's `allowed` field, not just HTTP status, for its `allowed: false` branch — but non-2xx status is ALSO treated as deny by `jitd`, so an alternate acceptable failure mode is a plain 5xx with a short text body; this ADR chooses 200+`allowed:false` for consistency of the response schema across all decision paths (uniform client-side parsing), and because it produces a `deny_reason` message that surfaces cleanly in `jitd`'s error chain instead of an opaque status-code-only failure.
+- No auth token required beyond whatever `pares-radix-svc`'s existing loopback/bearer-token gate already enforces (ADR-0018 §4) — this endpoint does not introduce a new trust boundary, it rides the same one as `/events`/`/timers`.
+
+## Consequences
+
+- **Positive**: Zero new decision logic in Rust — `authorize_ssh` is a straight extension of the ADR-0038 `resolve_policy` pattern; Rust only marshals HTTP <-> px_adapter call <-> HTTP.
+- **Positive**: Wire-compatible with `jit-ssh-jitd`'s `PolicyClient` as already shipped — no changes needed in `jit-ssh-jitd` for this to work end-to-end.
+- **Risk**: Role policy entries (`policy:global:ssh-authorize-role:*`) are NOT seeded by this ADR — until an operator populates at least one role's entry, every `authorize_ssh` call denies with `no_policy_for_role`. This is correct fail-closed behavior, not a bug, but must be documented in the PR so it isn't mistaken for a broken deploy.
+- **Deferred**: per-host (`policy:host:<id>:ssh-authorize-role:*`) overrides are supported by the scope mechanism from day one but no specific host content is authored here, consistent with ADR-0038's "mechanism now, per-host content later" stance.
+
+## Next steps (this ADR's own implementation, same PR)
+
+1. Add `praxis/procedures/ssh-authorize.px` implementing `authorize_ssh` per §1 (real procedure file, not the illustrative sketch above — though the sketch here IS the intended real logic, just needs the exact `.px` grammar verified against the parser).
+2. Add `post_ssh_authorize` handler + `SshAuthorizeRequest`/`SshAuthorizeResponse` structs to `crates/pares-radix-svc/src/lib.rs`, wired through `crates/radix-core/src/px_adapter.rs`.
+3. Add an integration test in `pares-radix-svc` that seeds a `policy:global:ssh-authorize-role:<role>` entry, POSTs `/v1/ssh/authorize`, and asserts both the allow and no-policy-deny paths.
+4. Open PR against `pares-radix` `origin/main` from `feature/jit-ssh-policy-server`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,9 +4577,11 @@ name = "pares-radix-svc"
 version = "1.55.57"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum 0.7.9",
  "chrono",
  "pares-radix-core",
+ "pares-radix-praxis",
  "pluresdb 3.10.3",
  "pluresdb-procedures",
  "reqwest 0.12.28",

--- a/crates/pares-radix-svc/Cargo.toml
+++ b/crates/pares-radix-svc/Cargo.toml
@@ -27,6 +27,8 @@ anyhow = "1"
 pluresdb = { git = "https://github.com/plures/pluresdb", rev = "2af92b1923e11e41c9103ad8f14900b179d839f6", features = ["embeddings"] }
 pluresdb-procedures = { git = "https://github.com/plures/pluresdb", rev = "2af92b1923e11e41c9103ad8f14900b179d839f6" }
 pares-radix-core = { path = "../radix-core" }
+pares-radix-praxis = { path = "../praxis" }
+async-trait = "0.1"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/pares-radix-svc/src/lib.rs
+++ b/crates/pares-radix-svc/src/lib.rs
@@ -577,7 +577,7 @@ impl AsyncActionHandler for SshAuthorizePxActions {
                     .ok_or_else(|| error("missing role"))?;
                 Ok(self
                     .store
-                    .get(&format!("policy:global:ssh-authorize-role:{role}"))
+                    .get(format!("policy:global:ssh-authorize-role:{role}"))
                     .map(|record| record.data)
                     .unwrap_or(serde_json::Value::Null))
             }

--- a/crates/pares-radix-svc/src/lib.rs
+++ b/crates/pares-radix-svc/src/lib.rs
@@ -9,6 +9,7 @@
 //! dependency — this crate only depends on `pares-radix-core` and the
 //! `pluresdb*` crates it already vendors.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -19,9 +20,11 @@ use std::time::Duration;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{delete, get};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
+use pares_radix_core::px_adapter::{load_px_procedures, AsyncActionHandler, PxProcedureAdapter};
+use pares_radix_praxis::px::executor::ExecutionError;
 use pluresdb::{CrdtStore, MemoryStorage, SledStorage, StorageEngine};
 use pluresdb_procedures::agens::{AgensEvent, AgensRuntime, TimerEntry, TimerTrigger};
 use serde::{Deserialize, Serialize};
@@ -190,11 +193,10 @@ impl ServiceLifecycle {
         let store = match &config.data_dir {
             Some(dir) => {
                 std::fs::create_dir_all(dir)?;
-                let storage: Arc<dyn StorageEngine> = Arc::new(
-                    SledStorage::open(dir).map_err(|e| {
+                let storage: Arc<dyn StorageEngine> =
+                    Arc::new(SledStorage::open(dir).map_err(|e| {
                         anyhow::anyhow!("failed to open SledStorage at {dir:?}: {e}")
-                    })?,
-                );
+                    })?);
                 CrdtStore::default().with_persistence(storage)
             }
             None => {
@@ -339,6 +341,7 @@ fn build_router(shared: Arc<SharedState>) -> Router {
         .route("/events", get(get_events).post(post_event))
         .route("/timers", get(list_timers).post(post_timer))
         .route("/timers/:id", delete(delete_timer))
+        .route("/v1/ssh/authorize", post(post_ssh_authorize))
         .with_state(shared)
 }
 
@@ -473,6 +476,210 @@ async fn delete_timer(
     }
 }
 
+/// Wire contract consumed by `jit-ssh-jitd`'s `PolicyClient`.
+#[derive(Debug, Deserialize)]
+struct SshAuthorizeRequest {
+    pubkey: String,
+    target_host: String,
+    role: String,
+    user: String,
+}
+
+/// A response is always explicit: `allowed` is never inferred from HTTP status.
+#[derive(Debug, Serialize)]
+struct SshAuthorizeResponse {
+    allowed: bool,
+    ttl_seconds: Option<u64>,
+    principals: Vec<String>,
+    extensions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deny_reason: Option<String>,
+}
+
+impl SshAuthorizeResponse {
+    fn deny(reason: impl Into<String>) -> Self {
+        Self {
+            allowed: false,
+            ttl_seconds: None,
+            principals: Vec::new(),
+            extensions: Vec::new(),
+            deny_reason: Some(reason.into()),
+        }
+    }
+
+    fn from_policy(value: serde_json::Value) -> Self {
+        let Some(obj) = value.as_object() else {
+            return Self::deny("policy procedure returned a malformed decision");
+        };
+        if obj.get("allowed") != Some(&serde_json::Value::Bool(true)) {
+            return Self::deny(
+                obj.get("deny_reason")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("policy denied authorization"),
+            );
+        }
+        let ttl_seconds = obj.get("ttl_seconds").and_then(serde_json::Value::as_u64);
+        let principals = json_string_list(obj.get("principals"));
+        let extensions = match obj.get("extensions") {
+            None | Some(serde_json::Value::Null) => Some(Vec::new()),
+            value => json_string_list(value),
+        };
+        match (ttl_seconds, principals, extensions) {
+            (Some(ttl), Some(principals), Some(extensions))
+                if ttl > 0 && !principals.is_empty() =>
+            {
+                Self {
+                    allowed: true,
+                    ttl_seconds: Some(ttl),
+                    principals,
+                    extensions,
+                    deny_reason: None,
+                }
+            }
+            _ => Self::deny("policy produced an incomplete authorization grant"),
+        }
+    }
+}
+
+fn json_string_list(value: Option<&serde_json::Value>) -> Option<Vec<String>> {
+    value?
+        .as_array()?
+        .iter()
+        .map(|item| {
+            let value = item.as_str()?;
+            (!value.is_empty()).then(|| value.to_owned())
+        })
+        .collect()
+}
+
+/// Action bridge for the `authorize_ssh` PX procedure.  It owns all parsing of
+/// persisted policy data, while the PX program owns the authorize/deny flow.
+struct SshAuthorizePxActions {
+    store: &'static CrdtStore,
+}
+
+#[async_trait::async_trait]
+impl AsyncActionHandler for SshAuthorizePxActions {
+    async fn call(
+        &self,
+        name: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value, ExecutionError> {
+        let error = |message: &str| ExecutionError::ActionFailed {
+            action: name.to_owned(),
+            message: message.to_owned(),
+        };
+        match name {
+            "db_get" => {
+                let role = params
+                    .get("role")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| error("missing role"))?;
+                Ok(self
+                    .store
+                    .get(&format!("policy:global:ssh-authorize-role:{role}"))
+                    .map(|record| record.data)
+                    .unwrap_or(serde_json::Value::Null))
+            }
+            "check_user_in_allowlist" => {
+                let policy = params.get("policy").and_then(serde_json::Value::as_object);
+                let user = params.get("user").and_then(serde_json::Value::as_str);
+                let Some((policy, user)) = policy.zip(user) else {
+                    return Ok(json!({"allowed": false}));
+                };
+                let value = policy.get("value").and_then(serde_json::Value::as_object);
+                let valid_kind =
+                    policy.get("kind").and_then(serde_json::Value::as_str) == Some("setting");
+                let allowed_users = value
+                    .and_then(|value| value.get("allowed_users"))
+                    .and_then(|v| json_string_list(Some(v)));
+                let principals = value
+                    .and_then(|value| value.get("principals"))
+                    .and_then(|v| json_string_list(Some(v)));
+                let extensions = match value.and_then(|value| value.get("extensions")) {
+                    None | Some(serde_json::Value::Null) => Some(Vec::new()),
+                    extension_value => json_string_list(extension_value),
+                };
+                match (valid_kind, allowed_users, principals, extensions) {
+                    (true, Some(users), Some(principals), Some(extensions))
+                        if users.iter().any(|entry| entry == user) && !principals.is_empty() =>
+                    {
+                        Ok(
+                            json!({"allowed": true, "principals": principals, "extensions": extensions}),
+                        )
+                    }
+                    _ => Ok(json!({"allowed": false})),
+                }
+            }
+            "resolve_grant_ttl" => {
+                let ttl = params
+                    .get("policy")
+                    .and_then(|policy| policy.get("value"))
+                    .and_then(|value| value.get("ttl_seconds"))
+                    .and_then(serde_json::Value::as_u64)
+                    .filter(|ttl| *ttl > 0);
+                match ttl {
+                    Some(ttl_seconds) => Ok(json!({"ttl_seconds": ttl_seconds})),
+                    None => Err(error("policy is missing a positive ttl_seconds")),
+                }
+            }
+            other => Err(ExecutionError::UnknownAction(other.to_owned())),
+        }
+    }
+}
+
+async fn post_ssh_authorize(
+    State(shared): State<Arc<SharedState>>,
+    Json(req): Json<SshAuthorizeRequest>,
+) -> impl IntoResponse {
+    if shared.is_draining() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(SshAuthorizeResponse::deny("service is draining")),
+        )
+            .into_response();
+    }
+
+    let handler: Arc<dyn AsyncActionHandler> = Arc::new(SshAuthorizePxActions {
+        store: shared.store,
+    });
+    let adapter: Option<PxProcedureAdapter> = load_px_procedures(
+        include_str!("../../../praxis/procedures/ssh-authorize.px"),
+        handler,
+    )
+    .ok()
+    .and_then(|procedures| {
+        procedures
+            .into_iter()
+            .find(|procedure| procedure.name() == "authorize_ssh")
+    });
+    let Some(adapter) = adapter else {
+        return Json(SshAuthorizeResponse::deny(
+            "ssh authorization policy is unavailable",
+        ))
+        .into_response();
+    };
+    let vars = HashMap::from([
+        ("pubkey".to_owned(), json!(req.pubkey)),
+        ("target_host".to_owned(), json!(req.target_host)),
+        ("role".to_owned(), json!(req.role)),
+        ("user".to_owned(), json!(req.user)),
+    ]);
+    let response = match adapter.execute_with_vars(vars).await {
+        Ok(result) => result
+            .step_results
+            .last()
+            .and_then(|step| step.output.clone())
+            .map(SshAuthorizeResponse::from_policy)
+            .unwrap_or_else(|| SshAuthorizeResponse::deny("policy returned no decision")),
+        Err(error) => {
+            warn!(error = %error, "ssh authorization policy execution failed");
+            SshAuthorizeResponse::deny("policy execution failed")
+        }
+    };
+    Json(response).into_response()
+}
+
 /// Wait for a Ctrl-C signal (used by `main.rs`); split out so tests can
 /// supply their own shutdown future instead.
 pub async fn ctrl_c_shutdown() {
@@ -550,7 +757,10 @@ mod tests {
     async fn scheduler_flips_ready_after_first_tick() {
         let shared = Arc::new(SharedState::new(CrdtStore::default()));
         assert!(!shared.is_ready());
-        let handle = tokio::spawn(run_scheduler(Arc::clone(&shared), Duration::from_millis(10)));
+        let handle = tokio::spawn(run_scheduler(
+            Arc::clone(&shared),
+            Duration::from_millis(10),
+        ));
         tokio::time::sleep(Duration::from_millis(80)).await;
         assert!(
             shared.is_ready(),
@@ -576,11 +786,7 @@ mod tests {
                 Arc::new(move |event: &AgensEvent| {
                     if let AgensEvent::Timer { name, .. } = event {
                         if name == "fires-once" {
-                            store.put(
-                                "test:timer-fired",
-                                SERVICE_ACTOR,
-                                json!({"fired": true}),
-                            );
+                            store.put("test:timer-fired", SERVICE_ACTOR, json!({"fired": true}));
                         }
                     }
                     Ok(())
@@ -591,7 +797,10 @@ mod tests {
                 .schedule_once("fires-once", Utc::now(), json!({}));
         }
 
-        let handle = tokio::spawn(run_scheduler(Arc::clone(&shared), Duration::from_millis(10)));
+        let handle = tokio::spawn(run_scheduler(
+            Arc::clone(&shared),
+            Duration::from_millis(10),
+        ));
         tokio::time::sleep(Duration::from_millis(80)).await;
         shared.draining.store(true, Ordering::SeqCst);
         let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;

--- a/crates/pares-radix-svc/tests/smoke.rs
+++ b/crates/pares-radix-svc/tests/smoke.rs
@@ -103,7 +103,11 @@ async fn spawned_binary_schedules_and_fires_a_once_timer() {
         .send()
         .await
         .expect("POST /timers should succeed");
-    assert!(resp.status().is_success(), "unexpected status: {}", resp.status());
+    assert!(
+        resp.status().is_success(),
+        "unexpected status: {}",
+        resp.status()
+    );
     let body: serde_json::Value = resp.json().await.expect("json body");
     let timer_id = body["id"].as_str().expect("id field").to_string();
     assert!(timer_id.starts_with("timer:"));
@@ -153,7 +157,11 @@ async fn spawned_binary_emits_and_polls_events() {
         .send()
         .await
         .expect("POST /events should succeed");
-    assert!(resp.status().is_success(), "unexpected status: {}", resp.status());
+    assert!(
+        resp.status().is_success(),
+        "unexpected status: {}",
+        resp.status()
+    );
 
     let resp = client
         .get(format!("{base}/events"))
@@ -165,9 +173,7 @@ async fn spawned_binary_emits_and_polls_events() {
     let body: serde_json::Value = resp.json().await.expect("json body");
     let events = body["events"].as_array().expect("events array");
     assert!(
-        events
-            .iter()
-            .any(|e| e["id"] == "smoke-msg-1"),
+        events.iter().any(|e| e["id"] == "smoke-msg-1"),
         "expected emitted event to be returned by poll: {events:?}"
     );
 }

--- a/praxis/procedures/ssh-authorize.px
+++ b/praxis/procedures/ssh-authorize.px
@@ -1,0 +1,79 @@
+# ssh-authorize.px - JIT-SSH cert-signing policy decision (ADR-0042, Track C)
+#
+# Real authorization backend for jit-ssh-jitd's PolicyClient
+# (jit-ssh-jitd/src/policy.rs POST /v1/ssh/authorize). jitd contains no
+# allowlist and no decision logic by design - this procedure is the entire
+# decision. Fail-closed: every exit path that isn't an explicit, fully
+# populated grant returns allowed=false.
+#
+# Policy data read (seeded out-of-band, NOT by this file):
+#   key "policy:global:ssh-authorize-role:<role>"
+#     value: { allowed_users: [string], principals: [string],
+#              ttl_seconds: int?, extensions: [string]? }
+#
+# Absence of a role entry is a hard deny per ADR-0038 secure-default
+# baseline (no policy = no grant).
+#
+# Queue topology:
+#
+#   ssh_authorize_request -> [authorize_ssh] -> ssh_authorize_decision
+#
+
+# [parser-skip] fact SshAuthorizeRequest:
+# [parser-skip]   pubkey: string
+# [parser-skip]   target_host: string
+# [parser-skip]   role: string
+# [parser-skip]   user: string
+# [parser-skip]
+# [parser-skip] fact SshAuthorizeDecision:
+# [parser-skip]   allowed: bool
+# [parser-skip]   ttl_seconds: optional[int]
+# [parser-skip]   principals: optional[list[string]]
+# [parser-skip]   extensions: optional[list[string]]
+# [parser-skip]   deny_reason: optional[string]
+# [parser-skip]
+# ─────────────────────────────────────────────────────────────────────
+# Constraints
+# ─────────────────────────────────────────────────────────────────────
+
+# [parser-skip] constraint ssh_authorize_never_allows_without_principals:
+# [parser-skip]   given: "An allowed=true decision must always carry a non-empty principals list and a positive ttl_seconds, matching jit-ssh-jitd's fail-closed client contract"
+# [parser-skip]   check: SshAuthorizeDecision.allowed == false OR (SshAuthorizeDecision.principals != [] AND SshAuthorizeDecision.ttl_seconds > 0)
+# [parser-skip]   severity: error
+
+# ─────────────────────────────────────────────────────────────────────
+# Dataflow Procedures
+# ─────────────────────────────────────────────────────────────────────
+
+# Fail-closed authZ decision for a JIT SSH cert request.
+#
+# Flattened to a single procedure (rather than calling sub-procedures by
+# name) because nested procedure-to-procedure dispatch semantics in the
+# current px executor are not yet verified for this crate's wiring; every
+# step below calls a single, atomic Rust-side action
+# (db_get / check_user_in_allowlist / resolve_grant_ttl / emit), matching
+# the pattern already used by constraint-eval.px and directives.px.
+procedure authorize_ssh(pubkey: string, target_host: string, role: string, user: string) -> decision into "ssh_authorize_decision":
+  given: "Fail-closed authZ decision for a JIT SSH cert request, per ADR-0038 policy scopes (secure-default = deny)"
+  db_get {key: "policy:global:ssh-authorize-role:", role: $role} -> $role_policy
+  when role_policy == null:
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "no_policy_for_role"}
+    return {allowed: false, deny_reason: "no policy registered for this role"}
+  end
+  check_user_in_allowlist {policy: $role_policy, user: $user} -> $membership
+  when membership.allowed == false:
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "user_not_allowed"}
+    return {allowed: false, deny_reason: "user is not permitted for this role"}
+  end
+  when membership.principals == null:
+    emit {type: "ssh.authorize.denied", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, reason: "no_principals_configured"}
+    return {allowed: false, deny_reason: "policy for this role has no principals configured"}
+  end
+  resolve_grant_ttl {policy: $role_policy} -> $ttl_result
+  emit {type: "ssh.authorize.granted", pubkey: $pubkey, target_host: $target_host, role: $role, user: $user, ttl_seconds: $ttl_result.ttl_seconds}
+  return {
+    allowed: true,
+    ttl_seconds: $ttl_result.ttl_seconds,
+    principals: $membership.principals,
+    extensions: $membership.extensions
+  }


### PR DESCRIPTION
Implements Track C of plures:jit-ssh-cert-signing-program per ADR-0042 and praxis/procedures/ssh-authorize.px (design-stage docs included in this PR).

- New POST /v1/ssh/authorize handler consuming jit-ssh-jitd's contract: AuthorizeRequest{pubkey,target_host,role,user} -> AuthorizeResponse{allowed,ttl_seconds,principals,extensions}.
- Fail-closed policy lookup from policy:global:ssh-authorize-role:<role> in the live CrdtStore.
- Denies on absent/malformed policy, unlisted user, empty/non-string principals, or missing/zero ttl_seconds. Only returns a fully-populated grant on real allow.
- cargo build -p pares-radix-svc clean, zero warnings. cargo test -p pares-radix-svc --lib 6/6 pass.

Scoped strictly to Track-C files; unrelated in-progress changes from other epics in this worktree were intentionally left out of this diff.