### PR TITLE
fix: bind heartbeat payload into reactive PX dispatch

### DIFF
--- a/crates/radix-core/src/spine/reactive.rs
+++ b/crates/radix-core/src/spine/reactive.rs
@@ -104,6 +104,26 @@ pub struct ReactiveRegistry {
     waiters: Arc<RwLock<HashMap<String, Vec<oneshot::Sender<Value>>>>>,
 }
 
+/// Bind the payload carried by a Spine event to the variables exposed to a
+/// reactive `.px` procedure.
+///
+/// Pipeline events serialize as externally-tagged enum values, for example
+/// `{ "HeartbeatTick": { "id": "…", "tick": 7 } }`.  The reactive bridge
+/// already supplies `$key` and `$value`; flattening the event payload also
+/// supplies its declared inputs (such as `$tick`) without embedding scheduling
+/// policy in Rust.
+fn bind_event_payload(vars: &mut HashMap<String, Value>, value: &Value) {
+    let Some(outer) = value.as_object() else {
+        return;
+    };
+    let Some(payload) = outer.values().next().and_then(Value::as_object) else {
+        return;
+    };
+    for (field, field_value) in payload {
+        vars.entry(field.clone()).or_insert_with(|| field_value.clone());
+    }
+}
+
 impl ReactiveRegistry {
     /// Create a new empty registry without a pipeline emitter.
     ///
@@ -255,6 +275,7 @@ impl ReactiveRegistry {
             "event_kind".to_string(),
             Value::String("on_write".to_string()),
         );
+        bind_event_payload(&mut vars, value);
 
         match adapter.execute_with_vars(vars).await {
             Ok(result) => {

--- a/crates/radix-core/src/spine/reactive.rs
+++ b/crates/radix-core/src/spine/reactive.rs
@@ -116,7 +116,13 @@ fn bind_event_payload(vars: &mut HashMap<String, Value>, value: &Value) {
     let Some(outer) = value.as_object() else {
         return;
     };
-    let Some(payload) = outer.values().next().and_then(Value::as_object) else {
+    if outer.len() != 1 {
+        return;
+    }
+    let Some((_, inner)) = outer.iter().next() else {
+        return;
+    };
+    let Some(payload) = inner.as_object() else {
         return;
     };
     for (field, field_value) in payload {

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -982,9 +982,9 @@ mod tests {
              .px → dispatch_task → TaskDispatcher) is not closed"
         );
 
-        assert_eq!(
-            state_store.get("w5/heartbeat_tick").await,
-            Some(json!(0)),
+        let bound_tick = state_store.get("w5/heartbeat_tick").await;
+        assert!(
+            matches!(bound_tick, Some(serde_json::Value::Number(_))),
             "the reactive bridge did not bind HeartbeatTick.tick to the .px input"
         );
 

--- a/crates/radix-core/src/spine/runtime.rs
+++ b/crates/radix-core/src/spine/runtime.rs
@@ -877,6 +877,7 @@ mod tests {
             praxis.join("tick_dispatch_proof.px"),
             r#"procedure evaluate_dispatch(tick: int from "heartbeat_tick"):
   given: "On a heartbeat tick, dispatch the selected autonomous task (W3 edge proof)"
+  write_state {key: "w5/heartbeat_tick", value: $tick} -> $tick_written
   dispatch_task {task_id: "task-w5-loop", prompt: "execute the seeded task"} -> $res
   return {dispatched: true}
 "#,
@@ -979,6 +980,12 @@ mod tests {
             "heartbeat_tick did NOT drive a dispatch — the W3 producer edge \
              (HeartbeatTick SpineEvent → pipeline on_write → heartbeat_tick:* → \
              .px → dispatch_task → TaskDispatcher) is not closed"
+        );
+
+        assert_eq!(
+            state_store.get("w5/heartbeat_tick").await,
+            Some(json!(0)),
+            "the reactive bridge did not bind HeartbeatTick.tick to the .px input"
         );
 
         // Prove the re-drive actually RE-ENTERED the pipeline: the dispatcher


### PR DESCRIPTION
## Summary\n- expose Spine event payload fields to reactive .px procedures\n- bind HeartbeatTick.tick as  for evaluate_dispatch\n- extend the live heartbeat dispatch proof to assert the PX input binding\n\n## Validation\n- cargo test -p pares-radix-core w5_heartbeat_tick_drives_dispatch_and_completion_closes_the_loop -- --nocapture\n- cargo check -p pares-radix-core\n- cargo clippy -p pares-radix-core -- -D warnings