### PR TITLE
feat(spine): gate reactive registration on checked PX

### DIFF
--- a/crates/radix-core/src/spine/bootstrap.rs
+++ b/crates/radix-core/src/spine/bootstrap.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use tracing::{debug, info, warn};
 
-use crate::px_adapter::{load_px_directory, AsyncActionHandler};
+use crate::px_adapter::{load_px_directory, AsyncActionHandler, PxProcedureAdapter};
 use crate::spine::reactive::ReactiveRegistry;
 
 /// Mapping from procedure name to the trigger pattern it should be registered under.
@@ -175,24 +175,45 @@ pub async fn register_reactive_procedures(
     registry: &ReactiveRegistry,
     handler: Arc<dyn AsyncActionHandler>,
 ) -> usize {
-    let trigger_map = default_trigger_map();
-
     // Load all .px procedures from the directory tree
     let adapters = load_px_directory(praxis_dir, handler);
+    register_reactive_adapters(adapters, registry, Some(praxis_dir)).await
+}
+
+/// Register precompiled adapters through the platform's canonical trigger map.
+///
+/// A host may validate source against a stronger schema contract before
+/// compiling it. This function lets that host preserve the platform-owned
+/// trigger mapping instead of reimplementing bootstrap registration logic.
+/// The adapters supplied here are the exact adapters that become reactive.
+pub async fn register_reactive_adapters(
+    adapters: Vec<PxProcedureAdapter>,
+    registry: &ReactiveRegistry,
+    source_dir: Option<&Path>,
+) -> usize {
+    let trigger_map = default_trigger_map();
 
     if adapters.is_empty() {
-        warn!(
-            dir = %praxis_dir.display(),
-            "bootstrap: no .px procedures found"
-        );
+        if let Some(dir) = source_dir {
+            warn!(dir = %dir.display(), "bootstrap: no .px procedures found");
+        } else {
+            warn!("bootstrap: no precompiled .px procedures supplied");
+        }
         return 0;
     }
 
-    info!(
-        count = adapters.len(),
-        dir = %praxis_dir.display(),
-        "bootstrap: compiled .px procedures, registering triggers"
-    );
+    if let Some(dir) = source_dir {
+        info!(
+            count = adapters.len(),
+            dir = %dir.display(),
+            "bootstrap: compiled .px procedures, registering triggers"
+        );
+    } else {
+        info!(
+            count = adapters.len(),
+            "bootstrap: registering precompiled .px procedures"
+        );
+    }
 
     let mut registered = 0;
 
@@ -305,6 +326,25 @@ procedure classify_message:
         // the parser's current state. The test verifies no panic.
         // When the parser supports this syntax fully, assert count >= 1.
         assert!(registry.trigger_count().await == count);
+    }
+
+    #[tokio::test]
+    async fn checked_host_can_register_precompiled_adapters_without_reimplementing_routes() {
+        let source = r#"
+procedure evaluate_dispatch:
+  trigger: on_write
+  given: "Dispatch work after a heartbeat tick"
+  return {should_dispatch: false}
+"#;
+        let handler: Arc<dyn AsyncActionHandler> = Arc::new(NoOpHandler);
+        let adapters = crate::px_adapter::load_px_procedures(source, handler)
+            .expect("test procedure must compile");
+        let registry = ReactiveRegistry::new();
+
+        let registered = register_reactive_adapters(adapters, &registry, None).await;
+
+        assert_eq!(registered, 1);
+        assert_eq!(registry.trigger_count().await, 1);
     }
 
     #[tokio::test]

--- a/crates/radix-core/src/spine/task_dispatch_actions.rs
+++ b/crates/radix-core/src/spine/task_dispatch_actions.rs
@@ -30,6 +30,7 @@ use pares_radix_praxis::px::executor::ExecutionError;
 const TASK_DISPATCH_ACTIONS: &[&str] = &[
     "dispatch_task",
     "read_evaluable_tasks",
+    "task_list_evaluable_graph",
     "mark_task_in_progress",
 ];
 
@@ -98,6 +99,10 @@ impl TaskDispatchActionHandler {
             "last_evaluated_at": task.last_evaluated_at,
             "attempts": task.attempts,
             "status": Self::status_to_px(&task.status),
+            // The graph edges are durable task data. PX uses them to exclude
+            // fan-in parents and select only runnable child leaves.
+            "subtasks": task.subtasks,
+            "parent_task": task.parent_task,
             "conditions": conditions,
         })
     }
@@ -202,6 +207,10 @@ impl AsyncActionHandler for TaskDispatchActionHandler {
         match action {
             "dispatch_task" => self.dispatch_task(params).await,
             "read_evaluable_tasks" => self.read_evaluable_tasks().await,
+            // The graph-aware name is the contract used by
+            // autonomous-dispatch.px. It is the same durable read with its
+            // parent/child edges included by task_to_evaluable above.
+            "task_list_evaluable_graph" => self.read_evaluable_tasks().await,
             "mark_task_in_progress" => self.mark_task_in_progress(params).await,
             _ => Err(ExecutionError::ActionFailed {
                 action: action.to_string(),
@@ -239,6 +248,34 @@ mod tests {
         let arr = out.as_array().expect("array");
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["status"], "pending");
+    }
+
+    #[tokio::test]
+    async fn graph_task_read_preserves_parent_child_edges_for_px_leaf_selection() {
+        let tm = manager();
+        let parent = tm.create_task("coordinate the work", "chat-1", vec![]);
+        let child = tm
+            .create_subtask(&parent.id, "perform the runnable work", vec![])
+            .expect("parent task exists");
+
+        let h = handler_with_manager(tm);
+        let out = h
+            .call("task_list_evaluable_graph", &json!({}))
+            .await
+            .expect("graph task action succeeds");
+        let tasks = out.as_array().expect("graph task action returns an array");
+        let parent = tasks
+            .iter()
+            .find(|task| task["id"] == parent.id)
+            .expect("parent is present");
+        let child = tasks
+            .iter()
+            .find(|task| task["id"] == child.id)
+            .expect("child is present");
+
+        assert_eq!(parent["subtasks"], json!([child["id"].clone()]));
+        assert_eq!(child["parent_task"], parent["id"]);
+        assert_eq!(child["subtasks"], json!([]));
     }
 
     #[tokio::test]
@@ -334,6 +371,7 @@ mod tests {
         for required in [
             "dispatch_task",
             "read_evaluable_tasks",
+            "task_list_evaluable_graph",
             "mark_task_in_progress",
         ] {
             assert!(


### PR DESCRIPTION
## Summary
- expose the evaluable task graph to autonomous PX procedures
- let hosts register precompiled adapters through Radix's canonical trigger map
- preserve Radix ownership of reactive trigger routing while Agens performs schema-contract validation

## Verification
- cargo test -p pares-radix-core spine::bootstrap::tests::checked_host_can_register_precompiled_adapters_without_reimplementing_routes -- --exact
- rustfmt --check crates/radix-core/src/spine/bootstrap.rs
- git diff --check