### PR TITLE
fix: register spine procedure actions

### DIFF
--- a/crates/radix-core/src/spine/actions.rs
+++ b/crates/radix-core/src/spine/actions.rs
@@ -218,11 +218,16 @@ use crate::spine::worktask_actions::{is_worktask_action, WorktaskActionHandler};
 /// 3. `WorktaskActionHandler` handles worktask git/fs/quarantine effects
 /// 4. `RunCommandActionHandler` handles `run_command` (real ShellExecutor, governed)
 /// 5. `BriefingActionHandler` handles `assemble_briefing_report` (pure classify/format)
-/// 6. `SubagentActor` handles spawn_subagent calls
-/// 7. `ToolDispatchActionHandler` handles everything else as tool calls
+/// 6. `ModelSelectionActionHandler` handles deterministic model-selection actions
+/// 7. `TopicRoutingActionHandler` handles deterministic topic-routing actions
+/// 8. RSI metric actions update running averages without tool dispatch
+/// 9. Task/dashboard, repo-health, privilege, GUI, grounding, subagent, dispatch,
+///    handoff, and epic-registry handlers process their owned actions
+/// 10. `ToolDispatchActionHandler` handles everything else as tool calls
 ///
 /// This gives .px procedures access to system state, lifecycle logic, worktask
-/// orchestration, shell commands, subagent spawning, AND external tools.
+/// orchestration, shell commands, deterministic routing/selection, RSI metrics,
+/// subagent spawning, and external tools.
 pub struct CompositeActionHandler {
     core: CoreActionHandler,
     dev_lifecycle: DevLifecycleActionHandler,
@@ -540,8 +545,9 @@ mod tests {
         assert_eq!(result, Value::Null);
     }
 
-    /// Regression proof for the live reactive action path: these PX-owned
-    /// actions must be handled by the composite, never misclassified as tools.
+    /// Regression proof for the live reactive action path: model-selection,
+    /// topic-routing, and RSI metric actions must be handled by the composite
+    /// before generic tool fallthrough.
     #[tokio::test]
     async fn composite_registers_model_topic_and_rsi_actions_before_tool_fallthrough() {
         use crate::model::{ToolDefinition, ToolDispatcher};

--- a/crates/radix-core/src/spine/actions.rs
+++ b/crates/radix-core/src/spine/actions.rs
@@ -148,6 +148,30 @@ impl CoreActionHandler {
         debug!(key = %key, "action: write_state");
         Ok(value)
     }
+
+    /// Read every durable state value whose key has `prefix`.
+    ///
+    /// Prefix reads are a PluresDB concern, not a cognition cache concern.
+    /// Sort keys so a procedure gets deterministic input regardless of storage
+    /// backend iteration order.
+    async fn read_state_prefix(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let prefix = params.get("prefix").and_then(Value::as_str).ok_or_else(|| {
+            ExecutionError::ActionFailed {
+                action: "read_state_prefix".into(),
+                message: "missing prefix".into(),
+            }
+        })?;
+        let mut keys = self.state_store.keys_with_prefix(prefix).await;
+        keys.sort();
+        let mut values = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(value) = self.state_store.get(&key).await {
+                values.push(value);
+            }
+        }
+        debug!(prefix, count = values.len(), "action: read_state_prefix");
+        Ok(Value::Array(values))
+    }
 }
 
 #[async_trait]
