### PR TITLE
pin pluresdb px runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1801,7 +1801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2759,7 +2759,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3788,7 +3788,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4345,7 +4345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4485,7 +4485,7 @@ dependencies = [
  "pares-radix-praxis",
  "pares-radix-privacy",
  "pluresdb 3.10.3",
- "pluresdb-procedures",
+ "pluresdb-procedures 3.10.3",
  "pluresdb-sea",
  "pluresdb-sync 3.10.3",
  "regex",
@@ -4576,7 +4576,7 @@ dependencies = [
  "pares-radix-core",
  "pares-radix-praxis",
  "pluresdb 3.10.3",
- "pluresdb-procedures",
+ "pluresdb-procedures 3.10.3",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4957,6 +4957,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pluresdb-core"
+version = "3.12.0"
+source = "git+https://github.com/plures/pluresdb?rev=328e060016fdc67e704712cffd71fcd9c38bfbf7#328e060016fdc67e704712cffd71fcd9c38bfbf7"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dashmap",
+ "parking_lot 0.12.5",
+ "pluresdb-storage 3.12.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "pluresdb-procedures"
 version = "3.10.3"
 source = "git+https://github.com/plures/pluresdb?rev=2af92b1923e11e41c9103ad8f14900b179d839f6#2af92b1923e11e41c9103ad8f14900b179d839f6"
@@ -4968,7 +4985,28 @@ dependencies = [
  "pest",
  "pest_derive",
  "pluresdb-core 3.10.3",
- "pluresdb-procedures-macros",
+ "pluresdb-procedures-macros 3.10.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "pluresdb-procedures"
+version = "3.12.0"
+source = "git+https://github.com/plures/pluresdb?rev=328e060016fdc67e704712cffd71fcd9c38bfbf7#328e060016fdc67e704712cffd71fcd9c38bfbf7"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "cron",
+ "parking_lot 0.12.5",
+ "pest",
+ "pest_derive",
+ "pluresdb-core 3.12.0",
+ "pluresdb-procedures-macros 3.12.0",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -4988,15 +5026,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pluresdb-procedures-macros"
+version = "3.12.0"
+source = "git+https://github.com/plures/pluresdb?rev=328e060016fdc67e704712cffd71fcd9c38bfbf7#328e060016fdc67e704712cffd71fcd9c38bfbf7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "pluresdb-px"
-version = "3.10.3"
-source = "git+https://github.com/plures/pluresdb?rev=2af92b1923e11e41c9103ad8f14900b179d839f6#2af92b1923e11e41c9103ad8f14900b179d839f6"
+version = "3.12.0"
+source = "git+https://github.com/plures/pluresdb?rev=328e060016fdc67e704712cffd71fcd9c38bfbf7#328e060016fdc67e704712cffd71fcd9c38bfbf7"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "notify",
- "pluresdb-procedures",
+ "pluresdb-procedures 3.12.0",
  "px-ast",
  "px-compiler",
  "px-eval",
@@ -5058,6 +5106,22 @@ dependencies = [
  "sled",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "pluresdb-storage"
+version = "3.12.0"
+source = "git+https://github.com/plures/pluresdb?rev=328e060016fdc67e704712cffd71fcd9c38bfbf7#328e060016fdc67e704712cffd71fcd9c38bfbf7"
+dependencies = [
+ "anyhow",
+ "base64 0.23.0",
+ "chrono",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
  "tracing",
  "uuid",
 ]
@@ -5455,7 +5519,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5493,9 +5557,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5938,7 +6002,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5996,7 +6060,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7176,7 +7240,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8381,7 +8445,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/praxis/Cargo.toml
+++ b/crates/praxis/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pluresdb-px = { git = "https://github.com/plures/pluresdb", rev = "2af92b1923e11e41c9103ad8f14900b179d839f6" }
+pluresdb-px = { git = "https://github.com/plures/pluresdb", rev = "328e060016fdc67e704712cffd71fcd9c38bfbf7" }
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true


### PR DESCRIPTION
## Summary

- Pin `pares-radix-praxis` to PluresDB `328e060`, which executes compiler-emitted `define` and positional `append` PX steps.

## Why

Praxisbot's reactive `evaluate_dispatch` procedure reached a valid `define` step that the previous runtime could compile but not execute.

## Validation

- `cargo check -p pares-radix-praxis`
- `cargo test -p pares-radix-praxis`
- `cargo clippy -p pares-radix-praxis -- -D warnings`