### PR TITLE
feat(design-dojo): 6 new components (pipeline/epic/schema-diff/praxis-rule/gate-banner/json-tree)

### DIFF
--- a/packages/design-dojo/UPSTREAM_MAP.json
+++ b/packages/design-dojo/UPSTREAM_MAP.json
@@ -8,13 +8,13 @@
       "upstreamPath": "src/lib/app/SettingsPanel.svelte",
       "status": "drifted",
       "removeAfterNpmVersion": "0.13.0",
-      "notes": "Founding shim comment said remove at npm v0.13+; npm is at 0.17.1. Stale — flagged by drift check."
+      "notes": "Founding shim comment said remove at npm v0.13+; npm is at 0.17.1. Stale - flagged by drift check."
     },
     "Sidebar.svelte": {
       "upstreamPath": "src/lib/layout/Sidebar.svelte",
       "status": "drifted",
       "removeAfterNpmVersion": "0.13.0",
-      "notes": "285 differing lines vs standalone (ADR-0035 audit). Reverted twice historically (20acb73, 0eb0734) due to API incompatibility — needs triage before removal, not blind sync."
+      "notes": "285 differing lines vs standalone (ADR-0035 audit). Reverted twice historically (20acb73, 0eb0734) due to API incompatibility - needs triage before removal, not blind sync."
     },
     "Input.svelte": {
       "upstreamPath": "src/lib/primitives/Input.svelte",
@@ -86,7 +86,7 @@
       "upstreamPath": "src/lib/app/GraphView.svelte",
       "status": "reconciled",
       "removeAfterNpmVersion": "0.18.0",
-      "notes": "ADR-0035 pilot reconciliation: shim now byte-identical to standalone repo HEAD (c0c7667) modulo the local './types-local.js' vs upstream './GraphView.types.js' type-import path, which is an intentional, documented override (see DRIFT.md) required because the shim package does not (yet) ship GraphView.types.ts as a separate module. Everything else — including the upstream doc header — is synced verbatim."
+      "notes": "ADR-0035 pilot reconciliation: shim now byte-identical to standalone repo HEAD (c0c7667) modulo the local './types-local.js' vs upstream './GraphView.types.js' type-import path, which is an intentional, documented override (see DRIFT.md) required because the shim package does not (yet) ship GraphView.types.ts as a separate module. Everything else - including the upstream doc header - is synced verbatim."
     },
     "DataGrid.svelte": {
       "upstreamPath": null,
@@ -104,25 +104,31 @@
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #1) — discrete-stage pipeline status indicator, distinct from ProgressBar's continuous-percent model. Same disposition as DataGrid.svelte: local-only, upstreaming candidate not a sync target."
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #1) - discrete-stage pipeline status indicator, distinct from ProgressBar's continuous-percent model. Same disposition as DataGrid.svelte: local-only, upstreaming candidate not a sync target."
     },
     "EpicStatusBoard.svelte": {
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #2) — epic-registry-shaped status/hierarchy card list, deliberately not a Kanban board. Same disposition as DataGrid.svelte."
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #2) - epic-registry-shaped status/hierarchy card list, deliberately not a Kanban board. Same disposition as DataGrid.svelte."
     },
     "SchemaDiffView.svelte": {
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #3) — visual renderer for schema-delta.ts's SchemaDelta operation vocabulary (add/update/rename/retype/remove/reorder_field), for reviewing pending schema customizations (ADR-0031 §6) before persisting + migration. Same disposition as DataGrid.svelte."
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #3) - visual renderer for schema-delta.ts's SchemaDelta operation vocabulary (add/update/rename/retype/remove/reorder_field), for reviewing pending schema customizations (ADR-0031 §6) before persisting + migration. Same disposition as DataGrid.svelte."
     },
     "PraxisRuleCard.svelte": {
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #4) — composite renderer for a single Praxis .px constraint/ADR (id, severity, live pass/fail status, evidence table), built from existing CodeBlock + Badge + Callout. Distinct from the npm-package repo's PraxisDevOverlay/PraxisBox (2026-08-04 batch). Same disposition as DataGrid.svelte."
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #4) - composite renderer for a single Praxis .px constraint/ADR (id, severity, live pass/fail status, evidence table), built from existing CodeBlock + Badge + Callout. Distinct from the npm-package repo's PraxisDevOverlay/PraxisBox (2026-08-04 batch). Same disposition as DataGrid.svelte."
+    },
+    "PersistentGateBanner.svelte": {
+      "upstreamPath": null,
+      "status": "local-only",
+      "removeAfterNpmVersion": null,
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #5) - non-dismissible, page-level banner for hard-gate violations (blocked epics, failing Praxis rules, ADO risk flags) that must stay visible until the host confirms resolution. Deliberately distinct from Toast/NotificationStack (transient) and Dialog (modal). Same disposition as DataGrid.svelte."
     }
   }
 }

--- a/packages/design-dojo/UPSTREAM_MAP.json
+++ b/packages/design-dojo/UPSTREAM_MAP.json
@@ -92,7 +92,7 @@
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream (ADR-0035 \u00c2\u00a72.1). Reclassified as an upstream contribution owed, not drift. Tracked as a pares-radix -> design-dojo upstreaming task, not a sync target for this check."
+      "notes": "Not present upstream (ADR-0035 \u00a72.1). Reclassified as an upstream contribution owed, not drift. Tracked as a pares-radix -> design-dojo upstreaming task, not a sync target for this check."
     },
     "SchemaForm.svelte": {
       "upstreamPath": null,

--- a/packages/design-dojo/UPSTREAM_MAP.json
+++ b/packages/design-dojo/UPSTREAM_MAP.json
@@ -111,6 +111,12 @@
       "status": "local-only",
       "removeAfterNpmVersion": null,
       "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #2) — epic-registry-shaped status/hierarchy card list, deliberately not a Kanban board. Same disposition as DataGrid.svelte."
+    },
+    "SchemaDiffView.svelte": {
+      "upstreamPath": null,
+      "status": "local-only",
+      "removeAfterNpmVersion": null,
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #3) — visual renderer for schema-delta.ts's SchemaDelta operation vocabulary (add/update/rename/retype/remove/reorder_field), for reviewing pending schema customizations (ADR-0031 §6) before persisting + migration. Same disposition as DataGrid.svelte."
     }
   }
 }

--- a/packages/design-dojo/UPSTREAM_MAP.json
+++ b/packages/design-dojo/UPSTREAM_MAP.json
@@ -92,13 +92,13 @@
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream (ADR-0035 §2.1). Reclassified as an upstream contribution owed, not drift. Tracked as a pares-radix -> design-dojo upstreaming task, not a sync target for this check."
+      "notes": "Not present upstream (ADR-0035 \u00c2\u00a72.1). Reclassified as an upstream contribution owed, not drift. Tracked as a pares-radix -> design-dojo upstreaming task, not a sync target for this check."
     },
     "SchemaForm.svelte": {
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream (ADR-0035 §2.1). Same disposition as DataGrid.svelte."
+      "notes": "Not present upstream (ADR-0035 \u00c2\u00a72.1). Same disposition as DataGrid.svelte."
     },
     "PipelineStageIndicator.svelte": {
       "upstreamPath": null,
@@ -116,7 +116,7 @@
       "upstreamPath": null,
       "status": "local-only",
       "removeAfterNpmVersion": null,
-      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #3) - visual renderer for schema-delta.ts's SchemaDelta operation vocabulary (add/update/rename/retype/remove/reorder_field), for reviewing pending schema customizations (ADR-0031 §6) before persisting + migration. Same disposition as DataGrid.svelte."
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #3) - visual renderer for schema-delta.ts's SchemaDelta operation vocabulary (add/update/rename/retype/remove/reorder_field), for reviewing pending schema customizations (ADR-0031 \u00c2\u00a76) before persisting + migration. Same disposition as DataGrid.svelte."
     },
     "PraxisRuleCard.svelte": {
       "upstreamPath": null,
@@ -129,6 +129,12 @@
       "status": "local-only",
       "removeAfterNpmVersion": null,
       "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #5) - non-dismissible, page-level banner for hard-gate violations (blocked epics, failing Praxis rules, ADO risk flags) that must stay visible until the host confirms resolution. Deliberately distinct from Toast/NotificationStack (transient) and Dialog (modal). Same disposition as DataGrid.svelte."
+    },
+    "JSONTreeViewer.svelte": {
+      "upstreamPath": null,
+      "status": "local-only",
+      "removeAfterNpmVersion": null,
+      "notes": "Not present upstream. New 2026-08-07 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #6) - collapsible raw-JSON inspector for ad-hoc inspection of registry/ADR/audit blobs, distinct from SchemaForm (validated-form model requiring an EntitySchema) and CodeBlock (static, non-interactive text). Same disposition as DataGrid.svelte."
     }
   }
 }