@@ -156,6 +180,7 @@ impl AsyncActionHandler for CoreActionHandler {
         match action {
             "read_state" => self.read_state(params).await,
             "write_state" => self.write_state(params).await,
+            "read_state_prefix" => self.read_state_prefix(params).await,
             "read_history" => self.read_history(params).await,
             "append_history" => self.append_history(params).await,
             _ => {
@@ -170,16 +195,19 @@ use crate::spine::briefing_actions::{is_briefing_action, BriefingActionHandler};
 use crate::spine::dev_lifecycle_actions::{is_dev_lifecycle_action, DevLifecycleActionHandler};
 use crate::spine::epic_registry_actions::{is_epic_registry_action, EpicRegistryActionHandler};
 use crate::spine::gui_launch_actions::{is_gui_launch_action, GuiLaunchActionHandler};
+use crate::spine::model_selection_actions::{is_model_selection_action, ModelSelectionActionHandler};
 use crate::spine::plugin_privilege_actions::{
     is_plugin_privilege_action, PluginPrivilegeActionHandler,
 };
 use crate::spine::repo_health_actions::{self, RepoHealthActionHandler};
+use crate::spine::rsi_actions::{is_rsi_metric_action, update_running_average};
 use crate::spine::run_command_actions::{is_run_command_action, RunCommandActionHandler};
 use crate::spine::subagent_actor::{is_subagent_action, SubagentActor};
 use crate::spine::task_dashboard_actions::{is_task_dashboard_action, TaskDashboardActionHandler};
 use crate::spine::task_dispatch_actions::{is_task_dispatch_action, TaskDispatchActionHandler};
 use crate::spine::task_grounding_actions::{is_task_grounding_action, TaskGroundingActionHandler};
 use crate::spine::task_handoff_actions::{is_task_handoff_action, TaskHandoffActionHandler};
+use crate::spine::topic_routing_actions::{is_topic_routing_action, TopicRoutingActionHandler};
 use crate::spine::worktask_actions::{is_worktask_action, WorktaskActionHandler};
 
 /// Composite action handler that delegates to multiple handlers in priority order.
@@ -201,6 +229,10 @@ pub struct CompositeActionHandler {
     worktask: WorktaskActionHandler,
     run_command: RunCommandActionHandler,
     briefing: BriefingActionHandler,
+    /// Pure model-selection decisions used by `model-selection.px`.
+    model_selection: ModelSelectionActionHandler,
+    /// Pure topic-routing decisions used by `topic-routing.px`.
+    topic_routing: TopicRoutingActionHandler,
     /// Native task dashboard aggregation + write-cache guard (ADR-0036).
     /// Shares the SAME durable state store as Core/Worktask so it reads the
     /// live `task:*`/`worktask:*`/`epic:*` namespaces those writers use.
@@ -254,6 +286,8 @@ impl CompositeActionHandler {
             dev_lifecycle: DevLifecycleActionHandler::new(),
             run_command: RunCommandActionHandler::new(),
             briefing: BriefingActionHandler::new(),
+            model_selection: ModelSelectionActionHandler::new(),
+            topic_routing: TopicRoutingActionHandler::new(),
             task_grounding: None,
             subagent: None,
             task_dispatch: None,
@@ -307,6 +341,7 @@ impl CompositeActionHandler {
 const CORE_ACTIONS: &[&str] = &[
     "read_state",
     "write_state",
+    "read_state_prefix",
     "read_history",
     "append_history",
 ];
@@ -324,6 +359,12 @@ impl AsyncActionHandler for CompositeActionHandler {
             self.run_command.call(action, params).await
         } else if is_briefing_action(action) {
             self.briefing.call(action, params).await
+        } else if is_model_selection_action(action) {
+            self.model_selection.call(action, params).await
+        } else if is_topic_routing_action(action) {
+            self.topic_routing.call(action, params).await
+        } else if is_rsi_metric_action(action) {
+            update_running_average(params)
         } else if is_task_dashboard_action(action) {
             self.task_dashboard.call(action, params).await
         } else if repo_health_actions::is_repo_health_action(action) {
@@ -472,6 +513,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_state_prefix_returns_durable_values_in_key_order() {
+        let store = test_state();
+        store.set("constraint:z", serde_json::json!({"id": "z"})).await;
+        store.set("constraint:a", serde_json::json!({"id": "a"})).await;
+        store.set("unrelated:x", serde_json::json!({"id": "x"})).await;
+        let handler = CoreActionHandler::new(Arc::new(MemoryConversationStore::new()), store);
+
+        let values = handler
+            .call("read_state_prefix", &serde_json::json!({"prefix": "constraint:"}))
+            .await
+            .unwrap();
+        assert_eq!(values, serde_json::json!([{"id": "a"}, {"id": "z"}]));
+    }
+
+    #[tokio::test]
     async fn unknown_action_returns_null() {
         let store = Arc::new(MemoryConversationStore::new());
         let handler = CoreActionHandler::new(store, test_state());
@@ -482,6 +538,72 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, Value::Null);
+    }
+
+    /// Regression proof for the live reactive action path: these PX-owned
+    /// actions must be handled by the composite, never misclassified as tools.
+    #[tokio::test]
+    async fn composite_registers_model_topic_and_rsi_actions_before_tool_fallthrough() {
+        use crate::model::{ToolDefinition, ToolDispatcher};
+        use crate::px_adapter::ToolDispatchActionHandler;
+
+        struct CountingDispatcher(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+        #[async_trait]
+        impl ToolDispatcher for CountingDispatcher {
+            async fn available_tools(&self) -> Vec<ToolDefinition> { vec![] }
+
+            async fn call_tool(&self, _name: &str, _args: Value) -> String {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                "unexpected tool fallthrough".to_string()
+            }
+        }
+
+        let tool_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let dispatcher: Arc<dyn ToolDispatcher> = Arc::new(CountingDispatcher(Arc::clone(&tool_calls)));
+        let handler = CompositeActionHandler::new(
+            Arc::new(MemoryConversationStore::new()),
+            test_state(),
+            Arc::new(ToolDispatchActionHandler::new(dispatcher)),
+        );
+
+        let available = handler.call("list_available_models", &serde_json::json!({})).await.unwrap();
+        let models = available["models"].as_array().unwrap().clone();
+        let requirements = handler.call(
+            "classify_task_requirements",
+            &serde_json::json!({"task": {"task_type": "code", "complexity": "high"}}),
+        ).await.unwrap();
+        let scored = handler.call(
+            "score_models_against_requirements",
+            &serde_json::json!({"models": models, "requirements": requirements}),
+        ).await.unwrap();
+        let selected = handler.call(
+            "select_top_with_fallback",
+            &serde_json::json!({"scored_models": scored["scored_models"]}),
+        ).await.unwrap();
+        assert!(selected["selected"].is_object());
+
+        let classification = handler.call(
+            "classify_message_topic",
+            &serde_json::json!({"message": {"content": "cargo compile error in function"}}),
+        ).await.unwrap();
+        let decision = handler.call(
+            "evaluate_topic_confidence",
+            &serde_json::json!({
+                "found_topic": classification["topic"],
+                "default_topic": "general",
+                "confidence": classification["confidence"],
+                "threshold": 0.7
+            }),
+        ).await.unwrap();
+        assert_eq!(decision["new_topic"], "code");
+
+        let averages = handler.call(
+            "update_running_average",
+            &serde_json::json!({"stats": {}, "new_quality": 0.9, "new_latency": 120}),
+        ).await.unwrap();
+        assert_eq!(averages["count"], 1);
+        assert_eq!(tool_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 
     /// END-TO-END LIVE-PATH PROOF (pares-radix#467 — task amnesia):

--- a/crates/radix-core/src/spine/model_selection_actions.rs
+++ b/crates/radix-core/src/spine/model_selection_actions.rs
@@ -12,6 +12,21 @@ use serde_json::{json, Value};
 use crate::px_adapter::AsyncActionHandler;
 use pares_radix_praxis::px::executor::ExecutionError;
 
+/// Returns whether `action` belongs to the model-selection PX contract.
+///
+/// Keeping the owned action names beside their implementation lets the spine
+/// composite dispatch them before the generic tool fallthrough.
+pub fn is_model_selection_action(action: &str) -> bool {
+    matches!(
+        action,
+        "list_available_models"
+            | "classify_task_requirements"
+            | "score_models_against_requirements"
+            | "select_top_with_fallback"
+            | "format_model_config"
+    )
+}
+
 /// Helper to construct ActionFailed errors concisely.
 fn err(action: &str, message: impl Into<String>) -> ExecutionError {
     ExecutionError::ActionFailed {
@@ -81,17 +96,22 @@ impl ModelSelectionActionHandler {
     /// Input: {task_type, complexity, context_length, ...}
     /// Output: {needs_reasoning, needs_code, needs_speed, context_demand, ...}
     fn classify_task_requirements(&self, params: &Value) -> Result<Value, ExecutionError> {
-        let task_type = params
+        // `model-selection.px` passes the inbound request as `task`; accepting
+        // the top-level shape as well keeps this boundary useful to direct
+        // callers without making the PX contract ambiguous.
+        let task = params.get("task").unwrap_or(params);
+        let task_type = task
             .get("task_type")
             .and_then(|v| v.as_str())
+            .or_else(|| task.get("kind").and_then(|v| v.as_str()))
             .unwrap_or("general");
 
-        let complexity = params
+        let complexity = task
             .get("complexity")
             .and_then(|v| v.as_str())
             .unwrap_or("medium");
 
-        let context_length = params
+        let context_length = task
             .get("context_length")
             .and_then(|v| v.as_u64())
             .unwrap_or(1000);

--- a/crates/radix-core/src/spine/rsi_actions.rs
+++ b/crates/radix-core/src/spine/rsi_actions.rs
@@ -33,6 +33,40 @@ fn err(action: &str, message: impl Into<String>) -> ExecutionError {
     }
 }
 
+/// Returns whether `action` is a stateless RSI metrics calculation that can be
+/// composed into every spine runtime without constructing the hot-reload actor.
+pub fn is_rsi_metric_action(action: &str) -> bool {
+    action == "update_running_average"
+}
+
+/// Update a running quality/latency average with a new generation result.
+///
+/// This is deliberately separate from the hot-reload actor: it has no IO and
+/// is shared by the model-selection PX procedure and the RSI procedures.
+pub fn update_running_average(params: &Value) -> Result<Value, ExecutionError> {
+    let stats = params.get("stats").unwrap_or(&Value::Null);
+    let new_quality = params.get("new_quality").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let new_latency = params.get("new_latency").and_then(|v| v.as_u64()).unwrap_or(0);
+    let prev_avg_quality = stats.get("avg_quality").and_then(|v| v.as_f64()).unwrap_or(new_quality);
+    let prev_avg_latency = stats
+        .get("avg_latency_ms")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(new_latency);
+    let count = stats.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let alpha = 0.2;
+    let avg_quality = prev_avg_quality * (1.0 - alpha) + new_quality * alpha;
+    let avg_latency =
+        (prev_avg_latency as f64 * (1.0 - alpha) + new_latency as f64 * alpha) as u64;
+
+    Ok(json!({
+        "avg_quality": avg_quality,
+        "avg_latency_ms": avg_latency,
+        "count": count + 1,
+        "last_quality": new_quality,
+        "last_latency_ms": new_latency
+    }))
+}
+
 /// Constraint ids that the RSI loop may **never** auto-remove or auto-disable,
 /// even via the rollback (`undo -> remove_constraint`) path.
 ///
@@ -584,38 +618,7 @@ impl RsiActionHandler {
 
     /// Update a running average with a new data point (EMA, alpha=0.2).
     fn update_running_average(&self, params: &Value) -> Result<Value, ExecutionError> {
-        let stats = params.get("stats").unwrap_or(&Value::Null);
-        let new_quality = params
-            .get("new_quality")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-        let new_latency = params
-            .get("new_latency")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
-
-        let prev_avg_quality = stats
-            .get("avg_quality")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(new_quality);
-        let prev_avg_latency = stats
-            .get("avg_latency_ms")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(new_latency);
-        let count = stats.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
-
-        let alpha = 0.2;
-        let avg_quality = prev_avg_quality * (1.0 - alpha) + new_quality * alpha;
-        let avg_latency =
-            (prev_avg_latency as f64 * (1.0 - alpha) + new_latency as f64 * alpha) as u64;
-
-        Ok(json!({
-            "avg_quality": avg_quality,
-            "avg_latency_ms": avg_latency,
-            "count": count + 1,
-            "last_quality": new_quality,
-            "last_latency_ms": new_latency
-        }))
+        update_running_average(params)
     }
 }
 

--- a/crates/radix-core/src/spine/topic_routing_actions.rs
+++ b/crates/radix-core/src/spine/topic_routing_actions.rs
@@ -12,6 +12,21 @@ use serde_json::{json, Value};
 use crate::px_adapter::AsyncActionHandler;
 use pares_radix_praxis::px::executor::ExecutionError;
 
+/// Returns whether `action` belongs to the topic-routing PX contract.
+pub fn is_topic_routing_action(action: &str) -> bool {
+    matches!(
+        action,
+        "classify_message_topic"
+            | "evaluate_topic_confidence"
+            | "build_steering_context"
+            | "build_steering"
+            | "format_topic_switch"
+            | "extract_topic_signals"
+            | "topic_changed"
+            | "force_classify_topic"
+    )
+}
+
 /// Helper to construct ActionFailed errors concisely.
 #[allow(dead_code)]
 fn err(action: &str, message: impl Into<String>) -> ExecutionError {
@@ -35,6 +50,40 @@ impl TopicRoutingActionHandler {
         Self
     }
 
+    /// Classify a message using the deterministic topic signals already owned
+    /// by this boundary. The result has the shape `topic-routing.px` binds.
+    fn classify_message_topic(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let message = params.get("message").unwrap_or(&Value::Null);
+        let content = message
+            .as_str()
+            .or_else(|| message.get("content").and_then(Value::as_str))
+            .or_else(|| message.get("text").and_then(Value::as_str))
+            .unwrap_or_default();
+        let signals = self.extract_topic_signals(&json!({ "message": content }))?;
+        let strength = signals
+            .get("total_signal_strength")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        let previous_topic = params
+            .get("previous_topic")
+            .and_then(Value::as_str)
+            .unwrap_or("general");
+        let topic = if strength == 0 {
+            previous_topic
+        } else {
+            signals
+                .get("dominant_signal")
+                .and_then(Value::as_str)
+                .unwrap_or(previous_topic)
+        };
+
+        Ok(json!({
+            "topic": topic,
+            "confidence": if strength >= 2 { 0.85 } else { 0.45 },
+            "signals": signals.get("signals").cloned().unwrap_or(Value::Array(vec![]))
+        }))
+    }
+
     /// Evaluate topic confidence — pure threshold check.
     /// Input: {confidence: 0.85, threshold: 0.7}
     /// Output: {above_threshold: true, confidence: 0.85}
@@ -53,7 +102,52 @@ impl TopicRoutingActionHandler {
             "above_threshold": confidence >= threshold,
             "confidence": confidence,
             "threshold": threshold,
-            "margin": confidence - threshold
+            "margin": confidence - threshold,
+            "default_topic": params.get("default_topic").cloned().unwrap_or(Value::Null),
+            "new_topic": if confidence >= threshold {
+                params.get("found_topic").cloned().unwrap_or(Value::Null)
+            } else {
+                params.get("default_topic").cloned().unwrap_or(Value::Null)
+            },
+            "changed": confidence >= threshold
+                && params.get("found_topic") != params.get("default_topic"),
+            "reeval_ids": Value::Array(vec![])
+        }))
+    }
+
+    /// Assemble the continuation guidance expected by `topic-routing.px`.
+    fn build_steering(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let topic = params
+            .get("topic")
+            .and_then(Value::as_str)
+            .unwrap_or("general");
+        let pending = params
+            .get("pending_reeval_count")
+            .cloned()
+            .unwrap_or(Value::Null);
+        Ok(json!({
+            "topic": topic,
+            "continuation": params.get("continuation").and_then(Value::as_bool).unwrap_or(true),
+            "pending_reeval_count": pending,
+            "steering_instruction": format!("Continue the conversation in the '{topic}' context.")
+        }))
+    }
+
+    /// Resolve an overflowed reevaluation queue without returning control to
+    /// the generic tool dispatcher.
+    fn force_classify_topic(&self, params: &Value) -> Result<Value, ExecutionError> {
+        let current_topic = params
+            .get("current_topic")
+            .and_then(|value| value.get("current_topic"))
+            .and_then(Value::as_str)
+            .unwrap_or("general");
+        Ok(json!({
+            "new_topic": current_topic,
+            "default_topic": current_topic,
+            "confidence": 1.0,
+            "changed": false,
+            "reeval_ids": Value::Array(vec![]),
+            "forced": true
         }))
     }
 
@@ -221,11 +315,14 @@ impl TopicRoutingActionHandler {
 impl AsyncActionHandler for TopicRoutingActionHandler {
     async fn call(&self, name: &str, params: &Value) -> Result<Value, ExecutionError> {
         match name {
+            "classify_message_topic" => self.classify_message_topic(params),
             "evaluate_topic_confidence" => self.evaluate_topic_confidence(params),
             "build_steering_context" => self.build_steering_context(params),
+            "build_steering" => self.build_steering(params),
             "format_topic_switch" => self.format_topic_switch(params),
             "extract_topic_signals" => self.extract_topic_signals(params),
             "topic_changed" => self.topic_changed(params),
+            "force_classify_topic" => self.force_classify_topic(params),
             _ => Err(ExecutionError::UnknownAction(name.to_string())),
         }
     }

--- a/crates/radix-core/src/spine/topic_routing_actions.rs
+++ b/crates/radix-core/src/spine/topic_routing_actions.rs
@@ -1,11 +1,14 @@
 //! Topic Routing action handlers.
 //!
 //! Provides boundary actors for the topic-routing.px procedure:
-//! - `classify_message_topic` — LLM-delegated classification (placeholder → routes to generate)
+//! - `classify_message_topic` — deterministic classification from extracted topic signals
 //! - `evaluate_topic_confidence` — pure confidence threshold check
 //! - `build_steering_context` — assemble context for steering
+//! - `build_steering` — assemble continuation steering guidance
 //! - `format_topic_switch` — format topic transition message
 //! - `extract_topic_signals` — extract topic signals from message content
+//! - `topic_changed` — compare current and newly classified topics
+//! - `force_classify_topic` — resolve overflow reevaluation without tool dispatch
 
 use serde_json::{json, Value};
 


### PR DESCRIPTION
## What changed

Registers the PX model-selection, topic-routing, RSI metrics, and durable prefix-read actions in the live spine composite.

## Why

Praxisbot's reactive procedures were falling through to generic tool dispatch even though the action implementations existed. That produced five-second fallback routing and a failed model context budget.

## Validation

- cargo test -p pares-radix-core composite_registers_model_topic_and_rsi_actions_before_tool_fallthrough --lib
- cargo test -p pares-radix-core read_state_prefix_returns_durable_values_in_key_order --lib

The regression test asserts these actions never reach the generic tool dispatcher.