### PR TITLE
feat(px): allow compiled adapters to be shared

### DIFF
--- a/crates/radix-core/src/px_adapter.rs
+++ b/crates/radix-core/src/px_adapter.rs
@@ -171,6 +171,7 @@ impl ActionHandler for BlockingHandlerWrapper {
 ///     registry.register(Box::new(adapter));
 /// }
 /// ```
+#[derive(Clone)]
 pub struct PxProcedureAdapter {
     /// Procedure name (from compiled record).
     name: String,
@@ -844,6 +845,10 @@ mod tests {
         assert_eq!(adapters.len(), 1);
         assert_eq!(adapters[0].name(), "health_check");
         assert_eq!(adapters[0].handles(), "manual");
+
+        let copied = adapters[0].clone();
+        assert_eq!(copied.name(), adapters[0].name());
+        assert_eq!(copied.trigger_kind(), adapters[0].trigger_kind());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make immutable PxProcedureAdapter values cloneable
- allow a host to register the same compiled PX source with both named and reactive paths without reparsing

## Verification
- targeted core test started from a clean Windows build but exceeded the local 180-second command cap while compiling dependencies; CI must complete this test