--- a/packages/design-dojo/UPSTREAM_MAP.json
+++ b/packages/design-dojo/UPSTREAM_MAP.json
@@ -117,6 +117,12 @@
       "status": "local-only",
       "removeAfterNpmVersion": null,
       "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #3) — visual renderer for schema-delta.ts's SchemaDelta operation vocabulary (add/update/rename/retype/remove/reorder_field), for reviewing pending schema customizations (ADR-0031 §6) before persisting + migration. Same disposition as DataGrid.svelte."
+    },
+    "PraxisRuleCard.svelte": {
+      "upstreamPath": null,
+      "status": "local-only",
+      "removeAfterNpmVersion": null,
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #4) — composite renderer for a single Praxis .px constraint/ADR (id, severity, live pass/fail status, evidence table), built from existing CodeBlock + Badge + Callout. Distinct from the npm-package repo's PraxisDevOverlay/PraxisBox (2026-08-04 batch). Same disposition as DataGrid.svelte."
     }
   }
 }

--- a/packages/design-dojo/UPSTREAM_MAP.json
+++ b/packages/design-dojo/UPSTREAM_MAP.json
@@ -99,6 +99,18 @@
       "status": "local-only",
       "removeAfterNpmVersion": null,
       "notes": "Not present upstream (ADR-0035 §2.1). Same disposition as DataGrid.svelte."
+    },
+    "PipelineStageIndicator.svelte": {
+      "upstreamPath": null,
+      "status": "local-only",
+      "removeAfterNpmVersion": null,
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #1) — discrete-stage pipeline status indicator, distinct from ProgressBar's continuous-percent model. Same disposition as DataGrid.svelte: local-only, upstreaming candidate not a sync target."
+    },
+    "EpicStatusBoard.svelte": {
+      "upstreamPath": null,
+      "status": "local-only",
+      "removeAfterNpmVersion": null,
+      "notes": "Not present upstream. New 2026-08-06 (epic design-dojo:preemptive-controls-and-improvements, gap-analysis candidate #2) — epic-registry-shaped status/hierarchy card list, deliberately not a Kanban board. Same disposition as DataGrid.svelte."
     }
   }
 }

--- a/packages/design-dojo/src/EpicStatusBoard.svelte
+++ b/packages/design-dojo/src/EpicStatusBoard.svelte
@@ -1,0 +1,404 @@
+<!--
+  EpicStatusBoard — status-hierarchy card renderer for epic/task registry data
+  (id, status, priority, tier, parent_epic_id chain, blocked_on, next_action).
+
+  Deliberately NOT a Kanban board: epic-registry-shaped entries carry free-text
+  `next_action` narratives + a parent/blocked-on hierarchy that a column-per-status
+  card board renders poorly. This renders a flat, filterable list of cards instead,
+  each card showing its full status/priority/tier/hierarchy/next-action at a glance.
+-->
+<script lang="ts">
+	import type { EpicStatusBoardProps, EpicEntry } from './types-local.js';
+
+	let { entries, onSelect, class: className = '' }: EpicStatusBoardProps = $props();
+
+	let statusFilter = $state<string>('all');
+	let loading = $derived(entries === undefined);
+
+	const STATUS_LABELS: Record<string, string> = {
+		in_progress: 'In progress',
+		awaiting_approval: 'Awaiting approval',
+		pending_pr: 'Pending PR',
+		assistance_required: 'Assistance required',
+		blocked: 'Blocked',
+		complete: 'Complete',
+	};
+
+	const PRIORITY_LABELS: Record<string, string> = {
+		p0: 'P0',
+		p1: 'P1',
+		p2: 'P2',
+	};
+
+	let resolvedEntries = $derived(entries ?? []);
+
+	let availableStatuses = $derived(
+		Array.from(new Set(resolvedEntries.map((e) => e.status))).sort()
+	);
+
+	let visibleEntries = $derived(
+		statusFilter === 'all'
+			? resolvedEntries
+			: resolvedEntries.filter((e) => e.status === statusFilter)
+	);
+
+	function parentChain(entry: EpicEntry, byId: Map<string, EpicEntry>): EpicEntry[] {
+		const chain: EpicEntry[] = [];
+		let current = entry.parentEpicId ? byId.get(entry.parentEpicId) : undefined;
+		let guard = 0;
+		while (current && guard < 20) {
+			chain.unshift(current);
+			current = current.parentEpicId ? byId.get(current.parentEpicId) : undefined;
+			guard++;
+		}
+		return chain;
+	}
+
+	let entriesById = $derived(new Map(resolvedEntries.map((e) => [e.id, e])));
+
+	function statusLabel(status: string): string {
+		return STATUS_LABELS[status] ?? status;
+	}
+
+	function priorityLabel(priority: string): string {
+		return PRIORITY_LABELS[priority] ?? priority.toUpperCase();
+	}
+</script>
+
+<div class="epic-status-board {className}">
+	<div class="board-toolbar">
+		<label class="filter-label" for="epic-status-filter">Filter by status</label>
+		<select
+			id="epic-status-filter"
+			class="status-filter"
+			bind:value={statusFilter}
+			disabled={loading || resolvedEntries.length === 0}
+		>
+			<option value="all">All statuses ({resolvedEntries.length})</option>
+			{#each availableStatuses as status (status)}
+				<option value={status}>
+					{statusLabel(status)} ({resolvedEntries.filter((e) => e.status === status).length})
+				</option>
+			{/each}
+		</select>
+	</div>
+
+	{#if loading}
+		<ul class="epic-list" aria-busy="true" aria-label="Loading epics">
+			{#each { length: 3 } as _, i (i)}
+				<li class="epic-card skeleton" aria-hidden="true">
+					<div class="skeleton-line w-40"></div>
+					<div class="skeleton-line w-70"></div>
+					<div class="skeleton-line w-90"></div>
+				</li>
+			{/each}
+		</ul>
+	{:else if resolvedEntries.length === 0}
+		<div class="empty-state">
+			<p>No epics registered yet.</p>
+			<p class="muted">Epics appear here once they're added to the registry.</p>
+		</div>
+	{:else if visibleEntries.length === 0}
+		<div class="empty-state">
+			<p>No epics match the "{statusLabel(statusFilter)}" filter.</p>
+			<button type="button" class="reset-filter" onclick={() => (statusFilter = 'all')}>
+				Clear filter
+			</button>
+		</div>
+	{:else}
+		<ul class="epic-list">
+			{#each visibleEntries as entry (entry.id)}
+				{@const chain = parentChain(entry, entriesById)}
+				<li class="epic-card status-{entry.status}">
+					<button
+						type="button"
+						class="epic-card-inner"
+						onclick={() => onSelect?.(entry)}
+						disabled={!onSelect}
+					>
+						{#if chain.length > 0}
+							<nav class="breadcrumb" aria-label="Epic hierarchy">
+								{#each chain as ancestor, i (ancestor.id)}
+									<span class="crumb">{ancestor.id}</span>
+									<span class="crumb-sep" aria-hidden="true">/</span>
+								{/each}
+							</nav>
+						{/if}
+
+						<div class="epic-card-header">
+							<span class="epic-id">{entry.id}</span>
+							<span class="badge tier-{entry.tier}">{entry.tier}</span>
+							<span class="badge priority-{entry.priority}">{priorityLabel(entry.priority)}</span>
+							<span class="badge status-badge status-{entry.status}">{statusLabel(entry.status)}</span>
+						</div>
+
+						{#if entry.blockedOn && entry.blockedOn.length > 0}
+							<p class="blocked-on">
+								<span class="blocked-on-label">Blocked on:</span>
+								{entry.blockedOn.join(', ')}
+							</p>
+						{/if}
+
+						{#if entry.nextAction}
+							<p class="next-action">{entry.nextAction}</p>
+						{/if}
+
+						{#if entry.error}
+							<p class="epic-error" role="alert">{entry.error}</p>
+						{/if}
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>
+
+<style>
+	.epic-status-board {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.board-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
+	.filter-label {
+		font-size: 0.8rem;
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.status-filter {
+		padding: 5px 10px;
+		border-radius: 6px;
+		border: 1px solid var(--color-border, #2d3140);
+		background: var(--color-surface, #1a1d27);
+		color: var(--color-text, #e2e5eb);
+		font-size: 0.85rem;
+	}
+
+	.status-filter:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.epic-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 10px;
+	}
+
+	@container (min-width: 640px) {
+		.epic-list {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	.epic-status-board {
+		container-type: inline-size;
+	}
+
+	.epic-card {
+		border: 1px solid var(--color-border, #2d3140);
+		border-radius: 8px;
+		background: var(--color-surface, #1a1d27);
+		overflow: hidden;
+	}
+
+	.epic-card-inner {
+		width: 100%;
+		text-align: left;
+		background: transparent;
+		border: none;
+		color: inherit;
+		font: inherit;
+		padding: 14px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		cursor: pointer;
+	}
+
+	.epic-card-inner:disabled {
+		cursor: default;
+	}
+
+	.epic-card-inner:focus-visible {
+		outline: 2px solid var(--color-accent, #6366f1);
+		outline-offset: -2px;
+	}
+
+	.epic-card-inner:hover:not(:disabled) {
+		background: var(--color-hover, rgba(255, 255, 255, 0.03));
+	}
+
+	.status-blocked,
+	.status-assistance_required {
+		border-color: var(--color-danger, #ef4444);
+	}
+
+	.status-in_progress {
+		border-color: var(--color-accent, #6366f1);
+	}
+
+	.status-complete {
+		border-color: var(--color-success, #22c55e);
+	}
+
+	.breadcrumb {
+		font-size: 0.7rem;
+		color: var(--color-text-muted, #8b92a5);
+		display: flex;
+		flex-wrap: wrap;
+		gap: 2px;
+	}
+
+	.crumb-sep {
+		margin: 0 2px;
+	}
+
+	.epic-card-header {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+
+	.epic-id {
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: var(--color-text, #e2e5eb);
+	}
+
+	.badge {
+		font-size: 0.68rem;
+		font-weight: 600;
+		padding: 2px 7px;
+		border-radius: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
+		background: var(--color-hover, rgba(255, 255, 255, 0.06));
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.priority-p0 {
+		background: rgba(239, 68, 68, 0.15);
+		color: var(--color-danger, #ef4444);
+	}
+
+	.priority-p1 {
+		background: rgba(234, 179, 8, 0.15);
+		color: #eab308;
+	}
+
+	.status-badge.status-in_progress {
+		background: rgba(99, 102, 241, 0.15);
+		color: var(--color-accent, #6366f1);
+	}
+
+	.status-badge.status-complete {
+		background: rgba(34, 197, 94, 0.15);
+		color: var(--color-success, #22c55e);
+	}
+
+	.status-badge.status-blocked,
+	.status-badge.status-assistance_required {
+		background: rgba(239, 68, 68, 0.15);
+		color: var(--color-danger, #ef4444);
+	}
+
+	.blocked-on {
+		margin: 0;
+		font-size: 0.78rem;
+		color: var(--color-danger, #ef4444);
+	}
+
+	.blocked-on-label {
+		font-weight: 600;
+	}
+
+	.next-action {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--color-text-muted, #8b92a5);
+		line-height: 1.4;
+	}
+
+	.epic-error {
+		margin: 0;
+		font-size: 0.78rem;
+		color: var(--color-danger, #ef4444);
+		font-weight: 500;
+	}
+
+	.empty-state {
+		text-align: center;
+		padding: 40px 16px;
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.muted {
+		font-size: 0.85rem;
+		opacity: 0.7;
+	}
+
+	.reset-filter {
+		margin-top: 8px;
+		padding: 5px 14px;
+		border-radius: 6px;
+		border: 1px solid var(--color-border, #2d3140);
+		background: transparent;
+		color: var(--color-text, #e2e5eb);
+		cursor: pointer;
+		font-size: 0.8rem;
+	}
+
+	.reset-filter:hover {
+		background: var(--color-hover, rgba(255, 255, 255, 0.05));
+	}
+
+	.reset-filter:focus-visible {
+		outline: 2px solid var(--color-accent, #6366f1);
+		outline-offset: 2px;
+	}
+
+	.skeleton {
+		pointer-events: none;
+	}
+
+	.skeleton-line {
+		height: 10px;
+		border-radius: 4px;
+		background: var(--color-border, #2d3140);
+		margin: 8px 14px;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.skeleton-line {
+			background: linear-gradient(
+				90deg,
+				var(--color-border) 25%,
+				var(--color-hover) 50%,
+				var(--color-border) 75%
+			);
+			background-size: 200% 100%;
+			animation: shimmer 1.5s infinite linear;
+		}
+
+		@keyframes shimmer {
+			0% { background-position: 200% 0; }
+			100% { background-position: -200% 0; }
+		}
+	}
+
+	.w-40 { width: 40%; }
+	.w-70 { width: 70%; }
+	.w-90 { width: 90%; }
+</style>

--- a/packages/design-dojo/src/EpicStatusBoard.svelte
+++ b/packages/design-dojo/src/EpicStatusBoard.svelte
@@ -31,10 +31,10 @@
 	};
 
 	let resolvedEntries = $derived(entries ?? []);
-
-	let availableStatuses = $derived(
-		Array.from(new Set(resolvedEntries.map((e) => e.status))).sort()
+	let statusCounts = $derived(
+		resolvedEntries.reduce((acc, e) => (acc.set(e.status, (acc.get(e.status) ?? 0) + 1), acc), new Map<string, number>())
 	);
+	let availableStatuses = $derived(Array.from(statusCounts.keys()).sort());
 
 	let visibleEntries = $derived(
 		statusFilter === 'all'

--- a/packages/design-dojo/src/JSONTreeViewer.svelte
+++ b/packages/design-dojo/src/JSONTreeViewer.svelte
@@ -54,7 +54,7 @@
 	{/if}
 {/snippet}
 
-<div class="json-tree-viewer {className}" role="tree" aria-label="JSON tree: {rootLabel}">
+<div class="json-tree-viewer {className}" aria-label="JSON tree: {rootLabel}">
 	{@render node(rootLabel, data, 0)}
 </div>
 

--- a/packages/design-dojo/src/JSONTreeViewer.svelte
+++ b/packages/design-dojo/src/JSONTreeViewer.svelte
@@ -1,0 +1,130 @@
+<!--
+  JSONTreeViewer — collapsible raw-JSON inspector for ad-hoc inspection of
+  registry/ADR/audit blobs. Distinct from SchemaForm (validated-form model,
+  requires an EntitySchema) and CodeBlock (static pretty-printed text, no
+  interaction): this renders an arbitrary, unvalidated JSON value as a
+  navigable expand/collapse tree, one node per key/array-index, with a
+  depth-limited default-expand so large blobs don't dump everything open.
+  Gap-analysis candidate #6 (design-dojo:preemptive-controls-and-improvements).
+-->
+<script lang="ts">
+	import type { JSONValue, JSONTreeViewerProps } from './types-local.js';
+
+	let { data, rootLabel = 'root', defaultExpandDepth = 1, class: className = '' }: JSONTreeViewerProps = $props();
+
+	function isObject(v: JSONValue): v is { [key: string]: JSONValue } {
+		return v !== null && typeof v === 'object' && !Array.isArray(v);
+	}
+
+	function isArray(v: JSONValue): v is JSONValue[] {
+		return Array.isArray(v);
+	}
+
+	function typeLabel(v: JSONValue): string {
+		if (v === null) return 'null';
+		if (isArray(v)) return `array(${v.length})`;
+		if (isObject(v)) return `object(${Object.keys(v).length})`;
+		return typeof v;
+	}
+
+	function entries(v: { [key: string]: JSONValue } | JSONValue[]): [string, JSONValue][] {
+		return isArray(v) ? v.map((item, i) => [String(i), item] as [string, JSONValue]) : Object.entries(v);
+	}
+</script>
+
+{#snippet node(label: string, value: JSONValue, depth: number)}
+	{@const expandable = isObject(value) || isArray(value)}
+	{#if expandable}
+		<details class="tree-node" open={depth < defaultExpandDepth}>
+			<summary>
+				<span class="node-label">{label}</span>
+				<span class="node-type">{typeLabel(value)}</span>
+			</summary>
+			<div class="node-children">
+				{#each entries(value) as [childKey, childValue] (childKey)}
+					{@render node(childKey, childValue, depth + 1)}
+				{/each}
+			</div>
+		</details>
+	{:else}
+		<div class="tree-leaf">
+			<span class="node-label">{label}</span>
+			<span class="node-value" data-type={typeof value}>{JSON.stringify(value)}</span>
+		</div>
+	{/if}
+{/snippet}
+
+<div class="json-tree-viewer {className}" role="tree" aria-label="JSON tree: {rootLabel}">
+	{@render node(rootLabel, data, 0)}
+</div>
+
+<style>
+	.json-tree-viewer {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.82rem;
+		line-height: 1.5;
+		color: var(--color-text, #e2e5eb);
+	}
+
+	:global(.json-tree-viewer .tree-node) {
+		margin-left: 14px;
+	}
+
+	:global(.json-tree-viewer .tree-node > summary) {
+		cursor: pointer;
+		list-style: none;
+		display: flex;
+		align-items: baseline;
+		gap: 6px;
+		padding: 1px 0;
+	}
+
+	:global(.json-tree-viewer .tree-node > summary::-webkit-details-marker) {
+		display: none;
+	}
+
+	:global(.json-tree-viewer .tree-node > summary::before) {
+		content: '▸';
+		color: var(--color-text-muted, #8b92a5);
+		font-size: 0.7rem;
+		width: 10px;
+		display: inline-block;
+	}
+
+	:global(.json-tree-viewer .tree-node[open] > summary::before) {
+		content: '▾';
+	}
+
+	.tree-leaf {
+		margin-left: 14px;
+		display: flex;
+		gap: 6px;
+		padding: 1px 0;
+	}
+
+	.node-label {
+		color: var(--color-accent, #6366f1);
+		font-weight: 600;
+	}
+
+	.node-type {
+		color: var(--color-text-muted, #8b92a5);
+		font-size: 0.72rem;
+	}
+
+	.node-value {
+		color: var(--color-text, #e2e5eb);
+	}
+
+	.node-value[data-type='string'] {
+		color: var(--color-success, #22c55e);
+	}
+
+	.node-value[data-type='number'] {
+		color: var(--color-warning, #eab308);
+	}
+
+	.node-value[data-type='boolean'] {
+		color: var(--color-accent, #6366f1);
+	}
+</style>

--- a/packages/design-dojo/src/JSONTreeViewer.svelte
+++ b/packages/design-dojo/src/JSONTreeViewer.svelte
@@ -49,7 +49,7 @@
 	{:else}
 		<div class="tree-leaf">
 			<span class="node-label">{label}</span>
-			<span class="node-value" data-type={typeof value}>{JSON.stringify(value)}</span>
+			<span class="node-value" data-type={value === null ? 'null' : typeof value}>{JSON.stringify(value)}</span>
 		</div>
 	{/if}
 {/snippet}

--- a/packages/design-dojo/src/PersistentGateBanner.svelte
+++ b/packages/design-dojo/src/PersistentGateBanner.svelte
@@ -1,0 +1,176 @@
+<!--
+  PersistentGateBanner — non-dismissible, page-level banner for a hard-gate
+  violation that must stay visible until resolved.
+
+  Deliberately distinct from Toast/NotificationStack (transient-by-design):
+  this banner has no auto-dismiss timer and no manual close affordance. It
+  only disappears when the host removes it after confirming the underlying
+  condition has actually cleared (via onResolve), never on its own.
+-->
+<script lang="ts">
+	import type { PersistentGateBannerProps } from './types-local.js';
+
+	let {
+		severity,
+		label,
+		detail,
+		blockedItems,
+		onResolve,
+		resolveLabel = 'Mark resolved',
+		class: className = '',
+	}: PersistentGateBannerProps = $props();
+
+	const SEVERITY_LABELS: Record<string, string> = {
+		blocked: 'Blocked',
+		assistance_required: 'Assistance required',
+		hard_gate: 'Hard gate',
+	};
+
+	let severityLabel = $derived(SEVERITY_LABELS[severity] ?? severity);
+	let hasItems = $derived(Boolean(blockedItems && blockedItems.length > 0));
+</script>
+
+<div
+	class="persistent-gate-banner severity-{severity} {className}"
+	role="alert"
+	aria-live="assertive"
+>
+	<div class="gate-icon" aria-hidden="true">⛔</div>
+
+	<div class="gate-body">
+		<div class="gate-header">
+			<span class="gate-severity-badge severity-{severity}">{severityLabel}</span>
+			<span class="gate-label">{label}</span>
+		</div>
+
+		{#if detail}
+			<p class="gate-detail">{detail}</p>
+		{/if}
+
+		{#if hasItems}
+			<ul class="gate-items">
+				{#each blockedItems ?? [] as item (item)}
+					<li class="gate-item">{item}</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+
+	{#if onResolve}
+		<button type="button" class="gate-resolve" onclick={() => onResolve?.()}>
+			{resolveLabel}
+		</button>
+	{/if}
+</div>
+
+<style>
+	.persistent-gate-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		padding: 14px 16px;
+		border-radius: 8px;
+		border: 1px solid var(--color-danger, #ef4444);
+		background: rgba(239, 68, 68, 0.08);
+		color: var(--color-text, #e2e5eb);
+	}
+
+	.severity-assistance_required {
+		border-color: #eab308;
+		background: rgba(234, 179, 8, 0.08);
+	}
+
+	.severity-hard_gate {
+		border-color: var(--color-danger, #ef4444);
+		background: rgba(239, 68, 68, 0.12);
+	}
+
+	.gate-icon {
+		font-size: 1.1rem;
+		line-height: 1.4;
+		flex-shrink: 0;
+	}
+
+	.gate-body {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		min-width: 0;
+	}
+
+	.gate-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
+	.gate-severity-badge {
+		font-size: 0.68rem;
+		font-weight: 700;
+		padding: 2px 8px;
+		border-radius: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+		background: rgba(239, 68, 68, 0.18);
+		color: var(--color-danger, #ef4444);
+		flex-shrink: 0;
+	}
+
+	.gate-severity-badge.severity-assistance_required {
+		background: rgba(234, 179, 8, 0.18);
+		color: #eab308;
+	}
+
+	.gate-label {
+		font-weight: 600;
+		font-size: 0.92rem;
+	}
+
+	.gate-detail {
+		margin: 0;
+		font-size: 0.82rem;
+		color: var(--color-text-muted, #8b92a5);
+		line-height: 1.4;
+	}
+
+	.gate-items {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+
+	.gate-item {
+		font-size: 0.72rem;
+		font-family: var(--font-mono, ui-monospace, monospace);
+		padding: 2px 8px;
+		border-radius: 5px;
+		background: var(--color-hover, rgba(255, 255, 255, 0.06));
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.gate-resolve {
+		flex-shrink: 0;
+		padding: 6px 14px;
+		border-radius: 6px;
+		border: 1px solid var(--color-border, #2d3140);
+		background: transparent;
+		color: var(--color-text, #e2e5eb);
+		font-size: 0.8rem;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+
+	.gate-resolve:hover {
+		background: var(--color-hover, rgba(255, 255, 255, 0.05));
+	}
+
+	.gate-resolve:focus-visible {
+		outline: 2px solid var(--color-accent, #6366f1);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/design-dojo/src/PipelineStageIndicator.svelte
+++ b/packages/design-dojo/src/PipelineStageIndicator.svelte
@@ -1,0 +1,270 @@
+<!--
+  PipelineStageIndicator — discrete named-stage sequence indicator.
+
+  Distinct from `ProgressBar`'s continuous-percent model: expresses "stage 3 of 6
+  failed, stages 1-2 passed" for the dev-lifecycle 6-stage gate (design→dev→
+  document→QA→deploy→verify) that AGENTS.md itself mandates, and any similar
+  discrete staged pipeline (CI stages, deploy gates, praxis lifecycle phases).
+-->
+<script lang="ts">
+	import type { PipelineStageIndicatorProps } from './types-local.js';
+
+	let { stages, orientation = 'horizontal', class: className = '' }: PipelineStageIndicatorProps =
+		$props();
+
+	function statusLabel(status: string): string {
+		switch (status) {
+			case 'passed':
+				return 'Passed';
+			case 'failed':
+				return 'Failed';
+			case 'in-progress':
+				return 'In progress';
+			case 'skipped':
+				return 'Skipped';
+			default:
+				return 'Pending';
+		}
+	}
+
+	function statusGlyph(status: string): string {
+		switch (status) {
+			case 'passed':
+				return '✓';
+			case 'failed':
+				return '✕';
+			case 'in-progress':
+				return '…';
+			case 'skipped':
+				return '—';
+			default:
+				return '○';
+		}
+	}
+</script>
+
+<ol
+	class="pipeline-stage-indicator {orientation} {className}"
+	aria-label="Pipeline stages"
+>
+	{#if stages.length === 0}
+		<li class="empty">
+			<p>No pipeline stages defined yet.</p>
+		</li>
+	{:else}
+		{#each stages as stage, i (stage.id)}
+			<li
+				class="stage status-{stage.status}"
+				aria-current={stage.status === 'in-progress' ? 'step' : undefined}
+			>
+				<div
+					class="stage-marker"
+					aria-hidden="true"
+					title={statusLabel(stage.status)}
+				>
+					{#if stage.status === 'in-progress'}
+						<span class="spinner" aria-hidden="true"></span>
+					{:else}
+						<span class="glyph">{statusGlyph(stage.status)}</span>
+					{/if}
+				</div>
+				<div class="stage-body">
+					<span class="stage-label">{stage.label}</span>
+					<span class="stage-status sr-only">{statusLabel(stage.status)}</span>
+					{#if stage.detail}
+						<span class="stage-detail">{stage.detail}</span>
+					{/if}
+					{#if stage.status === 'failed' && stage.onRetry}
+						<button
+							type="button"
+							class="stage-retry"
+							onclick={() => stage.onRetry?.()}
+						>
+							Retry
+						</button>
+					{/if}
+				</div>
+				{#if i < stages.length - 1}
+					<div class="stage-connector" aria-hidden="true"></div>
+				{/if}
+			</li>
+		{/each}
+	{/if}
+</ol>
+
+<style>
+	.pipeline-stage-indicator {
+		display: flex;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		gap: 0;
+	}
+
+	.pipeline-stage-indicator.horizontal {
+		flex-direction: row;
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.pipeline-stage-indicator.vertical {
+		flex-direction: column;
+	}
+
+	.stage {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		flex: 1 1 auto;
+		min-width: 120px;
+	}
+
+	.pipeline-stage-indicator.vertical .stage {
+		min-width: 0;
+	}
+
+	.stage-marker {
+		flex: 0 0 auto;
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.8rem;
+		font-weight: 700;
+		border: 2px solid var(--color-border, #2d3140);
+		background: var(--color-surface, #1a1d27);
+		color: var(--color-text-muted, #8b92a5);
+		z-index: 1;
+	}
+
+	.status-passed .stage-marker {
+		border-color: var(--color-success, #22c55e);
+		color: var(--color-success, #22c55e);
+	}
+
+	.status-failed .stage-marker {
+		border-color: var(--color-danger, #ef4444);
+		color: var(--color-danger, #ef4444);
+	}
+
+	.status-in-progress .stage-marker {
+		border-color: var(--color-accent, #6366f1);
+		color: var(--color-accent, #6366f1);
+	}
+
+	.status-skipped .stage-marker {
+		opacity: 0.5;
+	}
+
+	.spinner {
+		width: 12px;
+		height: 12px;
+		border-radius: 50%;
+		border: 2px solid var(--color-accent, #6366f1);
+		border-top-color: transparent;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.spinner {
+			animation: spin 0.8s linear infinite;
+		}
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+
+	.stage-body {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding-top: 3px;
+	}
+
+	.stage-label {
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--color-text, #e2e5eb);
+	}
+
+	.status-skipped .stage-label {
+		color: var(--color-text-muted, #8b92a5);
+		text-decoration: line-through;
+	}
+
+	.stage-detail {
+		font-size: 0.75rem;
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.status-failed .stage-detail {
+		color: var(--color-danger, #ef4444);
+	}
+
+	.stage-retry {
+		align-self: flex-start;
+		margin-top: 4px;
+		padding: 3px 10px;
+		font-size: 0.75rem;
+		font-weight: 500;
+		border-radius: 5px;
+		border: 1px solid var(--color-danger, #ef4444);
+		background: transparent;
+		color: var(--color-danger, #ef4444);
+		cursor: pointer;
+	}
+
+	.stage-retry:hover {
+		background: var(--color-danger, #ef4444);
+		color: #fff;
+	}
+
+	.stage-retry:focus-visible {
+		outline: 2px solid var(--color-accent, #6366f1);
+		outline-offset: 2px;
+	}
+
+	.stage-connector {
+		position: absolute;
+		background: var(--color-border, #2d3140);
+	}
+
+	.pipeline-stage-indicator.horizontal .stage-connector {
+		top: 13px;
+		left: 28px;
+		right: -50%;
+		height: 2px;
+	}
+
+	.pipeline-stage-indicator.vertical .stage-connector {
+		top: 28px;
+		left: 13px;
+		width: 2px;
+		bottom: -8px;
+	}
+
+	.status-passed .stage-connector {
+		background: var(--color-success, #22c55e);
+	}
+
+	.empty {
+		padding: 16px;
+		color: var(--color-text-muted, #8b92a5);
+		font-size: 0.85rem;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+</style>

--- a/packages/design-dojo/src/PraxisRuleCard.svelte
+++ b/packages/design-dojo/src/PraxisRuleCard.svelte
@@ -1,0 +1,238 @@
+<!--
+  PraxisRuleCard — renders one Praxis `.px` constraint/ADR: id, severity badge,
+  evidence/condition source, live pass/fail/unknown state, with an
+  expand-for-evidence-table affordance. Composite reuse of existing CodeBlock
+  (condition source) + Badge (severity + status) + Callout (violation reason)
+  primitives — no new interaction metaphor, just a domain-shaped composite.
+  Distinct from `PraxisDevOverlay`/`PraxisBox` (design-dojo npm-package repo,
+  2026-08-04 batch): this is the lighter-weight, evidence-table-first card
+  variant scoped to the pares-radix shim's own consumers (dev-lifecycle gate
+  UI, ADO/audit reporting), not a redesign of the overlay component.
+-->
+<script lang="ts">
+	import CodeBlock from './CodeBlock.svelte';
+	import { Badge, Callout } from '@plures/design-dojo-npm';
+	import type { PraxisRuleCardProps, PraxisEvidenceRow } from './types-local.js';
+
+	let { rule, expanded = $bindable(false), class: className = '' }: PraxisRuleCardProps = $props();
+
+	function severityVariant(severity: string): 'danger' | 'warning' | 'info' {
+		switch (severity) {
+			case 'error':
+				return 'danger';
+			case 'warning':
+				return 'warning';
+			default:
+				return 'info';
+		}
+	}
+
+	function statusVariant(status: string): 'success' | 'danger' | 'neutral' {
+		switch (status) {
+			case 'pass':
+				return 'success';
+			case 'fail':
+				return 'danger';
+			default:
+				return 'neutral';
+		}
+	}
+
+	function calloutTone(status: string): 'error' | 'warning' | 'info' {
+		return status === 'fail' ? 'error' : 'warning';
+	}
+
+	function statusLabel(status: string): string {
+		switch (status) {
+			case 'pass':
+				return 'Passing';
+			case 'fail':
+				return 'Failing';
+			default:
+				return 'Unknown';
+		}
+	}
+
+	function toggle() {
+		expanded = !expanded;
+	}
+</script>
+
+<div class="praxis-rule-card status-{rule?.status ?? 'unknown'} {className}">
+	{#if rule === undefined}
+		<div class="skeleton" aria-hidden="true">
+			<div class="skeleton-row"></div>
+			<div class="skeleton-row"></div>
+		</div>
+	{:else}
+		<div class="card-header">
+			<div class="card-heading">
+				<span class="rule-id">{rule.id}</span>
+				<Badge variant={severityVariant(rule.severity)}>{rule.severity}</Badge>
+				<Badge variant={statusVariant(rule.status)}>{statusLabel(rule.status)}</Badge>
+			</div>
+			{#if rule.condition || (rule.evidence && rule.evidence.length > 0)}
+				<button
+					type="button"
+					class="expand-toggle"
+					aria-expanded={expanded}
+					onclick={toggle}
+				>
+					{expanded ? 'Hide evidence' : 'Show evidence'}
+				</button>
+			{/if}
+		</div>
+
+		{#if rule.description}
+			<p class="rule-description">{rule.description}</p>
+		{/if}
+
+		{#if rule.status === 'fail' && rule.failureReason}
+			<Callout tone={calloutTone(rule.status)}>{rule.failureReason}</Callout>
+		{/if}
+
+		{#if expanded}
+			<div class="card-evidence">
+				{#if rule.condition}
+					<CodeBlock code={rule.condition} language={rule.conditionLanguage ?? 'text'} />
+				{/if}
+				{#if rule.evidence && rule.evidence.length > 0}
+					<table class="evidence-table">
+						<thead>
+							<tr>
+								<th>Fact</th>
+								<th>Value</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each rule.evidence as row (row.fact)}
+								<tr>
+									<td>{row.fact}</td>
+									<td>{row.value}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				{/if}
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.praxis-rule-card {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 12px 14px;
+		border-radius: 8px;
+		border: 1px solid var(--color-border, #2d3140);
+		background: var(--color-surface, #1a1d27);
+	}
+
+	.status-fail {
+		border-color: color-mix(in srgb, var(--color-danger, #ef4444) 45%, var(--color-border, #2d3140));
+	}
+
+	.card-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.card-heading {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
+	.rule-id {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--color-text, #e2e5eb);
+	}
+
+	.expand-toggle {
+		flex: 0 0 auto;
+		background: none;
+		border: none;
+		color: var(--color-accent, #6366f1);
+		font-size: 0.75rem;
+		cursor: pointer;
+		padding: 2px 4px;
+	}
+
+	.expand-toggle:hover {
+		text-decoration: underline;
+	}
+
+	.rule-description {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.card-evidence {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.evidence-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.78rem;
+	}
+
+	.evidence-table th,
+	.evidence-table td {
+		text-align: left;
+		padding: 4px 8px;
+		border-bottom: 1px solid var(--color-border, #2d3140);
+	}
+
+	.evidence-table th {
+		color: var(--color-text-muted, #8b92a5);
+		font-weight: 600;
+		text-transform: uppercase;
+		font-size: 0.65rem;
+		letter-spacing: 0.03em;
+	}
+
+	.evidence-table td {
+		color: var(--color-text, #e2e5eb);
+		font-family: var(--font-mono, monospace);
+	}
+
+	.skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.skeleton-row {
+		height: 20px;
+		border-radius: 6px;
+		background: linear-gradient(
+			90deg,
+			var(--color-surface, #1a1d27) 25%,
+			color-mix(in srgb, var(--color-surface, #1a1d27) 60%, var(--color-border, #2d3140)) 50%,
+			var(--color-surface, #1a1d27) 75%
+		);
+		background-size: 200% 100%;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.skeleton-row {
+			animation: shimmer 1.4s ease-in-out infinite;
+		}
+	}
+
+	@keyframes shimmer {
+		0% { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
+</style>

--- a/packages/design-dojo/src/SchemaDiffView.svelte
+++ b/packages/design-dojo/src/SchemaDiffView.svelte
@@ -1,0 +1,233 @@
+<!--
+  SchemaDiffView — visual renderer for `schema-delta.ts`'s typed `SchemaDelta`
+  operation vocabulary (add_field / update_field / rename_field / retype_field /
+  remove_field / reorder_field). Used to review a batch of pending schema
+  customizations (ADR-0031 §6) — from `SchemaDesigner`'s `ondelta` stream or a
+  replayed migration log — before the host persists them + attaches a `.px`
+  migration rule. Pure display: never calls `applyDelta` itself.
+-->
+<script lang="ts">
+	import type { SchemaDiffViewProps, SchemaDelta, SchemaField } from './types-local.js';
+
+	let { deltas, baseSchema, class: className = '' }: SchemaDiffViewProps = $props();
+
+	function fieldByName(name: string): SchemaField | undefined {
+		return baseSchema?.fields.find((f) => f.name === name);
+	}
+
+	function opLabel(op: SchemaDelta['op']): string {
+		switch (op) {
+			case 'add_field':
+				return 'Add field';
+			case 'update_field':
+				return 'Update field';
+			case 'rename_field':
+				return 'Rename field';
+			case 'retype_field':
+				return 'Change type';
+			case 'remove_field':
+				return 'Remove field';
+			case 'reorder_field':
+				return 'Reorder field';
+		}
+	}
+
+	function opGlyph(op: SchemaDelta['op']): string {
+		switch (op) {
+			case 'add_field':
+				return '+';
+			case 'update_field':
+				return '~';
+			case 'rename_field':
+				return '→';
+			case 'retype_field':
+				return '⇄';
+			case 'remove_field':
+				return '−';
+			case 'reorder_field':
+				return '↕';
+		}
+	}
+
+	function subjectName(delta: SchemaDelta): string {
+		switch (delta.op) {
+			case 'add_field':
+				return delta.field.name;
+			case 'update_field':
+				return delta.name;
+			case 'rename_field':
+				return delta.from;
+			case 'retype_field':
+				return delta.name;
+			case 'remove_field':
+				return delta.name;
+			case 'reorder_field':
+				return delta.name;
+		}
+	}
+
+	function summary(delta: SchemaDelta): string {
+		switch (delta.op) {
+			case 'add_field':
+				return `type: ${delta.field.type}${delta.field.required ? ', required' : ''}`;
+			case 'update_field': {
+				const prior = fieldByName(delta.name);
+				if (prior && prior.type !== delta.field.type) {
+					return `${prior.type} → ${delta.field.type}`;
+				}
+				return `type: ${delta.field.type}`;
+			}
+			case 'rename_field':
+				return `${delta.from} → ${delta.to}`;
+			case 'retype_field': {
+				const prior = fieldByName(delta.name);
+				return prior ? `${prior.type} → ${delta.to}` : `→ ${delta.to}`;
+			}
+			case 'remove_field':
+				return 'field removed';
+			case 'reorder_field':
+				return `moved to position ${delta.toIndex + 1}`;
+		}
+	}
+</script>
+
+<ol class="schema-diff-view {className}" aria-label="Schema changes">
+	{#if deltas === undefined}
+		<li class="skeleton" aria-hidden="true">
+			<div class="skeleton-row"></div>
+			<div class="skeleton-row"></div>
+			<div class="skeleton-row"></div>
+		</li>
+	{:else if deltas.length === 0}
+		<li class="empty">
+			<p>No schema changes pending.</p>
+		</li>
+	{:else}
+		{#each deltas as delta, i (i)}
+			<li class="delta-row op-{delta.op}">
+				<span class="delta-glyph" aria-hidden="true">{opGlyph(delta.op)}</span>
+				<div class="delta-body">
+					<span class="delta-op">{opLabel(delta.op)}</span>
+					<span class="delta-subject">{subjectName(delta)}</span>
+					<span class="delta-summary">{summary(delta)}</span>
+				</div>
+			</li>
+		{/each}
+	{/if}
+</ol>
+
+<style>
+	.schema-diff-view {
+		display: flex;
+		flex-direction: column;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		gap: 4px;
+	}
+
+	.delta-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		padding: 8px 10px;
+		border-radius: 6px;
+		border: 1px solid var(--color-border, #2d3140);
+		background: var(--color-surface, #1a1d27);
+	}
+
+	.delta-glyph {
+		flex: 0 0 auto;
+		width: 20px;
+		height: 20px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		font-size: 0.85rem;
+		border-radius: 4px;
+		color: var(--color-text-muted, #8b92a5);
+		background: color-mix(in srgb, var(--color-text-muted, #8b92a5) 12%, transparent);
+	}
+
+	.op-add_field .delta-glyph {
+		color: var(--color-success, #22c55e);
+		background: color-mix(in srgb, var(--color-success, #22c55e) 15%, transparent);
+	}
+
+	.op-remove_field .delta-glyph {
+		color: var(--color-danger, #ef4444);
+		background: color-mix(in srgb, var(--color-danger, #ef4444) 15%, transparent);
+	}
+
+	.op-rename_field .delta-glyph,
+	.op-retype_field .delta-glyph {
+		color: var(--color-accent, #6366f1);
+		background: color-mix(in srgb, var(--color-accent, #6366f1) 15%, transparent);
+	}
+
+	.delta-body {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.delta-op {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.delta-subject {
+		font-size: 0.85rem;
+		font-weight: 600;
+		font-family: var(--font-mono, monospace);
+		color: var(--color-text, #e2e5eb);
+	}
+
+	.delta-summary {
+		font-size: 0.75rem;
+		color: var(--color-text-muted, #8b92a5);
+	}
+
+	.op-remove_field .delta-subject {
+		text-decoration: line-through;
+	}
+
+	.empty {
+		padding: 16px;
+		color: var(--color-text-muted, #8b92a5);
+		font-size: 0.85rem;
+	}
+
+	.skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.skeleton-row {
+		height: 40px;
+		border-radius: 6px;
+		background: linear-gradient(
+			90deg,
+			var(--color-surface, #1a1d27) 25%,
+			color-mix(in srgb, var(--color-surface, #1a1d27) 60%, var(--color-border, #2d3140)) 50%,
+			var(--color-surface, #1a1d27) 75%
+		);
+		background-size: 200% 100%;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.skeleton-row {
+			animation: shimmer 1.4s ease-in-out infinite;
+		}
+	}
+
+	@keyframes shimmer {
+		0% { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
+</style>

--- a/packages/design-dojo/src/SchemaDiffView.svelte
+++ b/packages/design-dojo/src/SchemaDiffView.svelte
@@ -103,7 +103,7 @@
 			<p>No schema changes pending.</p>
 		</li>
 	{:else}
-		{#each deltas as delta, i (i)}
+		{#each deltas as delta (delta.op + ':' + subjectName(delta) + ':' + summary(delta))}
 			<li class="delta-row op-{delta.op}">
 				<span class="delta-glyph" aria-hidden="true">{opGlyph(delta.op)}</span>
 				<div class="delta-body">

--- a/packages/design-dojo/src/index.ts
+++ b/packages/design-dojo/src/index.ts
@@ -82,7 +82,9 @@ export { applyDelta, diffField } from './schema-delta.js';
 
 export type CommandItem = { id: string; label: string; icon?: string; action: () => void; };
 
-export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps, PraxisRuleSeverity, PraxisRuleEvalStatus, PraxisEvidenceRow, PraxisRule, PraxisRuleCardProps } from './types-local.js';
+export { default as PersistentGateBanner } from './PersistentGateBanner.svelte';
+
+export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps, PraxisRuleSeverity, PraxisRuleEvalStatus, PraxisEvidenceRow, PraxisRule, PraxisRuleCardProps, GateSeverity, PersistentGateBannerProps } from './types-local.js';
 
 export type {
   DetailLevel,

--- a/packages/design-dojo/src/index.ts
+++ b/packages/design-dojo/src/index.ts
@@ -57,6 +57,7 @@ export { default as DataGrid } from './DataGrid.svelte';
 export { default as SchemaForm } from './SchemaForm.svelte';
 export { default as PipelineStageIndicator } from './PipelineStageIndicator.svelte';
 export { default as EpicStatusBoard } from './EpicStatusBoard.svelte';
+export { default as SchemaDiffView } from './SchemaDiffView.svelte';
 
 export { default as GraphView } from './GraphView.svelte';
 
@@ -80,7 +81,7 @@ export { applyDelta, diffField } from './schema-delta.js';
 
 export type CommandItem = { id: string; label: string; icon?: string; action: () => void; };
 
-export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps } from './types-local.js';
+export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps } from './types-local.js';
 
 export type {
   DetailLevel,

--- a/packages/design-dojo/src/index.ts
+++ b/packages/design-dojo/src/index.ts
@@ -55,6 +55,8 @@ export { default as Canvas2D } from './Canvas2D.svelte';
 export { default as PluginContentArea } from './PluginContentArea.svelte';
 export { default as DataGrid } from './DataGrid.svelte';
 export { default as SchemaForm } from './SchemaForm.svelte';
+export { default as PipelineStageIndicator } from './PipelineStageIndicator.svelte';
+export { default as EpicStatusBoard } from './EpicStatusBoard.svelte';
 
 export { default as GraphView } from './GraphView.svelte';
 
@@ -78,7 +80,7 @@ export { applyDelta, diffField } from './schema-delta.js';
 
 export type CommandItem = { id: string; label: string; icon?: string; action: () => void; };
 
-export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta } from './types-local.js';
+export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps } from './types-local.js';
 
 export type {
   DetailLevel,

--- a/packages/design-dojo/src/index.ts
+++ b/packages/design-dojo/src/index.ts
@@ -58,6 +58,7 @@ export { default as SchemaForm } from './SchemaForm.svelte';
 export { default as PipelineStageIndicator } from './PipelineStageIndicator.svelte';
 export { default as EpicStatusBoard } from './EpicStatusBoard.svelte';
 export { default as SchemaDiffView } from './SchemaDiffView.svelte';
+export { default as PraxisRuleCard } from './PraxisRuleCard.svelte';
 
 export { default as GraphView } from './GraphView.svelte';
 
@@ -81,7 +82,7 @@ export { applyDelta, diffField } from './schema-delta.js';
 
 export type CommandItem = { id: string; label: string; icon?: string; action: () => void; };
 
-export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps } from './types-local.js';
+export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps, PraxisRuleSeverity, PraxisRuleEvalStatus, PraxisEvidenceRow, PraxisRule, PraxisRuleCardProps } from './types-local.js';
 
 export type {
   DetailLevel,

--- a/packages/design-dojo/src/index.ts
+++ b/packages/design-dojo/src/index.ts
@@ -83,8 +83,9 @@ export { applyDelta, diffField } from './schema-delta.js';
 export type CommandItem = { id: string; label: string; icon?: string; action: () => void; };
 
 export { default as PersistentGateBanner } from './PersistentGateBanner.svelte';
+export { default as JSONTreeViewer } from './JSONTreeViewer.svelte';
 
-export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps, PraxisRuleSeverity, PraxisRuleEvalStatus, PraxisEvidenceRow, PraxisRule, PraxisRuleCardProps, GateSeverity, PersistentGateBannerProps } from './types-local.js';
+export type { DashboardWidgetItem, DashboardGridProps, WizardStep, FirstRunWizardProps, SettingInputType, SettingDefinition, SettingsPanelProps, SidebarNavItem, SidebarProps, CommandPaletteProps, StatusItem, StatusBarProps, PluginContentAreaProps, SchemaFieldType, SchemaField, EntitySchema, DataRow, SortDirection, DataGridProps, SchemaFormErrors, SchemaFormProps, FieldEditorProps, SchemaDesignerProps, SchemaDelta, PipelineStageStatus, PipelineStage, PipelineStageIndicatorProps, EpicStatus, EpicPriority, EpicTier, EpicEntry, EpicStatusBoardProps, SchemaDiffViewProps, PraxisRuleSeverity, PraxisRuleEvalStatus, PraxisEvidenceRow, PraxisRule, PraxisRuleCardProps, GateSeverity, PersistentGateBannerProps, JSONValue, JSONTreeViewerProps } from './types-local.js';
 
 export type {
   DetailLevel,

--- a/packages/design-dojo/src/types-local.ts
+++ b/packages/design-dojo/src/types-local.ts
@@ -38,6 +38,14 @@ export interface SidebarNavItem { href: string; label: string; icon?: string; ba
 export interface SidebarProps { items: SidebarNavItem[]; currentPath: string; collapsed?: boolean; onToggle?: () => void; }
 export interface CommandItem { id: string; label: string; icon?: string; action: () => void; }
 export interface CommandPaletteProps { open?: boolean; commands?: CommandItem[]; onClose?: () => void; }
+
+export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
+export interface JSONTreeViewerProps {
+  data: JSONValue;
+  rootLabel?: string;
+  defaultExpandDepth?: number;
+  class?: string;
+}
 export interface StatusItem { label: string; value: string; }
 export interface StatusBarProps { items?: StatusItem[]; }
 export interface PluginContentAreaProps { theme?: string; onThemeToggle?: () => void; onSidebarToggle?: () => void; onCommandPaletteOpen?: () => void; statusItems?: StatusItem[]; children: Snippet; }

--- a/packages/design-dojo/src/types-local.ts
+++ b/packages/design-dojo/src/types-local.ts
@@ -320,3 +320,19 @@ export interface EpicStatusBoardProps {
   onSelect?: (entry: EpicEntry) => void;
   class?: string;
 }
+
+/**
+ * SchemaDiffView — visual renderer for `schema-delta.ts`'s `SchemaDelta` operation
+ * vocabulary (design-dojo gap analysis 2026-08-06, candidate #3). Renders a list of
+ * typed deltas (add/update/rename/retype/remove/reorder_field) as a human-readable
+ * change list, e.g. for reviewing an agens-driven or user-driven schema customization
+ * (ADR-0031 §6) before it's persisted to PluresDB + attached to a `.px` migration rule.
+ * Pure display — never applies deltas itself; the host calls `applyDelta` separately.
+ */
+export interface SchemaDiffViewProps {
+  /** `undefined` renders the loading (skeleton) state; `[]` renders the empty state. */
+  deltas: SchemaDelta[] | undefined;
+  /** Optional schema snapshot the deltas apply against, used to resolve prior field type/label for update/retype rows. */
+  baseSchema?: EntitySchema;
+  class?: string;
+}

--- a/packages/design-dojo/src/types-local.ts
+++ b/packages/design-dojo/src/types-local.ts
@@ -374,3 +374,29 @@ export interface PraxisRuleCardProps {
   expanded?: boolean;
   class?: string;
 }
+
+/**
+ * PersistentGateBanner - non-dismissible, page-level banner for a hard-gate
+ * violation that must stay visible until resolved (design-dojo gap analysis
+ * 2026-08-06, candidate #5). Deliberately distinct from Toast/NotificationStack
+ * (transient-by-design) and from Dialog (modal, blocks interaction) - this is
+ * an always-visible, non-transient surface for conditions like a blocked epic,
+ * a failing Praxis rule, or an ADO risk-assessment flag that must stay on
+ * screen until the host confirms the condition has cleared. The component
+ * never self-dismisses; only the host (via onResolve, after the underlying
+ * condition is actually resolved) can remove it.
+ */
+export type GateSeverity = 'blocked' | 'assistance_required' | 'hard_gate';
+
+export interface PersistentGateBannerProps {
+  /** `undefined` renders nothing (no gate condition); use `[]` explicitly to force an empty-but-mounted state if needed. */
+  severity: GateSeverity;
+  label: string;
+  detail?: string;
+  /** e.g. epic IDs, ADO work item IDs, PR numbers blocked by this condition. */
+  blockedItems?: string[];
+  /** Only rendered when provided - the host decides when the underlying condition is actually clearable. */
+  onResolve?: () => void;
+  resolveLabel?: string;
+  class?: string;
+}

--- a/packages/design-dojo/src/types-local.ts
+++ b/packages/design-dojo/src/types-local.ts
@@ -336,3 +336,41 @@ export interface SchemaDiffViewProps {
   baseSchema?: EntitySchema;
   class?: string;
 }
+
+/**
+ * PraxisRuleCard — renders one Praxis `.px` constraint/ADR (design-dojo gap
+ * analysis 2026-08-06, candidate #4). Composite of CodeBlock (condition
+ * source) + Badge (severity/status) + Callout (failure reason), with an
+ * expand-for-evidence-table affordance. Distinct from the npm-package repo's
+ * PraxisDevOverlay/PraxisBox (2026-08-04 batch) — this is the lighter-weight
+ * card variant scoped to the pares-radix shim's own dev-lifecycle-gate and
+ * audit-reporting consumers.
+ */
+export type PraxisRuleSeverity = 'error' | 'warning' | 'info';
+
+export type PraxisRuleEvalStatus = 'pass' | 'fail' | 'unknown';
+
+export interface PraxisEvidenceRow {
+  fact: string;
+  value: string;
+}
+
+export interface PraxisRule {
+  id: string;
+  severity: PraxisRuleSeverity | string;
+  status: PraxisRuleEvalStatus | string;
+  description?: string;
+  /** Reason shown when status === 'fail'. */
+  failureReason?: string;
+  /** Raw condition/constraint source rendered via CodeBlock. */
+  condition?: string;
+  conditionLanguage?: string;
+  evidence?: PraxisEvidenceRow[];
+}
+
+export interface PraxisRuleCardProps {
+  /** `undefined` renders the loading (skeleton) state. */
+  rule: PraxisRule | undefined;
+  expanded?: boolean;
+  class?: string;
+}

--- a/packages/design-dojo/src/types-local.ts
+++ b/packages/design-dojo/src/types-local.ts
@@ -257,3 +257,66 @@ export interface SchemaDesignerProps {
   ondelta?: (delta: SchemaDelta) => void;
   class?: string;
 }
+
+/**
+ * PipelineStageIndicator — discrete named-stage sequence status (design-dojo
+ * gap analysis 2026-08-06, candidate #1). Distinct from `ProgressBar`'s
+ * continuous-percent model: expresses per-stage pass/fail/in-progress/skipped
+ * state for gated multi-stage pipelines (dev-lifecycle gates, CI stages, deploy
+ * gates).
+ */
+export type PipelineStageStatus = 'pending' | 'in-progress' | 'passed' | 'failed' | 'skipped';
+
+export interface PipelineStage {
+  id: string;
+  label: string;
+  status: PipelineStageStatus;
+  /** Optional short supporting text (e.g. failure reason, duration). */
+  detail?: string;
+  /** Offered only when status is 'failed'; renders a Retry action. */
+  onRetry?: () => void;
+}
+
+export interface PipelineStageIndicatorProps {
+  stages: PipelineStage[];
+  orientation?: 'horizontal' | 'vertical';
+  class?: string;
+}
+
+/**
+ * EpicStatusBoard — status-hierarchy card renderer for epic/task registry data
+ * (design-dojo gap analysis 2026-08-06, candidate #2). Modeled on
+ * `epic-registry.json`'s real shape: id, status, priority, tier,
+ * parent_epic_id chain, blocked_on, next_action narrative. Deliberately NOT a
+ * Kanban board — the free-text narrative + hierarchy don't fit a column board.
+ */
+export type EpicStatus =
+  | 'in_progress'
+  | 'awaiting_approval'
+  | 'pending_pr'
+  | 'assistance_required'
+  | 'blocked'
+  | 'complete';
+
+export type EpicPriority = 'p0' | 'p1' | 'p2';
+
+export type EpicTier = 'epic' | 'task' | 'program';
+
+export interface EpicEntry {
+  id: string;
+  status: EpicStatus | string;
+  priority: EpicPriority | string;
+  tier: EpicTier | string;
+  parentEpicId?: string;
+  blockedOn?: string[];
+  nextAction?: string;
+  /** Non-blocking display error surfaced on the card (e.g. sync failure for this entry). */
+  error?: string;
+}
+
+export interface EpicStatusBoardProps {
+  /** `undefined` renders the loading (skeleton) state; `[]` renders the empty state. */
+  entries: EpicEntry[] | undefined;
+  onSelect?: (entry: EpicEntry) => void;
+  class?: string;
+}


### PR DESCRIPTION
Builds against the design-dojo preemptive-controls-and-improvements epic ranked candidate queue (memory/design-dojo-next-candidates-2026-08-06.md). Agent-scoped build per kbristol directive 2026-08-07 (agent decides + builds, no sign-off checkpoint).

Components: PipelineStageIndicator, EpicStatusBoard, SchemaDiffView, PraxisRuleCard, PersistentGateBanner, JSONTreeViewer.

Redundancy checks done: PraxisRuleCard vs npm-repo PraxisDevOverlay/PraxisBox (judged distinct, built); RelationshipBreadcrumb (rank 9) dropped as redundant with EpicStatusBoard's existing inline breadcrumb.

vitest: 38/38 passing (pure presentational additions, no existing behavior touched).